### PR TITLE
Fix csstext not outputting the liniar angle that was parsed

### DIFF
--- a/src/AngleSharp.Css.Tests/Declarations/CssBackgroundProperty.cs
+++ b/src/AngleSharp.Css.Tests/Declarations/CssBackgroundProperty.cs
@@ -661,5 +661,16 @@ namespace AngleSharp.Css.Tests.Declarations
             Assert.IsTrue(property.HasValue);
             Assert.AreEqual("url(\"" + url + "\")", property.Value);
         }
+
+        [Test]
+        public void CssBackgroundImageLinearGradientLegal()
+        {
+            var source = "background-image: linear-gradient(to right, rgba(255, 0, 0, 1), rgba(0, 0, 255, 1))";
+            var property = ParseDeclaration(source);
+            Assert.IsTrue(property.HasValue);
+
+            var expected = "linear-gradient(90deg, rgba(255, 0, 0, 1), rgba(0, 0, 255, 1))";
+            Assert.AreEqual(expected, property.Value);
+        }
     }
 }

--- a/src/AngleSharp.Css.Tests/Declarations/CssBorderImageProperty.cs
+++ b/src/AngleSharp.Css.Tests/Declarations/CssBorderImageProperty.cs
@@ -1,4 +1,4 @@
-﻿namespace AngleSharp.Css.Tests.Declarations
+namespace AngleSharp.Css.Tests.Declarations
 {
     using NUnit.Framework;
     using static CssConstructionFunctions;
@@ -39,7 +39,7 @@
             Assert.IsFalse(property.IsImportant);
             Assert.IsFalse(property.IsInherited);
             Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("linear-gradient(rgba(255, 0, 0, 1), rgba(255, 255, 0, 1))", property.Value);
+            Assert.AreEqual("linear-gradient(0deg, rgba(255, 0, 0, 1), rgba(255, 255, 0, 1))", property.Value);
         }
 
         [Test]

--- a/src/AngleSharp.Css.Tests/Values/Gradient.cs
+++ b/src/AngleSharp.Css.Tests/Values/Gradient.cs
@@ -29,7 +29,9 @@ namespace AngleSharp.Css.Tests.Values
         [Test]
         public void BackgroundImageLinearGradientWithAngle()
         {
-            var source = "background-image: linear-gradient(135deg, red, blue)";
+            var red = Color.Red;
+            var blue = Color.Blue;
+            var source = $"background-image: linear-gradient(135deg, {red.CssText}, {blue.CssText})";
             var property = ParseDeclaration(source);
             Assert.IsTrue(property.HasValue);
             Assert.IsFalse(property.IsInitial);
@@ -41,8 +43,10 @@ namespace AngleSharp.Css.Tests.Values
             Assert.IsFalse(gradient.IsRepeating);
             Assert.AreEqual(Angle.TripleHalfQuarter, gradient.Angle);
             Assert.AreEqual(2, gradient.Stops.Length);
-            Assert.AreEqual(Color.Red, gradient.Stops.First().Color);
-            Assert.AreEqual(Color.Blue, gradient.Stops.Last().Color);
+            Assert.AreEqual(red, gradient.Stops.First().Color);
+            Assert.AreEqual(blue, gradient.Stops.Last().Color);
+
+            Assert.AreEqual(source, property.CssText);
         }
 
         [Test]

--- a/src/AngleSharp.Css/Values/Functions/CssLinearGradientValue.cs
+++ b/src/AngleSharp.Css/Values/Functions/CssLinearGradientValue.cs
@@ -69,7 +69,7 @@ namespace AngleSharp.Css.Values
             get
             {
                 var defaultAngle = _angle as Angle?;
-                var offset = defaultAngle.HasValue ? 0 : 1;
+                var offset = defaultAngle.HasValue ? 1 : 0;
                 var args = new String[_stops.Length + offset];
 
                 if (defaultAngle.HasValue)
@@ -80,7 +80,7 @@ namespace AngleSharp.Css.Values
                     {
                         if (angle.Value == value)
                         {
-                            args[0] = angle.Key;
+                            args[0] = angle.Value.CssText;
                             break;
                         }
                     }


### PR DESCRIPTION
# Types of Changes
Bugfix

## Prerequisites

Please make sure you can check the following two boxes:

- [X] I have read the **CONTRIBUTING** document
- [X] My code follows the code style of this project

## Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [X] Bug fix (non-breaking change which fixes an issue, issue: #45 )
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [X] I have added tests to cover my changes
- [X] All new and existing tests passed

## Description

Fix an off-by-1 error causing the angle to get overridden in `args` and output the correct angle for "known" values.
