### PR TITLE
Fix InvalidOperationException when CSS engine is not configured

### DIFF
--- a/src/AngleSharp.Css.Tests/Library/ComputedStyle.cs
+++ b/src/AngleSharp.Css.Tests/Library/ComputedStyle.cs
@@ -1,5 +1,6 @@
 namespace AngleSharp.Css.Tests.Library
 {
+    using AngleSharp.Css.Dom;
     using AngleSharp.Dom;
     using AngleSharp.Html.Dom;
     using NUnit.Framework;
@@ -8,6 +9,19 @@ namespace AngleSharp.Css.Tests.Library
     [TestFixture]
     public class ComputedStyleTests
     {
+        [Test]
+        public async Task GetColorWithoutCssEngine_ShouldNotThrow()
+        {
+            var config = Configuration.Default;
+            var context = BrowsingContext.New(config);
+            var document = await context.OpenAsync(req => req.Content("<div>hi</div>"));
+            var div = document.QuerySelector("div");
+            var style = div.ComputeCurrentStyle();
+
+            Assert.IsNotNull(style);
+            Assert.DoesNotThrow(() => style.GetColor());
+        }
+
         [Test]
         public async Task TransformEmToPx_Issue136()
         {

--- a/src/AngleSharp.Css/BrowsingContextExtensions.cs
+++ b/src/AngleSharp.Css/BrowsingContextExtensions.cs
@@ -53,13 +53,13 @@ namespace AngleSharp.Css
 
         internal static DeclarationInfo GetDeclarationInfo(this IBrowsingContext context, String propertyName)
         {
-            var factory = context.GetFactory<IDeclarationFactory>();
+            var factory = context.GetService<IDeclarationFactory>() ?? Factory.Declaration;
             return factory.Create(propertyName);
         }
 
         internal static ICssProperty CreateShorthand(this IBrowsingContext context, String name, ICssValue[] longhands, Boolean important)
         {
-            var factory = context.GetFactory<IDeclarationFactory>();
+            var factory = context.GetService<IDeclarationFactory>() ?? Factory.Declaration;
             var info = factory.Create(name);
             var value = info.Collapse(factory, longhands);
 
@@ -73,7 +73,7 @@ namespace AngleSharp.Css
 
         internal static ICssProperty[] CreateLonghands(this IBrowsingContext context, ICssProperty shorthand)
         {
-            var factory = context.GetFactory<IDeclarationFactory>();
+            var factory = context.GetService<IDeclarationFactory>() ?? Factory.Declaration;
             var info = factory.Create(shorthand.Name);
             var values = info.Expand(factory, shorthand.RawValue);
             return factory.CreateProperties(info.Longhands, values, shorthand.IsImportant);

--- a/src/AngleSharp.Css/Dom/Internal/CssStyleDeclaration.cs
+++ b/src/AngleSharp.Css/Dom/Internal/CssStyleDeclaration.cs
@@ -115,7 +115,7 @@ namespace AngleSharp.Css.Dom
 
         private ICssProperty TryCreateShorthand(String shorthandName, IEnumerable<String> serialized, List<String> usedProperties, Boolean force)
         {
-            var factory = _context.GetFactory<IDeclarationFactory>();
+            var factory = _context?.GetService<IDeclarationFactory>() ?? Factory.Declaration;
             var shorthand = factory.Create(shorthandName);
             var requiredProperties = shorthand.Longhands;
 
@@ -155,7 +155,7 @@ namespace AngleSharp.Css.Dom
         {
             var list = new List<ICssProperty>();
             var serialized = new List<String>();
-            var factory = _context.GetFactory<IDeclarationFactory>();
+            var factory = _context?.GetService<IDeclarationFactory>() ?? Factory.Declaration;
 
             foreach (var declaration in Declarations)
             {


### PR DESCRIPTION
# Types of Changes

## Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

## Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## Description

Replace GetFactory<IDeclarationFactory>() with GetService fallback to Factory.Declaration, preventing crash when ComputeCurrentStyle() is called without WithCss() configuration.

Resolves #183 