### PR TITLE
Escape property name

### DIFF
--- a/src/AngleSharp.Css.Tests/Library/StringRepresentation.cs
+++ b/src/AngleSharp.Css.Tests/Library/StringRepresentation.cs
@@ -83,5 +83,27 @@ namespace AngleSharp.Css.Tests.Library
             var css = styleSheet.ToCss();
             Assert.AreEqual("div { background: conic-gradient(rgba(255, 0, 0, 1), rgba(255, 255, 0, 1), rgba(0, 128, 0, 1)) }", css);
         }
+
+        [Test]
+        public void EscapePropertyNames_CustomProperty_Issue120()
+        {
+            var css = @".class { --\/\%\$\!: value }";
+            var styleSheet = ParseStyleSheet(css);
+
+            var generatedCss = styleSheet.ToCss();
+
+            Assert.AreEqual(css, generatedCss);
+        }
+
+        [Test]
+        public void EscapePropertyNames_UnknownDeclaration_Issue120()
+        {
+            var css = @".class { \/\%\$\!: value }";
+            var styleSheet = ParseStyleSheet(css, new CssParserOptions{ IsIncludingUnknownDeclarations = true });
+
+            var generatedCss = styleSheet.ToCss();
+
+            Assert.AreEqual(css, generatedCss);
+        }
     }
 }

--- a/src/AngleSharp.Css/Dom/Internal/CssProperty.cs
+++ b/src/AngleSharp.Css/Dom/Internal/CssProperty.cs
@@ -86,7 +86,7 @@ namespace AngleSharp.Css.Dom
 
         #region String Representation
 
-        public void ToCss(TextWriter writer, IStyleFormatter formatter) => writer.Write(formatter.Declaration(Name, Value, IsImportant));
+        public void ToCss(TextWriter writer, IStyleFormatter formatter) => writer.Write(formatter.Declaration(CssUtilities.Escape(Name), Value, IsImportant));
 
         #endregion
     }


### PR DESCRIPTION
# Types of Changes

## Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

## Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## Description
Fixes #120

The property name is escaped using `CssUtilities.Escape(Name)` before being passed to the formatter.
