### PR TITLE
Allow calculating size of relative units, #3

### DIFF
--- a/src/AngleSharp.Css.Tests/Values/UnitConversion.cs
+++ b/src/AngleSharp.Css.Tests/Values/UnitConversion.cs
@@ -38,55 +38,55 @@ namespace AngleSharp.Css.Tests.Values
         }
 
         [Test]
-        public void LengthToPixlesCorrectPercentWidth()
+        public void LengthToPixelsCorrectPercentWidth()
         {
             var l = new Length(50, Length.Unit.Percent);
-            var renderDevice = new DefaultRenderDevice{ ViewPortWidth = 500};
+            var renderDevice = new DefaultRenderDevice {ViewPortWidth = 500};
             Assert.AreEqual(250, l.ToPixel(renderDevice, true));
         }
 
         [Test]
-        public void LengthToPixlesCorrectPercentHeight()
+        public void LengthToPixelsCorrectPercentHeight()
         {
             var l = new Length(25, Length.Unit.Percent);
-            var renderDevice = new DefaultRenderDevice{ ViewPortHeight = 600};
+            var renderDevice = new DefaultRenderDevice {ViewPortHeight = 600};
             Assert.AreEqual(150, l.ToPixel(renderDevice, false));
         }
 
         [Test]
-        public void LengthToPixlesCorrectRem()
+        public void LengthToPixelsCorrectRem()
         {
             var l = new Length(25, Length.Unit.Rem);
-            var renderDevice = new DefaultRenderDevice{ FontSize = 10};
+            var renderDevice = new DefaultRenderDevice {FontSize = 10};
             Assert.AreEqual(250, l.ToPixel(renderDevice));
         }
 
         [Test]
-        public void LengthToPixlesCorrectEm()
+        public void LengthToPixelsCorrectEm()
         {
             var l = new Length(10, Length.Unit.Em);
-            var renderDevice = new DefaultRenderDevice{ FontSize = 10};
+            var renderDevice = new DefaultRenderDevice {FontSize = 10};
             Assert.AreEqual(100, l.ToPixel(renderDevice));
         }
 
         [Test]
-        public void LengthToPixlesCorrectVh()
+        public void LengthToPixelsCorrectVh()
         {
             var l = new Length(10, Length.Unit.Vh);
-            var renderDevice = new DefaultRenderDevice{ ViewPortHeight = 1000};
+            var renderDevice = new DefaultRenderDevice {ViewPortHeight = 1000};
             Assert.AreEqual(100, l.ToPixel(renderDevice));
         }
 
         [Test]
-        public void LengthToPixlesCorrectVw()
+        public void LengthToPixelsCorrectVw()
         {
             var l = new Length(20, Length.Unit.Vw);
-            var renderDevice = new DefaultRenderDevice{ ViewPortHeight = 1000};
+            var renderDevice = new DefaultRenderDevice {ViewPortHeight = 1000};
             Assert.AreEqual(200, l.ToPixel(renderDevice));
         }
 
         [Test]
-        public void LengthToPixlesCorrectVmax()
+        public void LengthToPixelsCorrectVmax()
         {
             var l = new Length(20, Length.Unit.Vmax);
             var renderDevice = new DefaultRenderDevice
@@ -98,7 +98,7 @@ namespace AngleSharp.Css.Tests.Values
         }
 
         [Test]
-        public void LengthToPixlesCorrectVmin()
+        public void LengthToPixelsCorrectVmin()
         {
             var l = new Length(20, Length.Unit.Vmin);
             var renderDevice = new DefaultRenderDevice
@@ -107,6 +107,78 @@ namespace AngleSharp.Css.Tests.Values
                 ViewPortWidth = 500
             };
             Assert.AreEqual(100, l.ToPixel(renderDevice));
+        }
+
+        [Test]
+        public void LengthToPercentCorrectWidth()
+        {
+            var l = new Length(100, Length.Unit.Px);
+            var renderDevice = new DefaultRenderDevice {ViewPortWidth = 500};
+            Assert.AreEqual(20, l.To(Length.Unit.Percent, renderDevice, true));
+        }
+
+        [Test]
+        public void LengthToPercentCorrectHeight()
+        {
+            var l = new Length(100, Length.Unit.Px);
+            var renderDevice = new DefaultRenderDevice {ViewPortHeight = 1000};
+            Assert.AreEqual(10, l.To(Length.Unit.Percent, renderDevice, false));
+        }
+
+        [Test]
+        public void LengthToRemCorrectValue()
+        {
+            var l = new Length(100, Length.Unit.Px);
+            var renderDevice = new DefaultRenderDevice {FontSize = 16};
+            Assert.AreEqual(6.25d, l.To(Length.Unit.Rem, renderDevice));
+        }
+
+        [Test]
+        public void LengthToEmCorrectValue()
+        {
+            var l = new Length(1600, Length.Unit.Px);
+            var renderDevice = new DefaultRenderDevice {FontSize = 16};
+            Assert.AreEqual(100, l.To(Length.Unit.Em, renderDevice));
+        }
+
+        [Test]
+        public void LengthToVhCorrectValue()
+        {
+            var l = new Length(100, Length.Unit.Px);
+            var renderDevice = new DefaultRenderDevice {ViewPortHeight = 1000};
+            Assert.AreEqual(10, l.To(Length.Unit.Vh, renderDevice));
+        }
+
+        [Test]
+        public void LengthToVwCorrectValue()
+        {
+            var l = new Length(50, Length.Unit.Px);
+            var renderDevice = new DefaultRenderDevice {ViewPortWidth = 1000};
+            Assert.AreEqual(5, l.To(Length.Unit.Vw, renderDevice));
+        }
+
+        [Test]
+        public void LengthToVmaxCorrectValue()
+        {
+            var l = new Length(50, Length.Unit.Px);
+            var renderDevice = new DefaultRenderDevice
+            {
+                ViewPortWidth = 1000,
+                ViewPortHeight = 500
+            };
+            Assert.AreEqual(5, l.To(Length.Unit.Vmax, renderDevice));
+        }
+
+        [Test]
+        public void LengthToVminCorrectValue()
+        {
+            var l = new Length(50, Length.Unit.Px);
+            var renderDevice = new DefaultRenderDevice
+            {
+                ViewPortWidth = 1000,
+                ViewPortHeight = 500
+            };
+            Assert.AreEqual(10, l.To(Length.Unit.Vmin, renderDevice));
         }
 
         [Test]

--- a/src/AngleSharp.Css.Tests/Values/UnitConversion.cs
+++ b/src/AngleSharp.Css.Tests/Values/UnitConversion.cs
@@ -38,6 +38,78 @@ namespace AngleSharp.Css.Tests.Values
         }
 
         [Test]
+        public void LengthToPixlesCorrectPercentWidth()
+        {
+            var l = new Length(50, Length.Unit.Percent);
+            var renderDevice = new DefaultRenderDevice{ ViewPortWidth = 500};
+            Assert.AreEqual(250, l.ToPixel(renderDevice, true));
+        }
+
+        [Test]
+        public void LengthToPixlesCorrectPercentHeight()
+        {
+            var l = new Length(25, Length.Unit.Percent);
+            var renderDevice = new DefaultRenderDevice{ ViewPortHeight = 600};
+            Assert.AreEqual(150, l.ToPixel(renderDevice, false));
+        }
+
+        [Test]
+        public void LengthToPixlesCorrectRem()
+        {
+            var l = new Length(25, Length.Unit.Rem);
+            var renderDevice = new DefaultRenderDevice{ FontSize = 10};
+            Assert.AreEqual(250, l.ToPixel(renderDevice));
+        }
+
+        [Test]
+        public void LengthToPixlesCorrectEm()
+        {
+            var l = new Length(10, Length.Unit.Em);
+            var renderDevice = new DefaultRenderDevice{ FontSize = 10};
+            Assert.AreEqual(100, l.ToPixel(renderDevice));
+        }
+
+        [Test]
+        public void LengthToPixlesCorrectVh()
+        {
+            var l = new Length(10, Length.Unit.Vh);
+            var renderDevice = new DefaultRenderDevice{ ViewPortHeight = 1000};
+            Assert.AreEqual(100, l.ToPixel(renderDevice));
+        }
+
+        [Test]
+        public void LengthToPixlesCorrectVw()
+        {
+            var l = new Length(20, Length.Unit.Vw);
+            var renderDevice = new DefaultRenderDevice{ ViewPortHeight = 1000};
+            Assert.AreEqual(200, l.ToPixel(renderDevice));
+        }
+
+        [Test]
+        public void LengthToPixlesCorrectVmax()
+        {
+            var l = new Length(20, Length.Unit.Vmax);
+            var renderDevice = new DefaultRenderDevice
+            {
+                ViewPortHeight = 1000,
+                ViewPortWidth = 500
+            };
+            Assert.AreEqual(200, l.ToPixel(renderDevice));
+        }
+
+        [Test]
+        public void LengthToPixlesCorrectVmin()
+        {
+            var l = new Length(20, Length.Unit.Vmin);
+            var renderDevice = new DefaultRenderDevice
+            {
+                ViewPortHeight = 1000,
+                ViewPortWidth = 500
+            };
+            Assert.AreEqual(100, l.ToPixel(renderDevice));
+        }
+
+        [Test]
         public void AngleParseCorrectDegValue()
         {
             var s = "1.35e2deg";

--- a/src/AngleSharp.Css.Tests/Values/UnitConversion.cs
+++ b/src/AngleSharp.Css.Tests/Values/UnitConversion.cs
@@ -43,8 +43,8 @@ namespace AngleSharp.Css.Tests.Values
         {
             var l = new Length(50, Length.Unit.Percent);
             var renderDevice = new DefaultRenderDevice();
-            Assert.Throws<ArgumentException>(() => l.ToPixel(renderDevice));
-            Assert.Throws<ArgumentException>(() => l.ToPixel(null));
+            Assert.Throws<ArgumentException>(() => l.ToPixel(renderDevice, RenderMode.Undefined));
+            Assert.Throws<ArgumentException>(() => l.ToPixel(null, RenderMode.Undefined));
         }
 
         [Test]
@@ -52,8 +52,8 @@ namespace AngleSharp.Css.Tests.Values
         {
             var l = new Length(50, Length.Unit.Em);
             var renderDevice = new DefaultRenderDevice { FontSize = 0 };
-            Assert.Throws<ArgumentException>(() => l.ToPixel(renderDevice));
-            Assert.Throws<ArgumentException>(() => l.ToPixel(null));
+            Assert.Throws<ArgumentException>(() => l.ToPixel(renderDevice, RenderMode.Undefined));
+            Assert.Throws<ArgumentException>(() => l.ToPixel(null, RenderMode.Undefined));
         }
 
         [Test]
@@ -61,7 +61,7 @@ namespace AngleSharp.Css.Tests.Values
         {
             var l = new Length(50, Length.Unit.Percent);
             var renderDevice = new DefaultRenderDevice {ViewPortWidth = 500};
-            Assert.AreEqual(250, l.ToPixel(renderDevice, true));
+            Assert.AreEqual(250, l.ToPixel(renderDevice, RenderMode.Horizontal));
         }
 
         [Test]
@@ -69,7 +69,7 @@ namespace AngleSharp.Css.Tests.Values
         {
             var l = new Length(25, Length.Unit.Percent);
             var renderDevice = new DefaultRenderDevice {ViewPortHeight = 600};
-            Assert.AreEqual(150, l.ToPixel(renderDevice, false));
+            Assert.AreEqual(150, l.ToPixel(renderDevice, RenderMode.Vertical));
         }
 
         [Test]
@@ -77,7 +77,7 @@ namespace AngleSharp.Css.Tests.Values
         {
             var l = new Length(25, Length.Unit.Rem);
             var renderDevice = new DefaultRenderDevice {FontSize = 10};
-            Assert.AreEqual(250, l.ToPixel(renderDevice));
+            Assert.AreEqual(250, l.ToPixel(renderDevice, RenderMode.Undefined));
         }
 
         [Test]
@@ -85,7 +85,7 @@ namespace AngleSharp.Css.Tests.Values
         {
             var l = new Length(10, Length.Unit.Em);
             var renderDevice = new DefaultRenderDevice {FontSize = 10};
-            Assert.AreEqual(100, l.ToPixel(renderDevice));
+            Assert.AreEqual(100, l.ToPixel(renderDevice, RenderMode.Undefined));
         }
 
         [Test]
@@ -93,7 +93,7 @@ namespace AngleSharp.Css.Tests.Values
         {
             var l = new Length(10, Length.Unit.Vh);
             var renderDevice = new DefaultRenderDevice {ViewPortHeight = 1000};
-            Assert.AreEqual(100, l.ToPixel(renderDevice));
+            Assert.AreEqual(100, l.ToPixel(renderDevice, RenderMode.Undefined));
         }
 
         [Test]
@@ -101,7 +101,7 @@ namespace AngleSharp.Css.Tests.Values
         {
             var l = new Length(20, Length.Unit.Vw);
             var renderDevice = new DefaultRenderDevice {ViewPortWidth = 1000};
-            Assert.AreEqual(200, l.ToPixel(renderDevice));
+            Assert.AreEqual(200, l.ToPixel(renderDevice, RenderMode.Undefined));
         }
 
         [Test]
@@ -113,7 +113,7 @@ namespace AngleSharp.Css.Tests.Values
                 ViewPortHeight = 1000,
                 ViewPortWidth = 500
             };
-            Assert.AreEqual(200, l.ToPixel(renderDevice));
+            Assert.AreEqual(200, l.ToPixel(renderDevice, RenderMode.Undefined));
         }
 
         [Test]
@@ -125,7 +125,7 @@ namespace AngleSharp.Css.Tests.Values
                 ViewPortHeight = 1000,
                 ViewPortWidth = 500
             };
-            Assert.AreEqual(100, l.ToPixel(renderDevice));
+            Assert.AreEqual(100, l.ToPixel(renderDevice, RenderMode.Undefined));
         }
 
         [Test]
@@ -133,7 +133,7 @@ namespace AngleSharp.Css.Tests.Values
         {
             var l = new Length(100, Length.Unit.Px);
             var renderDevice = new DefaultRenderDevice {ViewPortWidth = 500};
-            Assert.AreEqual(20, l.To(Length.Unit.Percent, renderDevice, true));
+            Assert.AreEqual(20, l.To(Length.Unit.Percent, renderDevice, RenderMode.Horizontal));
         }
 
         [Test]
@@ -141,7 +141,7 @@ namespace AngleSharp.Css.Tests.Values
         {
             var l = new Length(100, Length.Unit.Px);
             var renderDevice = new DefaultRenderDevice {ViewPortHeight = 1000};
-            Assert.AreEqual(10, l.To(Length.Unit.Percent, renderDevice, false));
+            Assert.AreEqual(10, l.To(Length.Unit.Percent, renderDevice, RenderMode.Vertical));
         }
 
         [Test]
@@ -149,7 +149,7 @@ namespace AngleSharp.Css.Tests.Values
         {
             var l = new Length(100, Length.Unit.Px);
             var renderDevice = new DefaultRenderDevice {FontSize = 16};
-            Assert.AreEqual(6.25d, l.To(Length.Unit.Rem, renderDevice));
+            Assert.AreEqual(6.25d, l.To(Length.Unit.Rem, renderDevice, RenderMode.Undefined));
         }
 
         [Test]
@@ -157,7 +157,7 @@ namespace AngleSharp.Css.Tests.Values
         {
             var l = new Length(1600, Length.Unit.Px);
             var renderDevice = new DefaultRenderDevice {FontSize = 16};
-            Assert.AreEqual(100, l.To(Length.Unit.Em, renderDevice));
+            Assert.AreEqual(100, l.To(Length.Unit.Em, renderDevice, RenderMode.Undefined));
         }
 
         [Test]
@@ -165,7 +165,7 @@ namespace AngleSharp.Css.Tests.Values
         {
             var l = new Length(100, Length.Unit.Px);
             var renderDevice = new DefaultRenderDevice {ViewPortHeight = 1000};
-            Assert.AreEqual(10, l.To(Length.Unit.Vh, renderDevice));
+            Assert.AreEqual(10, l.To(Length.Unit.Vh, renderDevice, RenderMode.Undefined));
         }
 
         [Test]
@@ -173,7 +173,7 @@ namespace AngleSharp.Css.Tests.Values
         {
             var l = new Length(50, Length.Unit.Px);
             var renderDevice = new DefaultRenderDevice {ViewPortWidth = 1000};
-            Assert.AreEqual(5, l.To(Length.Unit.Vw, renderDevice));
+            Assert.AreEqual(5, l.To(Length.Unit.Vw, renderDevice, RenderMode.Undefined));
         }
 
         [Test]
@@ -185,7 +185,7 @@ namespace AngleSharp.Css.Tests.Values
                 ViewPortWidth = 1000,
                 ViewPortHeight = 500
             };
-            Assert.AreEqual(5, l.To(Length.Unit.Vmax, renderDevice));
+            Assert.AreEqual(5, l.To(Length.Unit.Vmax, renderDevice, RenderMode.Undefined));
         }
 
         [Test]
@@ -197,7 +197,7 @@ namespace AngleSharp.Css.Tests.Values
                 ViewPortWidth = 1000,
                 ViewPortHeight = 500
             };
-            Assert.AreEqual(10, l.To(Length.Unit.Vmin, renderDevice));
+            Assert.AreEqual(10, l.To(Length.Unit.Vmin, renderDevice, RenderMode.Undefined));
         }
 
         [Test]

--- a/src/AngleSharp.Css.Tests/Values/UnitConversion.cs
+++ b/src/AngleSharp.Css.Tests/Values/UnitConversion.cs
@@ -51,7 +51,7 @@ namespace AngleSharp.Css.Tests.Values
         public void LengthToPixelsEmThrowsOnInvalidRenderDimensions()
         {
             var l = new Length(50, Length.Unit.Em);
-            var renderDevice = new DefaultRenderDevice();
+            var renderDevice = new DefaultRenderDevice { FontSize = 0 };
             Assert.Throws<ArgumentException>(() => l.ToPixel(renderDevice));
             Assert.Throws<ArgumentException>(() => l.ToPixel(null));
         }
@@ -100,7 +100,7 @@ namespace AngleSharp.Css.Tests.Values
         public void LengthToPixelsCorrectVw()
         {
             var l = new Length(20, Length.Unit.Vw);
-            var renderDevice = new DefaultRenderDevice {ViewPortHeight = 1000};
+            var renderDevice = new DefaultRenderDevice {ViewPortWidth = 1000};
             Assert.AreEqual(200, l.ToPixel(renderDevice));
         }
 

--- a/src/AngleSharp.Css.Tests/Values/UnitConversion.cs
+++ b/src/AngleSharp.Css.Tests/Values/UnitConversion.cs
@@ -1,9 +1,8 @@
-using System;
-
 namespace AngleSharp.Css.Tests.Values
 {
     using AngleSharp.Css.Values;
     using NUnit.Framework;
+    using System;
 
     [TestFixture]
     public class UnitConversionTests

--- a/src/AngleSharp.Css.Tests/Values/UnitConversion.cs
+++ b/src/AngleSharp.Css.Tests/Values/UnitConversion.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace AngleSharp.Css.Tests.Values
 {
     using AngleSharp.Css.Values;
@@ -35,6 +37,24 @@ namespace AngleSharp.Css.Tests.Values
             Assert.IsTrue(r);
             Assert.AreEqual(12.2, v.Value);
             Assert.AreEqual(Length.Unit.Vw, v.Type);
+        }
+
+        [Test]
+        public void LengthToPixelsPercentThrowsOnInvalidRenderDimensions()
+        {
+            var l = new Length(50, Length.Unit.Percent);
+            var renderDevice = new DefaultRenderDevice();
+            Assert.Throws<ArgumentException>(() => l.ToPixel(renderDevice));
+            Assert.Throws<ArgumentException>(() => l.ToPixel(null));
+        }
+
+        [Test]
+        public void LengthToPixelsEmThrowsOnInvalidRenderDimensions()
+        {
+            var l = new Length(50, Length.Unit.Em);
+            var renderDevice = new DefaultRenderDevice();
+            Assert.Throws<ArgumentException>(() => l.ToPixel(renderDevice));
+            Assert.Throws<ArgumentException>(() => l.ToPixel(null));
         }
 
         [Test]

--- a/src/AngleSharp.Css/DefaultRenderDevice.cs
+++ b/src/AngleSharp.Css/DefaultRenderDevice.cs
@@ -91,9 +91,17 @@ namespace AngleSharp.Css
             set;
         } = 0;
 
-        //todo
-        public int RenderWidth { get; set; }
-        public int RenderHeight { get; set; }
-        public double FontSize { get; set; }
+        /// <inheritdoc />
+        public Double RenderWidth => ViewPortWidth;
+
+        /// <inheritdoc />
+        public Double RenderHeight => ViewPortHeight;
+
+        /// <inheritdoc />
+        public double FontSize
+        {
+            get;
+            set;
+        } = 16;
     }
 }

--- a/src/AngleSharp.Css/DefaultRenderDevice.cs
+++ b/src/AngleSharp.Css/DefaultRenderDevice.cs
@@ -90,5 +90,10 @@ namespace AngleSharp.Css
             get;
             set;
         } = 0;
+
+        //todo
+        public int RenderWidth { get; set; }
+        public int RenderHeight { get; set; }
+        public double FontSize { get; set; }
     }
 }

--- a/src/AngleSharp.Css/Extensions/CssValueExtensions.cs
+++ b/src/AngleSharp.Css/Extensions/CssValueExtensions.cs
@@ -40,20 +40,22 @@ namespace AngleSharp.Css.Dom
         /// Tries to convert the value to a number of pixels.
         /// </summary>
         /// <param name="value">The value to convert.</param>
+        /// <param name="renderDimensions">the render device used to calculate relative units, can be null if units are absolute.</param>
+        /// <param name="isWidth">If a relative unit is being calculated, true signifies that that unit is width, false height.</param>
         /// <returns>The resulting number.</returns>
-        public static Double AsPx(this ICssValue value, IRenderDimensions renderDimensions)
+        public static Double AsPx(this ICssValue value, IRenderDimensions renderDimensions, Boolean isWidth = true)
         {
             if (value is Length length && length.Type != Length.Unit.None)
             {
-                return length.ToPixel(renderDimensions);
+                return length.ToPixel(renderDimensions, isWidth);
             }
             else if (value is ICssMultipleValue multiple && multiple.Count == 1)
             {
-                return multiple[0].AsPx(renderDimensions);
+                return multiple[0].AsPx(renderDimensions, isWidth);
             }
             else if (value is ICssSpecialValue special && special.Value != null)
             {
-                return special.Value.AsPx(renderDimensions);
+                return special.Value.AsPx(renderDimensions, isWidth);
             }
 
             return 0.0;
@@ -201,20 +203,21 @@ namespace AngleSharp.Css.Dom
         /// Tries to convert the value to a transformation matrix.
         /// </summary>
         /// <param name="value">The value to convert.</param>
+        /// <param name="renderDimensions">the render device used to calculate relative units, can be null if units are absolute.</param>
         /// <returns>The resulting matrix.</returns>
-        public static TransformMatrix AsMatrix(this ICssValue value, IRenderDimensions dimensions)
+        public static TransformMatrix AsMatrix(this ICssValue value, IRenderDimensions renderDimensions)
         {
             if (value is ICssTransformFunctionValue res)
             {
-                return res.ComputeMatrix(dimensions);
+                return res.ComputeMatrix(renderDimensions);
             }
             else if (value is ICssMultipleValue multiple && multiple.Count == 1)
             {
-                return multiple[0].AsMatrix(dimensions);
+                return multiple[0].AsMatrix(renderDimensions);
             }
             else if (value is ICssSpecialValue special && special.Value != null)
             {
-                return special.Value.AsMatrix(dimensions);
+                return special.Value.AsMatrix(renderDimensions);
             }
 
             return null;

--- a/src/AngleSharp.Css/Extensions/CssValueExtensions.cs
+++ b/src/AngleSharp.Css/Extensions/CssValueExtensions.cs
@@ -41,21 +41,21 @@ namespace AngleSharp.Css.Dom
         /// </summary>
         /// <param name="value">The value to convert.</param>
         /// <param name="renderDimensions">the render device used to calculate relative units, can be null if units are absolute.</param>
-        /// <param name="isWidth">If a relative unit is being calculated, true signifies that that unit is width, false height.</param>
+        /// <param name="mode">Signifies the axis the unit represents, use to calculate relative units where the axis matters.</param>
         /// <returns>The resulting number.</returns>
-        public static Double AsPx(this ICssValue value, IRenderDimensions renderDimensions, Boolean isWidth = true)
+        public static Double AsPx(this ICssValue value, IRenderDimensions renderDimensions, RenderMode mode)
         {
             if (value is Length length && length.Type != Length.Unit.None)
             {
-                return length.ToPixel(renderDimensions, isWidth);
+                return length.ToPixel(renderDimensions, mode);
             }
             else if (value is ICssMultipleValue multiple && multiple.Count == 1)
             {
-                return multiple[0].AsPx(renderDimensions, isWidth);
+                return multiple[0].AsPx(renderDimensions, mode);
             }
             else if (value is ICssSpecialValue special && special.Value != null)
             {
-                return special.Value.AsPx(renderDimensions, isWidth);
+                return special.Value.AsPx(renderDimensions, mode);
             }
 
             return 0.0;

--- a/src/AngleSharp.Css/Extensions/CssValueExtensions.cs
+++ b/src/AngleSharp.Css/Extensions/CssValueExtensions.cs
@@ -41,19 +41,19 @@ namespace AngleSharp.Css.Dom
         /// </summary>
         /// <param name="value">The value to convert.</param>
         /// <returns>The resulting number.</returns>
-        public static Double AsPx(this ICssValue value)
+        public static Double AsPx(this ICssValue value, IRenderDimensions renderDimensions)
         {
             if (value is Length length && length.Type != Length.Unit.None)
             {
-                return length.ToPixel();
+                return length.ToPixel(renderDimensions);
             }
             else if (value is ICssMultipleValue multiple && multiple.Count == 1)
             {
-                return multiple[0].AsPx();
+                return multiple[0].AsPx(renderDimensions);
             }
             else if (value is ICssSpecialValue special && special.Value != null)
             {
-                return special.Value.AsPx();
+                return special.Value.AsPx(renderDimensions);
             }
 
             return 0.0;
@@ -202,19 +202,19 @@ namespace AngleSharp.Css.Dom
         /// </summary>
         /// <param name="value">The value to convert.</param>
         /// <returns>The resulting matrix.</returns>
-        public static TransformMatrix AsMatrix(this ICssValue value)
+        public static TransformMatrix AsMatrix(this ICssValue value, IRenderDimensions dimensions)
         {
             if (value is ICssTransformFunctionValue res)
             {
-                return res.ComputeMatrix();
+                return res.ComputeMatrix(dimensions);
             }
             else if (value is ICssMultipleValue multiple && multiple.Count == 1)
             {
-                return multiple[0].AsMatrix();
+                return multiple[0].AsMatrix(dimensions);
             }
             else if (value is ICssSpecialValue special && special.Value != null)
             {
-                return special.Value.AsMatrix();
+                return special.Value.AsMatrix(dimensions);
             }
 
             return null;

--- a/src/AngleSharp.Css/FeatureValidators/AspectRatioFeatureValidator.cs
+++ b/src/AngleSharp.Css/FeatureValidators/AspectRatioFeatureValidator.cs
@@ -7,14 +7,14 @@ namespace AngleSharp.Css.FeatureValidators
 
     sealed class AspectRatioFeatureValidator : IFeatureValidator
     {
-        public Boolean Validate(IMediaFeature feature, IRenderDevice device)
+        public Boolean Validate(IMediaFeature feature, IRenderDevice renderDevice)
         {
             var ratio = RatioConverter.Convert(feature.Value);
 
             if (ratio != null)
             {
                 var desired = ratio.AsDouble();
-                var available = device.ViewPortWidth / (Double)device.ViewPortHeight;
+                var available = renderDevice.ViewPortWidth / (Double)renderDevice.ViewPortHeight;
 
                 if (feature.IsMaximum)
                 {

--- a/src/AngleSharp.Css/FeatureValidators/ColorFeatureValidator.cs
+++ b/src/AngleSharp.Css/FeatureValidators/ColorFeatureValidator.cs
@@ -8,7 +8,7 @@ namespace AngleSharp.Css.FeatureValidators
 
     sealed class ColorFeatureValidator : IFeatureValidator
     {
-        public Boolean Validate(IMediaFeature feature, IRenderDevice device)
+        public Boolean Validate(IMediaFeature feature, IRenderDevice renderDevice)
         {
             var defaultValue = new Length(1.0, Length.Unit.None);
             var converter = feature.IsMinimum || feature.IsMaximum ? PositiveIntegerConverter : PositiveIntegerConverter.Option(defaultValue);
@@ -17,7 +17,7 @@ namespace AngleSharp.Css.FeatureValidators
             if (color != null)
             {
                 var desired = color.AsInt32();
-                var available = Math.Pow(device.ColorBits, 2);
+                var available = Math.Pow(renderDevice.ColorBits, 2);
 
                 if (feature.IsMaximum)
                 {

--- a/src/AngleSharp.Css/FeatureValidators/ColorIndexFeatureValidator.cs
+++ b/src/AngleSharp.Css/FeatureValidators/ColorIndexFeatureValidator.cs
@@ -8,7 +8,7 @@ namespace AngleSharp.Css.FeatureValidators
 
     sealed class ColorIndexFeatureValidator : IFeatureValidator
     {
-        public Boolean Validate(IMediaFeature feature, IRenderDevice device)
+        public Boolean Validate(IMediaFeature feature, IRenderDevice renderDevice)
         {
             var defaultValue = new Length(1.0, Length.Unit.None);
             var converter = feature.IsMinimum || feature.IsMaximum ? NaturalIntegerConverter : NaturalIntegerConverter.Option(defaultValue);
@@ -17,7 +17,7 @@ namespace AngleSharp.Css.FeatureValidators
             if (index != null)
             {
                 var desired = index.AsInt32();
-                var available = device.ColorBits;
+                var available = renderDevice.ColorBits;
 
                 if (feature.IsMaximum)
                 {

--- a/src/AngleSharp.Css/FeatureValidators/DeviceAspectRatioFeatureValidator.cs
+++ b/src/AngleSharp.Css/FeatureValidators/DeviceAspectRatioFeatureValidator.cs
@@ -7,14 +7,14 @@ namespace AngleSharp.Css.FeatureValidators
 
     sealed class DeviceAspectRatioFeatureValidator : IFeatureValidator
     {
-        public Boolean Validate(IMediaFeature feature, IRenderDevice device)
+        public Boolean Validate(IMediaFeature feature, IRenderDevice renderDevice)
         {
             var ratio = RatioConverter.Convert(feature.Value);
 
             if (ratio != null)
             {
                 var desired = ratio.AsDouble();
-                var available = device.DeviceWidth / (Double)device.DeviceHeight;
+                var available = renderDevice.DeviceWidth / (Double)renderDevice.DeviceHeight;
 
                 if (feature.IsMaximum)
                 {

--- a/src/AngleSharp.Css/FeatureValidators/DeviceHeightFeatureValidator.cs
+++ b/src/AngleSharp.Css/FeatureValidators/DeviceHeightFeatureValidator.cs
@@ -13,7 +13,7 @@ namespace AngleSharp.Css.FeatureValidators
 
             if (length != null)
             {
-                var desired = length.AsPx();
+                var desired = length.AsPx(device);
                 var available = (Double)device.DeviceHeight;
 
                 if (feature.IsMaximum)

--- a/src/AngleSharp.Css/FeatureValidators/DeviceHeightFeatureValidator.cs
+++ b/src/AngleSharp.Css/FeatureValidators/DeviceHeightFeatureValidator.cs
@@ -13,7 +13,7 @@ namespace AngleSharp.Css.FeatureValidators
 
             if (length != null)
             {
-                var desired = length.AsPx(renderDevice, false);
+                var desired = length.AsPx(renderDevice, RenderMode.Vertical);
                 var available = (Double)renderDevice.DeviceHeight;
 
                 if (feature.IsMaximum)

--- a/src/AngleSharp.Css/FeatureValidators/DeviceHeightFeatureValidator.cs
+++ b/src/AngleSharp.Css/FeatureValidators/DeviceHeightFeatureValidator.cs
@@ -7,14 +7,14 @@ namespace AngleSharp.Css.FeatureValidators
 
     sealed class DeviceHeightFeatureValidator : IFeatureValidator
     {
-        public Boolean Validate(IMediaFeature feature, IRenderDevice device)
+        public Boolean Validate(IMediaFeature feature, IRenderDevice renderDevice)
         {
             var length = LengthConverter.Convert(feature.Value);
 
             if (length != null)
             {
-                var desired = length.AsPx(device);
-                var available = (Double)device.DeviceHeight;
+                var desired = length.AsPx(renderDevice, false);
+                var available = (Double)renderDevice.DeviceHeight;
 
                 if (feature.IsMaximum)
                 {

--- a/src/AngleSharp.Css/FeatureValidators/DevicePixelRatioFeatureValidator.cs
+++ b/src/AngleSharp.Css/FeatureValidators/DevicePixelRatioFeatureValidator.cs
@@ -7,14 +7,14 @@ namespace AngleSharp.Css.FeatureValidators
 
     sealed class DevicePixelRatioFeatureValidator : IFeatureValidator
     {
-        public Boolean Validate(IMediaFeature feature, IRenderDevice device)
+        public Boolean Validate(IMediaFeature feature, IRenderDevice renderDevice)
         {
             var value = NaturalNumberConverter.Convert(feature.Value);
 
             if (value != null)
             {
                 var desired = value.AsDouble();
-                var available = device.Resolution / 96f;
+                var available = renderDevice.Resolution / 96f;
 
                 if (feature.IsMaximum)
                 {

--- a/src/AngleSharp.Css/FeatureValidators/DeviceWidthFeatureValidator.cs
+++ b/src/AngleSharp.Css/FeatureValidators/DeviceWidthFeatureValidator.cs
@@ -13,7 +13,7 @@ namespace AngleSharp.Css.FeatureValidators
 
             if (length != null)
             {
-                var desired = length.AsPx(renderDevice, true);
+                var desired = length.AsPx(renderDevice, RenderMode.Horizontal);
                 var available = (Double)renderDevice.DeviceWidth;
 
                 if (feature.IsMaximum)

--- a/src/AngleSharp.Css/FeatureValidators/DeviceWidthFeatureValidator.cs
+++ b/src/AngleSharp.Css/FeatureValidators/DeviceWidthFeatureValidator.cs
@@ -7,14 +7,14 @@ namespace AngleSharp.Css.FeatureValidators
 
     sealed class DeviceWidthFeatureValidator : IFeatureValidator
     {
-        public Boolean Validate(IMediaFeature feature, IRenderDevice device)
+        public Boolean Validate(IMediaFeature feature, IRenderDevice renderDevice)
         {
             var length = LengthConverter.Convert(feature.Value);
 
             if (length != null)
             {
-                var desired = length.AsPx(device);
-                var available = (Double)device.DeviceWidth;
+                var desired = length.AsPx(renderDevice, true);
+                var available = (Double)renderDevice.DeviceWidth;
 
                 if (feature.IsMaximum)
                 {

--- a/src/AngleSharp.Css/FeatureValidators/DeviceWidthFeatureValidator.cs
+++ b/src/AngleSharp.Css/FeatureValidators/DeviceWidthFeatureValidator.cs
@@ -13,7 +13,7 @@ namespace AngleSharp.Css.FeatureValidators
 
             if (length != null)
             {
-                var desired = length.AsPx();
+                var desired = length.AsPx(device);
                 var available = (Double)device.DeviceWidth;
 
                 if (feature.IsMaximum)

--- a/src/AngleSharp.Css/FeatureValidators/GridFeatureValidator.cs
+++ b/src/AngleSharp.Css/FeatureValidators/GridFeatureValidator.cs
@@ -7,14 +7,14 @@ namespace AngleSharp.Css.FeatureValidators
 
     sealed class GridFeatureValidator : IFeatureValidator
     {
-        public Boolean Validate(IMediaFeature feature, IRenderDevice device)
+        public Boolean Validate(IMediaFeature feature, IRenderDevice renderDevice)
         {
             var grid = BinaryConverter.Convert(feature.Value);
 
             if (grid != null)
             {
                 var desired = grid.AsBoolean();
-                var available = device.IsGrid;
+                var available = renderDevice.IsGrid;
                 return desired == available;
             }
 

--- a/src/AngleSharp.Css/FeatureValidators/HeightFeatureValidator.cs
+++ b/src/AngleSharp.Css/FeatureValidators/HeightFeatureValidator.cs
@@ -13,7 +13,7 @@ namespace AngleSharp.Css.FeatureValidators
 
             if (length != null)
             {
-                var desired = length.AsPx(renderDevice, false);
+                var desired = length.AsPx(renderDevice, RenderMode.Vertical);
                 var available = (Double)renderDevice.ViewPortHeight;
 
                 if (feature.IsMaximum)

--- a/src/AngleSharp.Css/FeatureValidators/HeightFeatureValidator.cs
+++ b/src/AngleSharp.Css/FeatureValidators/HeightFeatureValidator.cs
@@ -7,14 +7,14 @@ namespace AngleSharp.Css.FeatureValidators
 
     sealed class HeightFeatureValidator : IFeatureValidator
     {
-        public Boolean Validate(IMediaFeature feature, IRenderDevice device)
+        public Boolean Validate(IMediaFeature feature, IRenderDevice renderDevice)
         {
             var length = LengthConverter.Convert(feature.Value);
 
             if (length != null)
             {
-                var desired = length.AsPx(device);
-                var available = (Double)device.ViewPortHeight;
+                var desired = length.AsPx(renderDevice, false);
+                var available = (Double)renderDevice.ViewPortHeight;
 
                 if (feature.IsMaximum)
                 {

--- a/src/AngleSharp.Css/FeatureValidators/HeightFeatureValidator.cs
+++ b/src/AngleSharp.Css/FeatureValidators/HeightFeatureValidator.cs
@@ -13,7 +13,7 @@ namespace AngleSharp.Css.FeatureValidators
 
             if (length != null)
             {
-                var desired = length.AsPx();
+                var desired = length.AsPx(device);
                 var available = (Double)device.ViewPortHeight;
 
                 if (feature.IsMaximum)

--- a/src/AngleSharp.Css/FeatureValidators/HoverFeatureValidator.cs
+++ b/src/AngleSharp.Css/FeatureValidators/HoverFeatureValidator.cs
@@ -7,7 +7,7 @@ namespace AngleSharp.Css.FeatureValidators
 
     sealed class HoverFeatureValidator : IFeatureValidator
     {
-        public Boolean Validate(IMediaFeature feature, IRenderDevice device)
+        public Boolean Validate(IMediaFeature feature, IRenderDevice renderDevice)
         {
             var hover = HoverAbilityConverter.Convert(feature.Value);
 

--- a/src/AngleSharp.Css/FeatureValidators/MonochromeFeatureValidator.cs
+++ b/src/AngleSharp.Css/FeatureValidators/MonochromeFeatureValidator.cs
@@ -8,7 +8,7 @@ namespace AngleSharp.Css.FeatureValidators
 
     sealed class MonochromeFeatureValidator : IFeatureValidator
     {
-        public Boolean Validate(IMediaFeature feature, IRenderDevice device)
+        public Boolean Validate(IMediaFeature feature, IRenderDevice renderDevice)
         {
             var defaultValue = new Length(1.0, Length.Unit.None);
             var converter = feature.IsMinimum || feature.IsMaximum ? NaturalIntegerConverter : NaturalIntegerConverter.Option(defaultValue);
@@ -17,7 +17,7 @@ namespace AngleSharp.Css.FeatureValidators
             if (index != null)
             {
                 var desired = index.AsInt32();
-                var available = device.MonochromeBits;
+                var available = renderDevice.MonochromeBits;
 
                 if (feature.IsMaximum)
                 {

--- a/src/AngleSharp.Css/FeatureValidators/OrientationFeatureValidator.cs
+++ b/src/AngleSharp.Css/FeatureValidators/OrientationFeatureValidator.cs
@@ -7,14 +7,14 @@ namespace AngleSharp.Css.FeatureValidators
 
     sealed class OrientationFeatureValidator : IFeatureValidator
     {
-        public Boolean Validate(IMediaFeature feature, IRenderDevice device)
+        public Boolean Validate(IMediaFeature feature, IRenderDevice renderDevice)
         {
             var portrait = OrientationModeConverter.Convert(feature.Value);
 
             if (portrait != null)
             {
                 var desired = portrait.Is(CssKeywords.Portrait);
-                var available = device.DeviceHeight >= device.DeviceWidth;
+                var available = renderDevice.DeviceHeight >= renderDevice.DeviceWidth;
                 return desired == available;
             }
 

--- a/src/AngleSharp.Css/FeatureValidators/PointerFeatureValidator.cs
+++ b/src/AngleSharp.Css/FeatureValidators/PointerFeatureValidator.cs
@@ -7,7 +7,7 @@ namespace AngleSharp.Css.FeatureValidators
 
     sealed class PointerFeatureValidator : IFeatureValidator
     {
-        public Boolean Validate(IMediaFeature feature, IRenderDevice device)
+        public Boolean Validate(IMediaFeature feature, IRenderDevice renderDevice)
         {
             var accuracy = PointerAccuracyConverter.Convert(feature.Value);
 

--- a/src/AngleSharp.Css/FeatureValidators/ResolutionFeatureValidator.cs
+++ b/src/AngleSharp.Css/FeatureValidators/ResolutionFeatureValidator.cs
@@ -7,14 +7,14 @@ namespace AngleSharp.Css.FeatureValidators
 
     sealed class ResolutionFeatureValidator : IFeatureValidator
     {
-        public Boolean Validate(IMediaFeature feature, IRenderDevice device)
+        public Boolean Validate(IMediaFeature feature, IRenderDevice renderDevice)
         {
             var res = ResolutionConverter.Convert(feature.Value);
 
             if (res != null)
             {
                 var desired = res.AsInt32();
-                var available = device.Resolution;
+                var available = renderDevice.Resolution;
 
                 if (feature.IsMaximum)
                 {

--- a/src/AngleSharp.Css/FeatureValidators/ScanFeatureValidator.cs
+++ b/src/AngleSharp.Css/FeatureValidators/ScanFeatureValidator.cs
@@ -7,14 +7,14 @@ namespace AngleSharp.Css.FeatureValidators
 
     sealed class ScanFeatureValidator : IFeatureValidator
     {
-        public Boolean Validate(IMediaFeature feature, IRenderDevice device)
+        public Boolean Validate(IMediaFeature feature, IRenderDevice renderDevice)
         {
             var interlace = ScanModeConverter.Convert(feature.Value);
 
             if (interlace != null)
             {
                 var desired = interlace.Is(CssKeywords.Interlace);
-                var available = device.IsInterlaced;
+                var available = renderDevice.IsInterlaced;
                 return desired == available;
             }
 

--- a/src/AngleSharp.Css/FeatureValidators/ScriptingFeatureValidator.cs
+++ b/src/AngleSharp.Css/FeatureValidators/ScriptingFeatureValidator.cs
@@ -7,7 +7,7 @@ namespace AngleSharp.Css.FeatureValidators
 
     sealed class ScriptingFeatureValidator : IFeatureValidator
     {
-        public Boolean Validate(IMediaFeature feature, IRenderDevice device)
+        public Boolean Validate(IMediaFeature feature, IRenderDevice renderDevice)
         {
             var state = ScriptingStateConverter.Convert(feature.Value);
 
@@ -16,9 +16,9 @@ namespace AngleSharp.Css.FeatureValidators
                 var available = ScriptingState.None;
                 var desired = state.AsEnum<ScriptingState>();
 
-                if (device.IsScripting)
+                if (renderDevice.IsScripting)
                 {
-                    available = device.Category == DeviceCategory.Screen ? ScriptingState.Enabled : ScriptingState.InitialOnly;
+                    available = renderDevice.Category == DeviceCategory.Screen ? ScriptingState.Enabled : ScriptingState.InitialOnly;
                 }
 
                 return desired == available;

--- a/src/AngleSharp.Css/FeatureValidators/UnknownFeatureValidator.cs
+++ b/src/AngleSharp.Css/FeatureValidators/UnknownFeatureValidator.cs
@@ -5,7 +5,7 @@ namespace AngleSharp.Css.FeatureValidators
 
     sealed class UnknownFeatureValidator : IFeatureValidator
     {
-        public Boolean Validate(IMediaFeature feature, IRenderDevice device)
+        public Boolean Validate(IMediaFeature feature, IRenderDevice renderDevice)
         {
             return true;
         }

--- a/src/AngleSharp.Css/FeatureValidators/UpdateFrequencyFeatureValidator.cs
+++ b/src/AngleSharp.Css/FeatureValidators/UpdateFrequencyFeatureValidator.cs
@@ -7,14 +7,14 @@ namespace AngleSharp.Css.FeatureValidators
 
     sealed class UpdateFrequencyFeatureValidator : IFeatureValidator
     {
-        public Boolean Validate(IMediaFeature feature, IRenderDevice device)
+        public Boolean Validate(IMediaFeature feature, IRenderDevice renderDevice)
         {
             var frequency = UpdateFrequencyConverter.Convert(feature.Value);
 
             if (frequency != null)
             {
                 var desired = frequency.AsEnum<UpdateFrequency>();
-                var available = device.Frequency;
+                var available = renderDevice.Frequency;
 
                 if (available >= 30)
                 {

--- a/src/AngleSharp.Css/FeatureValidators/WidthFeatureValidator.cs
+++ b/src/AngleSharp.Css/FeatureValidators/WidthFeatureValidator.cs
@@ -13,7 +13,7 @@ namespace AngleSharp.Css.FeatureValidators
 
             if (length != null)
             {
-                var desired = length.AsPx(renderDevice, true);
+                var desired = length.AsPx(renderDevice, RenderMode.Horizontal);
                 var available = (Double)renderDevice.ViewPortWidth;
 
                 if (feature.IsMaximum)

--- a/src/AngleSharp.Css/FeatureValidators/WidthFeatureValidator.cs
+++ b/src/AngleSharp.Css/FeatureValidators/WidthFeatureValidator.cs
@@ -13,7 +13,7 @@ namespace AngleSharp.Css.FeatureValidators
 
             if (length != null)
             {
-                var desired = length.AsPx();
+                var desired = length.AsPx(device);
                 var available = (Double)device.ViewPortWidth;
 
                 if (feature.IsMaximum)

--- a/src/AngleSharp.Css/FeatureValidators/WidthFeatureValidator.cs
+++ b/src/AngleSharp.Css/FeatureValidators/WidthFeatureValidator.cs
@@ -7,14 +7,14 @@ namespace AngleSharp.Css.FeatureValidators
 
     sealed class WidthFeatureValidator : IFeatureValidator
     {
-        public Boolean Validate(IMediaFeature feature, IRenderDevice device)
+        public Boolean Validate(IMediaFeature feature, IRenderDevice renderDevice)
         {
             var length = LengthConverter.Convert(feature.Value);
 
             if (length != null)
             {
-                var desired = length.AsPx(device);
-                var available = (Double)device.ViewPortWidth;
+                var desired = length.AsPx(renderDevice, true);
+                var available = (Double)renderDevice.ViewPortWidth;
 
                 if (feature.IsMaximum)
                 {

--- a/src/AngleSharp.Css/IFeatureValidator.cs
+++ b/src/AngleSharp.Css/IFeatureValidator.cs
@@ -12,8 +12,8 @@
         /// Validates the given media feature against the given device.
         /// </summary>
         /// <param name="feature">The feature to examine.</param>
-        /// <param name="device">The device to use as basis.</param>
+        /// <param name="renderDevice">The device to use as basis.</param>
         /// <returns>True if the feature is present, otherwise false.</returns>
-        Boolean Validate(IMediaFeature feature, IRenderDevice device);
+        Boolean Validate(IMediaFeature feature, IRenderDevice renderDevice);
     }
 }

--- a/src/AngleSharp.Css/IRenderDevice.cs
+++ b/src/AngleSharp.Css/IRenderDevice.cs
@@ -5,7 +5,7 @@ namespace AngleSharp.Css
     /// <summary>
     /// Represents the renderers setting.
     /// </summary>
-    public interface IRenderDevice
+    public interface IRenderDevice : IRenderDimensions
     {
         /// <summary>
         /// Gets the width of the viewport in pixels.

--- a/src/AngleSharp.Css/IRenderDimensions.cs
+++ b/src/AngleSharp.Css/IRenderDimensions.cs
@@ -1,7 +1,7 @@
-using System;
-
 namespace AngleSharp.Css
 {
+    using System;
+
     /// <summary>
     /// Represents the render settings for an element, used to calculate relative sizes (E.G. %, rem).
     /// </summary>

--- a/src/AngleSharp.Css/IRenderDimensions.cs
+++ b/src/AngleSharp.Css/IRenderDimensions.cs
@@ -2,10 +2,24 @@ using System;
 
 namespace AngleSharp.Css
 {
+    /// <summary>
+    /// Represents the render settings for an element, used to calculate relative sizes (E.G. %, rem).
+    /// </summary>
     public interface IRenderDimensions
     {
-        Int32 RenderWidth { get; set; }
-        Int32 RenderHeight { get; set; }
-        double FontSize { get; set; }
+        /// <summary>
+        /// Gets Width of the render box.
+        /// </summary>
+        Double RenderWidth { get; }
+
+        /// <summary>
+        /// Gets Height of the render box.
+        /// </summary>
+        Double RenderHeight { get; }
+
+        /// <summary>
+        /// Gets the default font size in px.
+        /// </summary>
+        Double FontSize { get; }
     }
 }

--- a/src/AngleSharp.Css/IRenderDimensions.cs
+++ b/src/AngleSharp.Css/IRenderDimensions.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace AngleSharp.Css
+{
+    public interface IRenderDimensions
+    {
+        Int32 RenderWidth { get; set; }
+        Int32 RenderHeight { get; set; }
+        double FontSize { get; set; }
+    }
+}

--- a/src/AngleSharp.Css/RenderMode.cs
+++ b/src/AngleSharp.Css/RenderMode.cs
@@ -1,0 +1,22 @@
+namespace AngleSharp.Css
+{
+    /// <summary>
+    /// Used by To/ToPixel. If known, defines the axis the unit is in.
+    /// This is use to calculate relative units such as %
+    /// </summary>
+    public enum RenderMode
+    {
+        /// <summary>
+        /// Should be used if the unit is absolute, or the axis is unknown.
+        /// </summary>
+        Undefined,
+        /// <summary>
+        /// The current axis is horizontal meaning percentage will refer to percentage of width
+        /// </summary>
+        Horizontal,
+        /// <summary>
+        /// The current axis is vertical meaning percentage will refer to percentage of height
+        /// </summary>
+        Vertical,
+    }
+}

--- a/src/AngleSharp.Css/Values/Functions/CssMatrixValue.cs
+++ b/src/AngleSharp.Css/Values/Functions/CssMatrixValue.cs
@@ -70,7 +70,7 @@ namespace AngleSharp.Css.Values
         /// Returns the stored matrix.
         /// </summary>
         /// <returns>The current transformation.</returns>
-        public TransformMatrix ComputeMatrix()
+        public TransformMatrix ComputeMatrix(IRenderDimensions dimensions)
         {
             var values = _values;
 

--- a/src/AngleSharp.Css/Values/Functions/CssPerspectiveValue.cs
+++ b/src/AngleSharp.Css/Values/Functions/CssPerspectiveValue.cs
@@ -57,7 +57,7 @@ namespace AngleSharp.Css.Values
         public TransformMatrix ComputeMatrix(IRenderDimensions renderDimensions)
         {
             var distance = _distance as Length? ?? Length.Zero;
-            return new TransformMatrix(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, -1.0 / distance.ToPixel(renderDimensions));
+            return new TransformMatrix(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, -1.0 / distance.ToPixel(renderDimensions, RenderMode.Undefined));
         }
 
         #endregion

--- a/src/AngleSharp.Css/Values/Functions/CssPerspectiveValue.cs
+++ b/src/AngleSharp.Css/Values/Functions/CssPerspectiveValue.cs
@@ -54,10 +54,10 @@ namespace AngleSharp.Css.Values
         /// Computes the matrix for the given transformation.
         /// </summary>
         /// <returns>The transformation matrix representation.</returns>
-        public TransformMatrix ComputeMatrix()
+        public TransformMatrix ComputeMatrix(IRenderDimensions renderDimensions)
         {
             var distance = _distance as Length? ?? Length.Zero;
-            return new TransformMatrix(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, -1.0 / distance.ToPixel());
+            return new TransformMatrix(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, -1.0 / distance.ToPixel(renderDimensions));
         }
 
         #endregion

--- a/src/AngleSharp.Css/Values/Functions/CssRotateValue.cs
+++ b/src/AngleSharp.Css/Values/Functions/CssRotateValue.cs
@@ -126,7 +126,7 @@ namespace AngleSharp.Css.Values
         /// Computes the matrix for the given transformation.
         /// </summary>
         /// <returns>The transformation matrix representation.</returns>
-        public TransformMatrix ComputeMatrix()
+        public TransformMatrix ComputeMatrix(IRenderDimensions renderDimensions)
         {
             var norm = 1.0 / Math.Sqrt(_x * _x + _y * _y + _z * _z);
             var alpha = _angle as Angle ? ?? Values.Angle.Zero;

--- a/src/AngleSharp.Css/Values/Functions/CssScaleValue.cs
+++ b/src/AngleSharp.Css/Values/Functions/CssScaleValue.cs
@@ -136,7 +136,7 @@ namespace AngleSharp.Css.Values
         /// Computes the matrix for the given transformation.
         /// </summary>
         /// <returns>The transformation matrix representation.</returns>
-        public TransformMatrix ComputeMatrix() =>
+        public TransformMatrix ComputeMatrix(IRenderDimensions renderDimensions) =>
             new TransformMatrix(_sx, 0f, 0f, 0f, _sy, 0f, 0f, 0f, _sz, 0f, 0f, 0f, 0f, 0f, 0f);
 
         #endregion

--- a/src/AngleSharp.Css/Values/Functions/CssSkewValue.cs
+++ b/src/AngleSharp.Css/Values/Functions/CssSkewValue.cs
@@ -104,7 +104,7 @@ namespace AngleSharp.Css.Values
         /// Computes the matrix for the given transformation.
         /// </summary>
         /// <returns>The transformation matrix representation.</returns>
-        public TransformMatrix ComputeMatrix()
+        public TransformMatrix ComputeMatrix(IRenderDimensions renderDimensions)
         {
             var a = Math.Tan((_alpha as Angle ? ?? Angle.Zero).ToRadian());
             var b = Math.Tan((_beta as Angle? ?? Angle.Zero).ToRadian());

--- a/src/AngleSharp.Css/Values/Functions/CssTranslateValue.cs
+++ b/src/AngleSharp.Css/Values/Functions/CssTranslateValue.cs
@@ -109,7 +109,7 @@ namespace AngleSharp.Css.Values
             var y = _y as Length? ?? Length.Zero;
             var z = _z as Length? ?? Length.Zero;
             var dx = x.ToPixel(renderDimensions);
-            var dy = y.ToPixel(renderDimensions);
+            var dy = y.ToPixel(renderDimensions, false);
             var dz = z.ToPixel(renderDimensions);
             return new TransformMatrix(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, dx, dy, dz, 0.0, 0.0, 0.0);
         }

--- a/src/AngleSharp.Css/Values/Functions/CssTranslateValue.cs
+++ b/src/AngleSharp.Css/Values/Functions/CssTranslateValue.cs
@@ -108,9 +108,9 @@ namespace AngleSharp.Css.Values
             var x = _x as Length? ?? Length.Zero;
             var y = _y as Length? ?? Length.Zero;
             var z = _z as Length? ?? Length.Zero;
-            var dx = x.ToPixel(renderDimensions);
-            var dy = y.ToPixel(renderDimensions, false);
-            var dz = z.ToPixel(renderDimensions);
+            var dx = x.ToPixel(renderDimensions, RenderMode.Horizontal);
+            var dy = y.ToPixel(renderDimensions, RenderMode.Vertical);
+            var dz = z.ToPixel(renderDimensions, RenderMode.Undefined);
             return new TransformMatrix(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, dx, dy, dz, 0.0, 0.0, 0.0);
         }
 

--- a/src/AngleSharp.Css/Values/Functions/CssTranslateValue.cs
+++ b/src/AngleSharp.Css/Values/Functions/CssTranslateValue.cs
@@ -103,14 +103,14 @@ namespace AngleSharp.Css.Values
         /// Computes the matrix for the given transformation.
         /// </summary>
         /// <returns>The transformation matrix representation.</returns>
-        public TransformMatrix ComputeMatrix()
+        public TransformMatrix ComputeMatrix(IRenderDimensions renderDimensions)
         {
             var x = _x as Length? ?? Length.Zero;
             var y = _y as Length? ?? Length.Zero;
             var z = _z as Length? ?? Length.Zero;
-            var dx = x.ToPixel();
-            var dy = y.ToPixel();
-            var dz = z.ToPixel();
+            var dx = x.ToPixel(renderDimensions);
+            var dy = y.ToPixel(renderDimensions);
+            var dz = z.ToPixel(renderDimensions);
             return new TransformMatrix(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, dx, dy, dz, 0.0, 0.0, 0.0);
         }
 

--- a/src/AngleSharp.Css/Values/ICssTransformFunctionValue.cs
+++ b/src/AngleSharp.Css/Values/ICssTransformFunctionValue.cs
@@ -9,6 +9,6 @@ namespace AngleSharp.Css.Values
         /// Computes the matrix for the given transformation.
         /// </summary>
         /// <returns>The transformation matrix representation.</returns>
-        TransformMatrix ComputeMatrix();
+        TransformMatrix ComputeMatrix(IRenderDimensions renderDimensions);
     }
 }

--- a/src/AngleSharp.Css/Values/Primitives/Length.cs
+++ b/src/AngleSharp.Css/Values/Primitives/Length.cs
@@ -317,7 +317,7 @@ namespace AngleSharp.Css.Values
                     CheckForValidRenderDimensions(renderDimensions, RenderMode.Vertical);
                     return _value * 0.01 * Math.Min(renderDimensions.RenderHeight, renderDimensions.RenderWidth);
                 default:
-                    throw new InvalidOperationException("Unsupported Unit cant be converted.");
+                    throw new InvalidOperationException("Unsupported unit cannot be converted.");
             }
         }
 
@@ -373,7 +373,7 @@ namespace AngleSharp.Css.Values
                     CheckForValidRenderDimensions(renderDimensions, RenderMode.Horizontal);
                     return value / ( 0.01 * Math.Min(renderDimensions.RenderHeight, renderDimensions.RenderWidth));
                 default:
-                    throw new InvalidOperationException("Unsupported Unit cant be converted.");
+                    throw new InvalidOperationException("Unsupported unit cannot be converted.");
             }
         }
 

--- a/src/AngleSharp.Css/Values/Primitives/Length.cs
+++ b/src/AngleSharp.Css/Values/Primitives/Length.cs
@@ -299,7 +299,7 @@ namespace AngleSharp.Css.Values
                     return _value * renderDimensions.FontSize;
                 case Unit.Rem:
                     // here we dont actually know the root font size but currently the only IRenderDimensions used is
-                    // the IRenderDevice meaning its all the root font size
+                    // the IRenderDevice meaning its always the root font size
                     CheckForValidRenderDimensionsForFont(renderDimensions);
                     return _value * renderDimensions.FontSize;
                 case Unit.Vh:
@@ -355,7 +355,7 @@ namespace AngleSharp.Css.Values
                     return value / renderDimensions.FontSize;
                 case Unit.Rem:
                     // here we dont actually know the root font size but currently the only IRenderDimensions used is
-                    // the IRenderDevice meaning its all the root font size
+                    // the IRenderDevice meaning its always the root font size
                     CheckForValidRenderDimensionsForFont(renderDimensions);
                     return value / renderDimensions.FontSize;
                 case Unit.Vh:

--- a/src/AngleSharp.Css/Values/Primitives/Length.cs
+++ b/src/AngleSharp.Css/Values/Primitives/Length.cs
@@ -272,8 +272,10 @@ namespace AngleSharp.Css.Values
         /// Converts the length to a number of pixels, if possible. If the
         /// current unit is relative, then an exception will be thrown.
         /// </summary>
+        /// <param name="renderDimensions">the render device used to calculate relative units, can be null if units are absolute.</param>
+        /// <param name="isWidth">If a relative unit is being calculated, true signifies that that unit is width, false height.</param>
         /// <returns>The number of pixels represented by the current length.</returns>
-        public Double ToPixel(IRenderDimensions dimensions)
+        public Double ToPixel(IRenderDimensions renderDimensions, Boolean isWidth = true)
         {
             switch (_unit)
             {
@@ -289,6 +291,22 @@ namespace AngleSharp.Css.Values
                     return _value * 50.0 * 96.0 / 127.0;
                 case Unit.Px: // 1 px = 1/96 in
                     return _value;
+                case Unit.Percent:
+                    return _value * 0.01 * (isWidth ? renderDimensions.RenderWidth : renderDimensions.RenderHeight);
+                case Unit.Em:
+                    return _value * renderDimensions.FontSize;
+                case Unit.Rem:
+                    // here we dont actually know the root font size but currently the only IRenderDimensions used is
+                    // the IRenderDevice meaning its all the root font size
+                    return _value * renderDimensions.FontSize;
+                case Unit.Vh:
+                    return _value * 0.01 * renderDimensions.RenderHeight;
+                case Unit.Vw:
+                    return _value * 0.01 * renderDimensions.RenderHeight;
+                case Unit.Vmax:
+                    return _value * 0.01 * Math.Max(renderDimensions.RenderHeight, renderDimensions.RenderWidth);
+                case Unit.Vmin:
+                    return _value * 0.01 * Math.Min(renderDimensions.RenderHeight, renderDimensions.RenderWidth);
                 //todo implement other units and handle if dimensions is null
                 default:
                     throw new InvalidOperationException("A relative unit cannot be converted.");
@@ -300,10 +318,12 @@ namespace AngleSharp.Css.Values
         /// or given unit is relative, then an exception will be thrown.
         /// </summary>
         /// <param name="unit">The unit to convert to.</param>
+        /// <param name="renderDimensions">the render device used to calculate relative units, can be null if units are absolute.</param>
+        /// <param name="isWidth">If a relative unit is being calculated, true signifies that that unit is width, false height.</param>
         /// <returns>The value in the given unit of the current length.</returns>
-        public Double To(Unit unit, IRenderDimensions dimensions)
+        public Double To(Unit unit, IRenderDimensions renderDimensions, Boolean isWidth = true)
         {
-            var value = ToPixel(dimensions);
+            var value = ToPixel(renderDimensions, isWidth);
 
             switch (unit)
             {
@@ -319,6 +339,22 @@ namespace AngleSharp.Css.Values
                     return value * 127.0 / (50.0 * 96.0);
                 case Unit.Px: // 1 px = 1/96 in
                     return value;
+                case Unit.Percent:
+                    return value / (isWidth ? renderDimensions.RenderWidth : renderDimensions.RenderHeight) * 100;
+                case Unit.Em:
+                    return value / renderDimensions.FontSize;
+                case Unit.Rem:
+                    // here we dont actually know the root font size but currently the only IRenderDimensions used is
+                    // the IRenderDevice meaning its all the root font size
+                    return value / renderDimensions.FontSize;
+                case Unit.Vh:
+                    return value / (0.01 * renderDimensions.RenderHeight);
+                case Unit.Vw:
+                    return value / ( 0.01 * renderDimensions.RenderHeight);
+                case Unit.Vmax:
+                    return value / ( 0.01 * Math.Max(renderDimensions.RenderHeight, renderDimensions.RenderWidth));
+                case Unit.Vmin:
+                    return value / ( 0.01 * Math.Min(renderDimensions.RenderHeight, renderDimensions.RenderWidth));
                 //todo implement other units and handle if dimensions is null
                 default:
                     throw new InvalidOperationException("An absolute unit cannot be converted to a relative one.");

--- a/src/AngleSharp.Css/Values/Primitives/Length.cs
+++ b/src/AngleSharp.Css/Values/Primitives/Length.cs
@@ -203,7 +203,7 @@ namespace AngleSharp.Css.Values
                 }
                 else if (IsAbsolute && other.IsAbsolute)
                 {
-                    return ToPixel(null).CompareTo(other.ToPixel(null));
+                    return ToPixel(null, RenderMode.Undefined).CompareTo(other.ToPixel(null, RenderMode.Undefined));
                 }
             }
 
@@ -273,9 +273,9 @@ namespace AngleSharp.Css.Values
         /// current unit is relative, then an exception will be thrown.
         /// </summary>
         /// <param name="renderDimensions">the render device used to calculate relative units, can be null if units are absolute.</param>
-        /// <param name="isWidth">If a relative unit is being calculated, true signifies that that unit is width, false height.</param>
+        /// <param name="mode">Signifies the axis the unit represents, use to calculate relative units where the axis matters.</param>
         /// <returns>The number of pixels represented by the current length.</returns>
-        public Double ToPixel(IRenderDimensions renderDimensions, Boolean isWidth = true)
+        public Double ToPixel(IRenderDimensions renderDimensions, RenderMode mode)
         {
             switch (_unit)
             {
@@ -292,8 +292,8 @@ namespace AngleSharp.Css.Values
                 case Unit.Px: // 1 px = 1/96 in
                     return _value;
                 case Unit.Percent:
-                    CheckForValidRenderDimensions(renderDimensions, isWidth);
-                    return _value * 0.01 * (isWidth ? renderDimensions.RenderWidth : renderDimensions.RenderHeight);
+                    CheckForValidRenderDimensions(renderDimensions, mode);
+                    return _value * 0.01 * (mode == RenderMode.Horizontal ? renderDimensions.RenderWidth : renderDimensions.RenderHeight);
                 case Unit.Em:
                     CheckForValidRenderDimensionsForFont(renderDimensions);
                     return _value * renderDimensions.FontSize;
@@ -303,18 +303,18 @@ namespace AngleSharp.Css.Values
                     CheckForValidRenderDimensionsForFont(renderDimensions);
                     return _value * renderDimensions.FontSize;
                 case Unit.Vh:
-                    CheckForValidRenderDimensions(renderDimensions, false);
+                    CheckForValidRenderDimensions(renderDimensions, RenderMode.Vertical);
                     return _value * 0.01 * renderDimensions.RenderHeight;
                 case Unit.Vw:
-                    CheckForValidRenderDimensions(renderDimensions, true);
+                    CheckForValidRenderDimensions(renderDimensions, RenderMode.Horizontal);
                     return _value * 0.01 * renderDimensions.RenderWidth;
                 case Unit.Vmax:
-                    CheckForValidRenderDimensions(renderDimensions, true);
-                    CheckForValidRenderDimensions(renderDimensions, false);
+                    CheckForValidRenderDimensions(renderDimensions, RenderMode.Horizontal);
+                    CheckForValidRenderDimensions(renderDimensions, RenderMode.Vertical);
                     return _value * 0.01 * Math.Max(renderDimensions.RenderHeight, renderDimensions.RenderWidth);
                 case Unit.Vmin:
-                    CheckForValidRenderDimensions(renderDimensions, true);
-                    CheckForValidRenderDimensions(renderDimensions, false);
+                    CheckForValidRenderDimensions(renderDimensions, RenderMode.Horizontal);
+                    CheckForValidRenderDimensions(renderDimensions, RenderMode.Vertical);
                     return _value * 0.01 * Math.Min(renderDimensions.RenderHeight, renderDimensions.RenderWidth);
                 default:
                     throw new InvalidOperationException("Unsupported Unit cant be converted.");
@@ -327,11 +327,11 @@ namespace AngleSharp.Css.Values
         /// </summary>
         /// <param name="unit">The unit to convert to.</param>
         /// <param name="renderDimensions">the render device used to calculate relative units, can be null if units are absolute.</param>
-        /// <param name="isWidth">If a relative unit is being calculated, true signifies that that unit is width, false height.</param>
+        /// <param name="mode">Signifies the axis the unit represents, use to calculate relative units where the axis matters.</param>
         /// <returns>The value in the given unit of the current length.</returns>
-        public Double To(Unit unit, IRenderDimensions renderDimensions, Boolean isWidth = true)
+        public Double To(Unit unit, IRenderDimensions renderDimensions, RenderMode mode)
         {
-            var value = ToPixel(renderDimensions, isWidth);
+            var value = ToPixel(renderDimensions, mode);
 
             switch (unit)
             {
@@ -348,8 +348,8 @@ namespace AngleSharp.Css.Values
                 case Unit.Px: // 1 px = 1/96 in
                     return value;
                 case Unit.Percent:
-                    CheckForValidRenderDimensions(renderDimensions, isWidth);
-                    return value / (isWidth ? renderDimensions.RenderWidth : renderDimensions.RenderHeight) * 100;
+                    CheckForValidRenderDimensions(renderDimensions, mode);
+                    return value / (mode == RenderMode.Horizontal ? renderDimensions.RenderWidth : renderDimensions.RenderHeight) * 100;
                 case Unit.Em:
                     CheckForValidRenderDimensionsForFont(renderDimensions);
                     return value / renderDimensions.FontSize;
@@ -359,27 +359,27 @@ namespace AngleSharp.Css.Values
                     CheckForValidRenderDimensionsForFont(renderDimensions);
                     return value / renderDimensions.FontSize;
                 case Unit.Vh:
-                    CheckForValidRenderDimensions(renderDimensions, false);
+                    CheckForValidRenderDimensions(renderDimensions, RenderMode.Vertical);
                     return value / (0.01 * renderDimensions.RenderHeight);
                 case Unit.Vw:
-                    CheckForValidRenderDimensions(renderDimensions, true);
+                    CheckForValidRenderDimensions(renderDimensions, RenderMode.Horizontal);
                     return value / ( 0.01 * renderDimensions.RenderWidth);
                 case Unit.Vmax:
-                    CheckForValidRenderDimensions(renderDimensions, true);
-                    CheckForValidRenderDimensions(renderDimensions, false);
+                    CheckForValidRenderDimensions(renderDimensions, RenderMode.Vertical);
+                    CheckForValidRenderDimensions(renderDimensions, RenderMode.Horizontal);
                     return value / ( 0.01 * Math.Max(renderDimensions.RenderHeight, renderDimensions.RenderWidth));
                 case Unit.Vmin:
-                    CheckForValidRenderDimensions(renderDimensions, true);
-                    CheckForValidRenderDimensions(renderDimensions, false);
+                    CheckForValidRenderDimensions(renderDimensions, RenderMode.Vertical);
+                    CheckForValidRenderDimensions(renderDimensions, RenderMode.Horizontal);
                     return value / ( 0.01 * Math.Min(renderDimensions.RenderHeight, renderDimensions.RenderWidth));
                 default:
                     throw new InvalidOperationException("Unsupported Unit cant be converted.");
             }
         }
 
-        private void CheckForValidRenderDimensions(IRenderDimensions renderDimensions, bool isWidth)
+        private void CheckForValidRenderDimensions(IRenderDimensions renderDimensions, RenderMode mode)
         {
-            if (renderDimensions == null || (isWidth ? renderDimensions.RenderWidth : renderDimensions.RenderHeight) <= 0)
+            if (renderDimensions == null || mode == RenderMode.Undefined || (mode == RenderMode.Horizontal ? renderDimensions.RenderWidth : renderDimensions.RenderHeight) <= 0)
             {
                 throw new ArgumentException("A non null render device with a font size is required to calculate em or rem units.");
             }

--- a/src/AngleSharp.Css/Values/Primitives/Length.cs
+++ b/src/AngleSharp.Css/Values/Primitives/Length.cs
@@ -379,7 +379,7 @@ namespace AngleSharp.Css.Values
 
         private void CheckForValidRenderDimensions(IRenderDimensions renderDimensions, bool isWidth)
         {
-            if (renderDimensions == null || (isWidth ? renderDimensions.RenderWidth : renderDimensions.RenderHeight) > 0)
+            if (renderDimensions == null || (isWidth ? renderDimensions.RenderWidth : renderDimensions.RenderHeight) <= 0)
             {
                 throw new ArgumentException("A non null render device with a font size is required to calculate em or rem units.");
             }
@@ -387,7 +387,7 @@ namespace AngleSharp.Css.Values
 
         private void CheckForValidRenderDimensionsForFont(IRenderDimensions renderDimensions)
         {
-            if (renderDimensions == null || renderDimensions.FontSize > 0)
+            if (renderDimensions == null || renderDimensions.FontSize <= 0)
             {
                 throw new ArgumentException("A non null render device with a font size is required to calculate em or rem units.");
             }

--- a/src/AngleSharp.Css/Values/Primitives/Length.cs
+++ b/src/AngleSharp.Css/Values/Primitives/Length.cs
@@ -203,7 +203,7 @@ namespace AngleSharp.Css.Values
                 }
                 else if (IsAbsolute && other.IsAbsolute)
                 {
-                    return ToPixel().CompareTo(other.ToPixel());
+                    return ToPixel(null).CompareTo(other.ToPixel(null));
                 }
             }
 
@@ -273,7 +273,7 @@ namespace AngleSharp.Css.Values
         /// current unit is relative, then an exception will be thrown.
         /// </summary>
         /// <returns>The number of pixels represented by the current length.</returns>
-        public Double ToPixel()
+        public Double ToPixel(IRenderDimensions dimensions)
         {
             switch (_unit)
             {
@@ -289,6 +289,7 @@ namespace AngleSharp.Css.Values
                     return _value * 50.0 * 96.0 / 127.0;
                 case Unit.Px: // 1 px = 1/96 in
                     return _value;
+                //todo implement other units and handle if dimensions is null
                 default:
                     throw new InvalidOperationException("A relative unit cannot be converted.");
             }
@@ -300,9 +301,9 @@ namespace AngleSharp.Css.Values
         /// </summary>
         /// <param name="unit">The unit to convert to.</param>
         /// <returns>The value in the given unit of the current length.</returns>
-        public Double To(Unit unit)
+        public Double To(Unit unit, IRenderDimensions dimensions)
         {
-            var value = ToPixel();
+            var value = ToPixel(dimensions);
 
             switch (unit)
             {
@@ -318,6 +319,7 @@ namespace AngleSharp.Css.Values
                     return value * 127.0 / (50.0 * 96.0);
                 case Unit.Px: // 1 px = 1/96 in
                     return value;
+                //todo implement other units and handle if dimensions is null
                 default:
                     throw new InvalidOperationException("An absolute unit cannot be converted to a relative one.");
             }

--- a/src/AngleSharp.Css/Values/Primitives/Length.cs
+++ b/src/AngleSharp.Css/Values/Primitives/Length.cs
@@ -292,24 +292,32 @@ namespace AngleSharp.Css.Values
                 case Unit.Px: // 1 px = 1/96 in
                     return _value;
                 case Unit.Percent:
+                    CheckForValidRenderDimensions(renderDimensions, isWidth);
                     return _value * 0.01 * (isWidth ? renderDimensions.RenderWidth : renderDimensions.RenderHeight);
                 case Unit.Em:
+                    CheckForValidRenderDimensionsForFont(renderDimensions);
                     return _value * renderDimensions.FontSize;
                 case Unit.Rem:
                     // here we dont actually know the root font size but currently the only IRenderDimensions used is
                     // the IRenderDevice meaning its all the root font size
+                    CheckForValidRenderDimensionsForFont(renderDimensions);
                     return _value * renderDimensions.FontSize;
                 case Unit.Vh:
+                    CheckForValidRenderDimensions(renderDimensions, false);
                     return _value * 0.01 * renderDimensions.RenderHeight;
                 case Unit.Vw:
+                    CheckForValidRenderDimensions(renderDimensions, true);
                     return _value * 0.01 * renderDimensions.RenderWidth;
                 case Unit.Vmax:
+                    CheckForValidRenderDimensions(renderDimensions, true);
+                    CheckForValidRenderDimensions(renderDimensions, false);
                     return _value * 0.01 * Math.Max(renderDimensions.RenderHeight, renderDimensions.RenderWidth);
                 case Unit.Vmin:
+                    CheckForValidRenderDimensions(renderDimensions, true);
+                    CheckForValidRenderDimensions(renderDimensions, false);
                     return _value * 0.01 * Math.Min(renderDimensions.RenderHeight, renderDimensions.RenderWidth);
-                //todo implement other units and handle if dimensions is null
                 default:
-                    throw new InvalidOperationException("A relative unit cannot be converted.");
+                    throw new InvalidOperationException("Unsupported Unit cant be converted.");
             }
         }
 
@@ -340,24 +348,48 @@ namespace AngleSharp.Css.Values
                 case Unit.Px: // 1 px = 1/96 in
                     return value;
                 case Unit.Percent:
+                    CheckForValidRenderDimensions(renderDimensions, isWidth);
                     return value / (isWidth ? renderDimensions.RenderWidth : renderDimensions.RenderHeight) * 100;
                 case Unit.Em:
+                    CheckForValidRenderDimensionsForFont(renderDimensions);
                     return value / renderDimensions.FontSize;
                 case Unit.Rem:
                     // here we dont actually know the root font size but currently the only IRenderDimensions used is
                     // the IRenderDevice meaning its all the root font size
+                    CheckForValidRenderDimensionsForFont(renderDimensions);
                     return value / renderDimensions.FontSize;
                 case Unit.Vh:
+                    CheckForValidRenderDimensions(renderDimensions, false);
                     return value / (0.01 * renderDimensions.RenderHeight);
                 case Unit.Vw:
+                    CheckForValidRenderDimensions(renderDimensions, true);
                     return value / ( 0.01 * renderDimensions.RenderWidth);
                 case Unit.Vmax:
+                    CheckForValidRenderDimensions(renderDimensions, true);
+                    CheckForValidRenderDimensions(renderDimensions, false);
                     return value / ( 0.01 * Math.Max(renderDimensions.RenderHeight, renderDimensions.RenderWidth));
                 case Unit.Vmin:
+                    CheckForValidRenderDimensions(renderDimensions, true);
+                    CheckForValidRenderDimensions(renderDimensions, false);
                     return value / ( 0.01 * Math.Min(renderDimensions.RenderHeight, renderDimensions.RenderWidth));
-                //todo implement other units and handle if dimensions is null
                 default:
-                    throw new InvalidOperationException("An absolute unit cannot be converted to a relative one.");
+                    throw new InvalidOperationException("Unsupported Unit cant be converted.");
+            }
+        }
+
+        private void CheckForValidRenderDimensions(IRenderDimensions renderDimensions, bool isWidth)
+        {
+            if (renderDimensions == null || (isWidth ? renderDimensions.RenderWidth : renderDimensions.RenderHeight) > 0)
+            {
+                throw new ArgumentException("A non null render device with a font size is required to calculate em or rem units.");
+            }
+        }
+
+        private void CheckForValidRenderDimensionsForFont(IRenderDimensions renderDimensions)
+        {
+            if (renderDimensions == null || renderDimensions.FontSize > 0)
+            {
+                throw new ArgumentException("A non null render device with a font size is required to calculate em or rem units.");
             }
         }
 

--- a/src/AngleSharp.Css/Values/Primitives/Length.cs
+++ b/src/AngleSharp.Css/Values/Primitives/Length.cs
@@ -302,7 +302,7 @@ namespace AngleSharp.Css.Values
                 case Unit.Vh:
                     return _value * 0.01 * renderDimensions.RenderHeight;
                 case Unit.Vw:
-                    return _value * 0.01 * renderDimensions.RenderHeight;
+                    return _value * 0.01 * renderDimensions.RenderWidth;
                 case Unit.Vmax:
                     return _value * 0.01 * Math.Max(renderDimensions.RenderHeight, renderDimensions.RenderWidth);
                 case Unit.Vmin:
@@ -350,7 +350,7 @@ namespace AngleSharp.Css.Values
                 case Unit.Vh:
                     return value / (0.01 * renderDimensions.RenderHeight);
                 case Unit.Vw:
-                    return value / ( 0.01 * renderDimensions.RenderHeight);
+                    return value / ( 0.01 * renderDimensions.RenderWidth);
                 case Unit.Vmax:
                     return value / ( 0.01 * Math.Max(renderDimensions.RenderHeight, renderDimensions.RenderWidth));
                 case Unit.Vmin:


### PR DESCRIPTION
# Types of Changes
Allows relative units to be converted to pixles.
## Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

## Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## Description

As discussed in  https://github.com/AngleSharp/AngleSharp.Css/issues/3 allows Length.To and Length.ToPixel to accept relative units but taking a new interface IRenderDimensions, currently implemented by IRenderDevice.

## Discussion

There are a few areas of the current implementation that i would like feedback on, 

1. To/ToPixel both take 2 extra paramiters IRenderDimensions and a bool isWidth with a default value, IRenderDimensions i only used to calculate relative styles and isWidth is only used to calculate percentage's. Would a better option be to provide 3 overloads for the same method (No extra params, just IRenderDimensions and IRenderDimensions with isWidth) some places you know the unit is absolute before calling the method?
2. Error handling in To/ToPixel currently, when using an appropriate unit, checks if the IRenderDimensions is non null and that the appropriate value (font size, width, height) is > 0. Im unsure if this fits with the code style of the project and if there is a preferred way to do it.
3. Default font size in IRenderDevice is currently 16 as this is the standard default on most devices (as there is a normal default unlike width/height) would you rather this was set to 0?

