### PR TITLE
Consume '/' in background declaration (fixes #165)

### DIFF
--- a/src/AngleSharp.Css.Tests/Declarations/CssBackgroundProperty.cs
+++ b/src/AngleSharp.Css.Tests/Declarations/CssBackgroundProperty.cs
@@ -731,6 +731,18 @@ namespace AngleSharp.Css.Tests.Declarations
             var expected = "linear-gradient(0deg, rgba(255, 255, 255, 1), rgba(255, 255, 255, 1), rgba(248, 248, 248, 1), rgba(238, 238, 238, 1))";
             Assert.AreEqual(expected, property.Value);
         }
+
+        [Test]
+        public void CssBackgroundPositionSlashSizeLegal()
+        {
+            var snippet = "background: center / cover";
+            var property = ParseDeclaration(snippet);
+            Assert.AreEqual("background", property.Name);
+            Assert.IsFalse(property.IsImportant);
+            Assert.IsFalse(property.IsInherited);
+            Assert.IsTrue(property.HasValue);
+            Assert.AreEqual("center / cover", property.Value);
+        }
     }
 }
 

--- a/src/AngleSharp.Css/Declarations/BackgroundDeclaration.cs
+++ b/src/AngleSharp.Css/Declarations/BackgroundDeclaration.cs
@@ -126,6 +126,7 @@ namespace AngleSharp.Css.Declarations
 
                             if (c == Symbols.Solidus && size == null)
                             {
+                                c = source.Next();
                                 c = source.SkipSpacesAndComments();
                                 size = source.ParseSize();
                                 c = source.SkipSpacesAndComments();
@@ -230,7 +231,7 @@ namespace AngleSharp.Css.Declarations
 
                 return null;
             }
-            
+
             private static ICssValue CreateLayers(CssListValue image, CssListValue attachment, CssListValue clip, CssListValue position, CssListValue origin, CssListValue repeat, CssListValue size)
             {
                 var count = GetCount(image, attachment, clip, position, size, repeat, origin);


### PR DESCRIPTION
# Types of Changes

## Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

## Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## Description

Fixes #165 by consuming the solidus character after a position value to allow parsing the size value after it, e.g. `background: center / cover`
