### PR TITLE
Fix "transform: rotateZ" becoming "transform: rotateY"

### DIFF
--- a/src/AngleSharp.Css.Tests/Declarations/CssTransformProperty.cs
+++ b/src/AngleSharp.Css.Tests/Declarations/CssTransformProperty.cs
@@ -560,6 +560,7 @@
             Assert.IsFalse(property.IsImportant);
             Assert.IsFalse(property.IsInherited);
             Assert.IsTrue(property.HasValue);
+            Assert.AreEqual(property.Value, "rotateX(10deg)");
         }
 
         [Test]
@@ -571,6 +572,7 @@
             Assert.IsFalse(property.IsImportant);
             Assert.IsFalse(property.IsInherited);
             Assert.IsTrue(property.HasValue);
+            Assert.AreEqual(property.Value, "rotateY(10deg)");
         }
 
         [Test]
@@ -582,6 +584,7 @@
             Assert.IsFalse(property.IsImportant);
             Assert.IsFalse(property.IsInherited);
             Assert.IsTrue(property.HasValue);
+            Assert.AreEqual(property.Value, "rotateZ(10deg)");
         }
 
         [Test]

--- a/src/AngleSharp.Css/Values/Functions/CssRotateValue.cs
+++ b/src/AngleSharp.Css/Values/Functions/CssRotateValue.cs
@@ -62,7 +62,7 @@ namespace AngleSharp.Css.Values
                 }
                 else if (_x is null && _y is null && _z is not null)
                 {
-                    return FunctionNames.RotateY;
+                    return FunctionNames.RotateZ;
                 }
 
                 return FunctionNames.Rotate3d;


### PR DESCRIPTION
# Types of Changes

## Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

## Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## Description

`rotateZ` was parsed as `rotateY` in `transform`
