### PR TITLE
Don't throw in GetInnerText if there is no element style. e.g. for co…

### DIFF
--- a/src/AngleSharp.Css.Tests/Extensions/InnerText.cs
+++ b/src/AngleSharp.Css.Tests/Extensions/InnerText.cs
@@ -71,6 +71,7 @@ namespace AngleSharp.Css.Tests.Extensions
         [TestCase("<textarea>test</textarea>", "")]
         [TestCase("<script>test</noscript>", "")]
         [TestCase("<style>test</style>", "")]
+        [TestCase("<!-- comment -->Text<!-- comment --> with <!-- comment -->comments<!-- comment -->", "Text with comments")]
         public void GetInnerText(String fixture, String expected)
         {
             var defaultSheet = new CssDefaultStyleSheetProvider();

--- a/src/AngleSharp.Css/Extensions/ElementExtensions.cs
+++ b/src/AngleSharp.Css/Extensions/ElementExtensions.cs
@@ -202,7 +202,7 @@ namespace AngleSharp.Dom
                 {
                     sb.Append(Symbols.LineFeed);
                 }
-                else if ((node is IHtmlTableCellElement && String.IsNullOrEmpty(elementStyle.GetDisplay())) || elementStyle.GetDisplay() == CssKeywords.TableCell)
+                else if (elementStyle != null && ((node is IHtmlTableCellElement && String.IsNullOrEmpty(elementStyle.GetDisplay())) || elementStyle.GetDisplay() == CssKeywords.TableCell))
                 {
                     if (node.NextSibling is IElement nextSibling)
                     {
@@ -214,7 +214,7 @@ namespace AngleSharp.Dom
                         }
                     }
                 }
-                else if ((node is IHtmlTableRowElement && String.IsNullOrEmpty(elementStyle.GetDisplay())) || elementStyle.GetDisplay() == CssKeywords.TableRow)
+                else if (elementStyle != null && ((node is IHtmlTableRowElement && String.IsNullOrEmpty(elementStyle.GetDisplay())) || elementStyle.GetDisplay() == CssKeywords.TableRow))
                 {
                     if (node.NextSibling is IElement nextSibling)
                     {


### PR DESCRIPTION
…mments

# Types of Changes

## Prerequisites

Please make sure you can check the following two boxes:

- [X] I have read the **CONTRIBUTING** document
- [X] My code follows the code style of this project

## Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [X] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [X] I have added tests to cover my changes
- [X] All new and existing tests passed

## Description

Two null checks for `elementStyle` were missing which would throw a NRE for e.g. comment nodes.
