### PR TITLE
Fix NullReferenceException in CssShadowValue

### DIFF
--- a/src/AngleSharp.Css/Values/Composites/CssShadowValue.cs
+++ b/src/AngleSharp.Css/Values/Composites/CssShadowValue.cs
@@ -137,7 +137,7 @@ namespace AngleSharp.Css.Values
             var offsetX = _offsetX.Compute(context);
             var offsetY = _offsetY.Compute(context);
             var blurRadius = _blurRadius.Compute(context);
-            var spreadRadius = _spreadRadius.Compute(context);
+            var spreadRadius = _spreadRadius?.Compute(context);
             var color = (CssColorValue)((ICssValue)_color).Compute(context);
             return new CssShadowValue(_inset, offsetX, offsetY, blurRadius, spreadRadius, color);
         }


### PR DESCRIPTION
# Types of Changes

## Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

## Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## Description

I got another `NullReferenceException`

![image](https://github.com/AngleSharp/AngleSharp.Css/assets/509220/0ae1581e-ea73-4fc9-afcf-3f16f6858a07)

I don't know what should be nullable, so let me know if I should use `?.` for other fields
