### PR TITLE
Fix @font-face font-weight range values being lost during parse

### DIFF
--- a/src/AngleSharp.Css.Tests/Rules/FontFace.cs
+++ b/src/AngleSharp.Css.Tests/Rules/FontFace.cs
@@ -44,5 +44,108 @@
             Assert.AreEqual("", fontface.Variant);
             Assert.AreEqual("", fontface.Weight);
         }
+
+        [Test]
+        public void FontFaceWeightRangeShouldBePreserved()
+        {
+            var src = "@font-face { font-weight: 100 700; }";
+            var sheet = ParseStyleSheet(src);
+            Assert.IsNotNull(sheet);
+            Assert.AreEqual(1, sheet.Rules.Length);
+            Assert.IsInstanceOf<CssFontFaceRule>(sheet.Rules[0]);
+            var fontface = (ICssFontFaceRule)sheet.Rules[0];
+            Assert.AreEqual("100 700", fontface.Weight);
+        }
+
+        [Test]
+        public void FontFaceSingleWeightIntegerShouldBePreserved()
+        {
+            var src = "@font-face { font-weight: 400; }";
+            var sheet = ParseStyleSheet(src);
+            Assert.IsNotNull(sheet);
+            Assert.AreEqual(1, sheet.Rules.Length);
+            Assert.IsInstanceOf<CssFontFaceRule>(sheet.Rules[0]);
+            var fontface = (ICssFontFaceRule)sheet.Rules[0];
+            Assert.AreEqual("400", fontface.Weight);
+        }
+
+        [Test]
+        public void FontFaceWeightRangeShouldRoundtripViaToCss()
+        {
+            var src = "@font-face { font-weight: 100 700; }";
+            var sheet = ParseStyleSheet(src);
+            var css = sheet.ToCss();
+            Assert.That(css, Does.Contain("font-weight: 100 700"));
+        }
+
+        [Test]
+        public void FontFaceWeightBoldKeywordShouldBePreserved()
+        {
+            var src = "@font-face { font-weight: bold; }";
+            var sheet = ParseStyleSheet(src);
+            Assert.AreEqual(1, sheet.Rules.Length);
+            var fontface = (ICssFontFaceRule)sheet.Rules[0];
+            Assert.AreEqual("bold", fontface.Weight);
+        }
+
+        [Test]
+        public void FontFaceWeightNormalKeywordShouldBePreserved()
+        {
+            var src = "@font-face { font-weight: normal; }";
+            var sheet = ParseStyleSheet(src);
+            Assert.AreEqual(1, sheet.Rules.Length);
+            var fontface = (ICssFontFaceRule)sheet.Rules[0];
+            Assert.AreEqual("normal", fontface.Weight);
+        }
+
+        [Test]
+        public void FontFaceWeightMinBoundary100ShouldBePreserved()
+        {
+            var src = "@font-face { font-weight: 100; }";
+            var sheet = ParseStyleSheet(src);
+            Assert.AreEqual(1, sheet.Rules.Length);
+            var fontface = (ICssFontFaceRule)sheet.Rules[0];
+            Assert.AreEqual("100", fontface.Weight);
+        }
+
+        [Test]
+        public void FontFaceWeightMaxBoundary900ShouldBePreserved()
+        {
+            var src = "@font-face { font-weight: 900; }";
+            var sheet = ParseStyleSheet(src);
+            Assert.AreEqual(1, sheet.Rules.Length);
+            var fontface = (ICssFontFaceRule)sheet.Rules[0];
+            Assert.AreEqual("900", fontface.Weight);
+        }
+
+        [Test]
+        public void FontFaceWeightOutOfRange1ShouldBeInvalid()
+        {
+            var src = "@font-face { font-weight: 1; }";
+            var sheet = ParseStyleSheet(src);
+            Assert.AreEqual(1, sheet.Rules.Length);
+            var fontface = (ICssFontFaceRule)sheet.Rules[0];
+            Assert.AreEqual("", fontface.Weight);
+        }
+
+        [Test]
+        public void FontFaceWeightOutOfRange1000ShouldBeInvalid()
+        {
+            var src = "@font-face { font-weight: 1000; }";
+            var sheet = ParseStyleSheet(src);
+            Assert.AreEqual(1, sheet.Rules.Length);
+            var fontface = (ICssFontFaceRule)sheet.Rules[0];
+            Assert.AreEqual("", fontface.Weight);
+        }
+
+        [Test]
+        public void FontFaceWeightThreeValuesShouldBeInvalid()
+        {
+            var src = "@font-face { font-weight: 100 400 700; }";
+            var sheet = ParseStyleSheet(src);
+            Assert.AreEqual(1, sheet.Rules.Length);
+            var fontface = (ICssFontFaceRule)sheet.Rules[0];
+            Assert.AreEqual("", fontface.Weight);
+        }
     }
 }

--- a/src/AngleSharp.Css/Declarations/FontWeightDeclaration.cs
+++ b/src/AngleSharp.Css/Declarations/FontWeightDeclaration.cs
@@ -1,5 +1,6 @@
 namespace AngleSharp.Css.Declarations
 {
+    using AngleSharp.Css.Converters;
     using AngleSharp.Css.Dom;
     using System;
     using static ValueConverters;
@@ -13,7 +14,7 @@ namespace AngleSharp.Css.Declarations
             PropertyNames.Font,
         };
 
-        public static IValueConverter Converter = Or(FontWeightConverter, WeightIntegerConverter);
+        public static IValueConverter Converter = Or(FontWeightConverter, WeightIntegerConverter.Many(1, 2));
 
         public static ICssValue InitialValue = InitialValues.FontWeightDecl;
 


### PR DESCRIPTION
# Types of Changes

## Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

## Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## Description

The font-weight converter only accepted a single keyword or integer, so range values like "100 700" (valid CSS Fonts Level 4) were silently dropped. Use WeightIntegerConverter.Many(1, 2) to accept 1-2 space- separated weight integers.

Resolves #187