### PR TITLE
Get declarations

### DIFF
--- a/src/AngleSharp.Css.Tests/Extensions/Nesting.cs
+++ b/src/AngleSharp.Css.Tests/Extensions/Nesting.cs
@@ -26,6 +26,24 @@ namespace AngleSharp.Css.Tests.Extensions
         }
 
         [Test]
+        public void SimpleSelectorNestingImplicitDeclarations()
+        {
+            var source = @"<!doctype html><head><style>.foo {
+  color: green;
+  .bar {
+    font-size: 1.4rem;
+  }
+}</style></head><body class='foo'><div class='bar'>Larger and green";
+            var document = ParseDocument(source);
+            var window = document.DefaultView;
+            var element = document.QuerySelector(".bar");
+            var styleCollection = window.GetStyleCollection();
+            var style = styleCollection.GetDeclarations(element);
+
+            Assert.AreEqual("1.4rem", style.GetFontSize());
+        }
+
+        [Test]
         public void SimpleSelectorNestingExplicit()
         {
             var source = @"<!doctype html><head><style>.foo {

--- a/src/AngleSharp.Css/Extensions/StyleCollectionExtensions.cs
+++ b/src/AngleSharp.Css/Extensions/StyleCollectionExtensions.cs
@@ -44,8 +44,24 @@ namespace AngleSharp.Css
         public static ICssStyleDeclaration ComputeDeclarations(this IStyleCollection styles, IElement element, String pseudoSelector = null)
         {
             var ctx = element.Owner?.Context;
+            var declarations = GetDeclarations(styles, element, pseudoSelector);
+            var context = new CssComputeContext(styles.Device, ctx, declarations);
+
+            return declarations.Compute(context);
+        }
+
+        /// <summary>
+        /// Gets the declarations for the given element in the context of
+        /// the specified styling rules.
+        /// </summary>
+        /// <param name="styles">The styles to use.</param>
+        /// <param name="element">The element that is questioned.</param>
+        /// <param name="pseudoSelector">The optional pseudo selector to use.</param>
+        /// <returns>The style declaration containing all the declarations.</returns>
+        public static ICssStyleDeclaration GetDeclarations(this IStyleCollection styles, IElement element, String pseudoSelector = null)
+        {
+            var ctx = element.Owner?.Context;
             var computedStyle = new CssStyleDeclaration(ctx);
-            var context = new CssComputeContext(styles.Device, ctx, computedStyle);
             var nodes = element.GetAncestors().OfType<IElement>();
 
             if (!String.IsNullOrEmpty(pseudoSelector))
@@ -65,7 +81,7 @@ namespace AngleSharp.Css
                 computedStyle.UpdateDeclarations(styles.ComputeCascadedStyle(node));
             }
 
-            return computedStyle.Compute(context);
+            return computedStyle;
         }
 
         /// <summary>


### PR DESCRIPTION
# Types of Changes

## Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

## Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [x] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## Description

I was looking for a method to get all css declarations for an element. Unfortunately there is none and the types that are needed to duplicate some of the internal logic are internal. Therefore I have extracted the method from the computation logic. 
