### PR TITLE
Update ComputeDeclarations and ComputeCascadedStyle to take IEnumerable<ICssStyleRule>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.14.1
+
+Released on Monday, May 4 2020.
+
+- Changed StyleCollectionExtensions.ComputeDeclarations and StyleCollectionExtensions.ComputeCascadedStyle to take IEnumerable<ICssStyleRule> (#53)
+
 # 0.14.0
 
 Released on Tuesday, April 7 2020.

--- a/src/AngleSharp.Css/Extensions/StyleCollectionExtensions.cs
+++ b/src/AngleSharp.Css/Extensions/StyleCollectionExtensions.cs
@@ -40,7 +40,7 @@ namespace AngleSharp.Css
         /// <param name="element">The element that is questioned.</param>
         /// <param name="pseudoSelector">The optional pseudo selector to use.</param>
         /// <returns>The style declaration containing all the declarations.</returns>
-        public static ICssStyleDeclaration ComputeDeclarations(this IStyleCollection rules, IElement element, String pseudoSelector = null)
+        public static ICssStyleDeclaration ComputeDeclarations(this IEnumerable<ICssStyleRule> rules, IElement element, String pseudoSelector = null)
         {
             var computedStyle = new CssStyleDeclaration(element.Owner?.Context);
             var nodes = element.GetAncestors().OfType<IElement>();
@@ -74,7 +74,7 @@ namespace AngleSharp.Css
         /// <param name="element">The element to compute the cascade for.</param>
         /// <param name="parent">The potential parent for the cascade.</param>
         /// <returns>Returns the cascaded read-only style declaration.</returns>
-        public static ICssStyleDeclaration ComputeCascadedStyle(this IStyleCollection styleCollection, IElement element, ICssStyleDeclaration parent = null)
+        public static ICssStyleDeclaration ComputeCascadedStyle(this IEnumerable<ICssStyleRule> styleCollection, IElement element, ICssStyleDeclaration parent = null)
         {
             var computedStyle = new CssStyleDeclaration(element.Owner?.Context);
             var rules = styleCollection.SortBySpecificity(element);

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,6 +2,6 @@
   <PropertyGroup>
     <Description>Extends the CSSOM from the core AngleSharp library.</Description>
     <Product>AngleSharp.Css</Product>
-    <Version>0.14.0</Version>
+    <Version>0.14.1</Version>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
# Types of Changes

## Prerequisites

Please make sure you can check the following two boxes:

- [X] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

## Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## Description

See #53 allows StyleCollectionExtensions.ComputeDeclarations and StyleCollectionExtensions.ComputeCascadedStyle to take IEnumerable<ICssStyleRule> meaning that the rules can be pre-computed to save time.