### PR TITLE
Upgrade to NUnit 4.5.1 and modernize test assertions

### DIFF
--- a/src/AngleSharp.Css.Tests/AngleSharp.Css.Tests.csproj
+++ b/src/AngleSharp.Css.Tests/AngleSharp.Css.Tests.csproj
@@ -4,7 +4,7 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>Key.snk</AssemblyOriginatorKeyFile>
     <IsPackable>false</IsPackable>
-    <LangVersion>9</LangVersion>
+    <LangVersion>latest</LangVersion>
     <AssemblyName>AngleSharp.Css.Tests</AssemblyName>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies> <!-- https://github.com/Tyrrrz/GitHubActionsTestLogger/issues/5 -->
   </PropertyGroup>
@@ -18,10 +18,10 @@
   <ItemGroup>
     <PackageReference Include="AngleSharp.Xml" Version="1.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="NUnit" Version="3.13.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.0" />
-    <PackageReference Include="GitHubActionsTestLogger" Version="2.0.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="NUnit" Version="4.5.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
+    <PackageReference Include="GitHubActionsTestLogger" Version="3.0.2" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.3" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="8.0.0.0" />
   </ItemGroup>
 </Project>

--- a/src/AngleSharp.Css.Tests/Declarations/CssAnimationProperty.cs
+++ b/src/AngleSharp.Css.Tests/Declarations/CssAnimationProperty.cs
@@ -11,11 +11,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "animation-duration : 60ms";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("animation-duration", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("60ms", property.Value);
+            Assert.That(property.Name, Is.EqualTo("animation-duration"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("60ms"));
         }
 
         [Test]
@@ -23,11 +23,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "animation-duration : 1s  , 2s  , 3s  , 4s";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("animation-duration", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("1s, 2s, 3s, 4s", property.Value);
+            Assert.That(property.Name, Is.EqualTo("animation-duration"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("1s, 2s, 3s, 4s"));
         }
 
         [Test]
@@ -35,11 +35,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "animation-delay : 0ms";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("animation-delay", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("0ms", property.Value);
+            Assert.That(property.Name, Is.EqualTo("animation-delay"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("0ms"));
         }
 
         [Test]
@@ -47,10 +47,10 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "animation-delay : 0";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("animation-delay", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsFalse(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("animation-delay"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.False);
         }
 
         [Test]
@@ -58,11 +58,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "animation-delay : 0s  , 0s  , 1s  , 20ms";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("animation-delay", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("0s, 0s, 1s, 20ms", property.Value);
+            Assert.That(property.Name, Is.EqualTo("animation-delay"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("0s, 0s, 1s, 20ms"));
         }
 
         [Test]
@@ -70,11 +70,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "animation-name : -specific";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("animation-name", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("-specific", property.Value);
+            Assert.That(property.Name, Is.EqualTo("animation-name"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("-specific"));
         }
 
         [Test]
@@ -82,11 +82,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "animation-name : sliding-vertically";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("animation-name", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("sliding-vertically", property.Value);
+            Assert.That(property.Name, Is.EqualTo("animation-name"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("sliding-vertically"));
         }
 
         [Test]
@@ -94,11 +94,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "animation-name : test_05";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("animation-name", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("test_05", property.Value);
+            Assert.That(property.Name, Is.EqualTo("animation-name"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("test_05"));
         }
 
         [Test]
@@ -106,10 +106,10 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "animation-name : 42";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("animation-name", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsFalse(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("animation-name"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.False);
         }
 
         [Test]
@@ -117,11 +117,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "animation-name : my-animation, other-animation";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("animation-name", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("my-animation, other-animation", property.Value);
+            Assert.That(property.Name, Is.EqualTo("animation-name"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("my-animation, other-animation"));
         }
 
         [Test]
@@ -129,11 +129,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "animation-iteration-count : 0";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("animation-iteration-count", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("0", property.Value);
+            Assert.That(property.Name, Is.EqualTo("animation-iteration-count"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("0"));
         }
 
         [Test]
@@ -141,11 +141,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "animation-iteration-count : infinite";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("animation-iteration-count", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("infinite", property.Value);
+            Assert.That(property.Name, Is.EqualTo("animation-iteration-count"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("infinite"));
         }
 
         [Test]
@@ -153,11 +153,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "animation-iteration-count : INFINITE";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("animation-iteration-count", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("infinite", property.Value);
+            Assert.That(property.Name, Is.EqualTo("animation-iteration-count"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("infinite"));
         }
 
         [Test]
@@ -165,11 +165,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "animation-iteration-count : 2.3";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("animation-iteration-count", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("2.3", property.Value);
+            Assert.That(property.Name, Is.EqualTo("animation-iteration-count"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("2.3"));
         }
 
         [Test]
@@ -177,11 +177,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "animation-iteration-count : 2, 0, infinite";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("animation-iteration-count", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("2, 0, infinite", property.Value);
+            Assert.That(property.Name, Is.EqualTo("animation-iteration-count"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("2, 0, infinite"));
         }
 
         [Test]
@@ -189,10 +189,10 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "animation-iteration-count : -1";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("animation-iteration-count", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsFalse(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("animation-iteration-count"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.False);
         }
 
         [Test]
@@ -200,11 +200,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "animation-timing-function : EASE";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("animation-timing-function", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("ease", property.Value);
+            Assert.That(property.Name, Is.EqualTo("animation-timing-function"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("ease"));
         }
 
         [Test]
@@ -212,10 +212,10 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "animation-timing-function : none";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("animation-timing-function", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsFalse(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("animation-timing-function"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.False);
         }
 
         [Test]
@@ -223,11 +223,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "animation-timing-function : ease-IN-out";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("animation-timing-function", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("ease-in-out", property.Value);
+            Assert.That(property.Name, Is.EqualTo("animation-timing-function"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("ease-in-out"));
         }
 
         [Test]
@@ -235,11 +235,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "animation-timing-function : step-END";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("animation-timing-function", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("step-end", property.Value);
+            Assert.That(property.Name, Is.EqualTo("animation-timing-function"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("step-end"));
         }
 
         [Test]
@@ -247,11 +247,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "animation-timing-function : step-start  , LINeAr";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("animation-timing-function", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("step-start, linear", property.Value);
+            Assert.That(property.Name, Is.EqualTo("animation-timing-function"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("step-start, linear"));
         }
 
         [Test]
@@ -259,11 +259,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "animation-timing-function : step-start  , cubic-bezier(0,1,1,1)";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("animation-timing-function", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("step-start, cubic-bezier(0, 1, 1, 1)", property.Value);
+            Assert.That(property.Name, Is.EqualTo("animation-timing-function"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("step-start, cubic-bezier(0, 1, 1, 1)"));
         }
 
         [Test]
@@ -271,11 +271,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "animation-play-state: running";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("animation-play-state", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("running", property.Value);
+            Assert.That(property.Name, Is.EqualTo("animation-play-state"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("running"));
         }
 
         [Test]
@@ -283,11 +283,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "animation-play-state: PAUSED";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("animation-play-state", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("paused", property.Value);
+            Assert.That(property.Name, Is.EqualTo("animation-play-state"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("paused"));
         }
 
         [Test]
@@ -295,11 +295,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "animation-play-state: paused, Running, paused";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("animation-play-state", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("paused, running, paused", property.Value);
+            Assert.That(property.Name, Is.EqualTo("animation-play-state"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("paused, running, paused"));
         }
 
         [Test]
@@ -307,11 +307,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "animation-fill-mode: none";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("animation-fill-mode", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("none", property.Value);
+            Assert.That(property.Name, Is.EqualTo("animation-fill-mode"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("none"));
         }
 
         [Test]
@@ -319,10 +319,10 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "animation-fill-mode: 0";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("animation-fill-mode", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsFalse(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("animation-fill-mode"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.False);
         }
 
         [Test]
@@ -330,11 +330,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "animation-fill-mode: backwards !important";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("animation-fill-mode", property.Name);
-            Assert.IsTrue(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("backwards", property.Value);
+            Assert.That(property.Name, Is.EqualTo("animation-fill-mode"));
+            Assert.That(property.IsImportant, Is.True);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("backwards"));
         }
 
         [Test]
@@ -342,11 +342,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "animation-fill-mode: FORWARDS";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("animation-fill-mode", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("forwards", property.Value);
+            Assert.That(property.Name, Is.EqualTo("animation-fill-mode"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("forwards"));
         }
 
         [Test]
@@ -354,11 +354,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "animation-fill-mode: both , backwards ,  forwards  ,NONE";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("animation-fill-mode", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("both, backwards, forwards, none", property.Value);
+            Assert.That(property.Name, Is.EqualTo("animation-fill-mode"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("both, backwards, forwards, none"));
         }
 
         [Test]
@@ -366,11 +366,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "animation-direction: normal";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("animation-direction", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("normal", property.Value);
+            Assert.That(property.Name, Is.EqualTo("animation-direction"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("normal"));
         }
 
         [Test]
@@ -378,11 +378,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "animation-direction  : reverse";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("animation-direction", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("reverse", property.Value);
+            Assert.That(property.Name, Is.EqualTo("animation-direction"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("reverse"));
         }
 
         [Test]
@@ -390,10 +390,10 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "animation-direction  : none";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("animation-direction", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsFalse(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("animation-direction"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.False);
         }
 
         [Test]
@@ -401,11 +401,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "animation-direction : alternate-REVERSE";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("animation-direction", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("alternate-reverse", property.Value);
+            Assert.That(property.Name, Is.EqualTo("animation-direction"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("alternate-reverse"));
         }
 
         [Test]
@@ -413,11 +413,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "animation-direction: normal,alternate  , reverse   ,ALTERNATE-reverse !important";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("animation-direction", property.Name);
-            Assert.IsTrue(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("normal, alternate, reverse, alternate-reverse", property.Value);
+            Assert.That(property.Name, Is.EqualTo("animation-direction"));
+            Assert.That(property.IsImportant, Is.True);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("normal, alternate, reverse, alternate-reverse"));
         }
 
         [Test]
@@ -425,11 +425,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "animation : 5";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("animation", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("5", property.Value);
+            Assert.That(property.Name, Is.EqualTo("animation"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("5"));
         }
 
         [Test]
@@ -437,11 +437,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "animation : my-animation";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("animation", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("my-animation", property.Value);
+            Assert.That(property.Name, Is.EqualTo("animation"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("my-animation"));
         }
 
         [Test]
@@ -449,11 +449,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "animation : my-animation 2s 0.5s";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("animation", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("2s 0.5s my-animation", property.Value);
+            Assert.That(property.Name, Is.EqualTo("animation"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("2s 0.5s my-animation"));
         }
 
         [Test]
@@ -461,11 +461,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "animation : my-animation  200ms 0.5s    ease";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("animation", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("200ms ease 0.5s my-animation", property.Value);
+            Assert.That(property.Name, Is.EqualTo("animation"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("200ms ease 0.5s my-animation"));
         }
 
         [Test]
@@ -473,7 +473,7 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "animation : 10 20";
             var property = ParseDeclaration(snippet);
-            Assert.IsFalse(property.HasValue);
+            Assert.That(property.HasValue, Is.False);
         }
 
         [Test]
@@ -481,11 +481,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "animation : my-animation  200ms 2.5   ease-in-out";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("animation", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("200ms ease-in-out 2.5 my-animation", property.Value);
+            Assert.That(property.Name, Is.EqualTo("animation"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("200ms ease-in-out 2.5 my-animation"));
         }
 
         [Test]
@@ -493,11 +493,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "animation : my-animation 0s 10 ease,   other-animation  5 linear,yet-another 0s 1s  10 step-start !important";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("animation", property.Name);
-            Assert.IsTrue(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("0s ease 10 my-animation, linear 5 other-animation, 0s step-start 1s 10 yet-another", property.Value);
+            Assert.That(property.Name, Is.EqualTo("animation"));
+            Assert.That(property.IsImportant, Is.True);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("0s ease 10 my-animation, linear 5 other-animation, 0s step-start 1s 10 yet-another"));
         }
     }
 }

--- a/src/AngleSharp.Css.Tests/Declarations/CssBackgroundProperty.cs
+++ b/src/AngleSharp.Css.Tests/Declarations/CssBackgroundProperty.cs
@@ -11,11 +11,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "background-size : cover";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("background-size", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("cover", property.Value);
+            Assert.That(property.Name, Is.EqualTo("background-size"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("cover"));
         }
 
         [Test]
@@ -23,11 +23,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "background-size : contain";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("background-size", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("contain", property.Value);
+            Assert.That(property.Name, Is.EqualTo("background-size"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("contain"));
         }
 
         [Test]
@@ -35,11 +35,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "background-attachment : scroll";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("background-attachment", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("scroll", property.Value);
+            Assert.That(property.Name, Is.EqualTo("background-attachment"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("scroll"));
         }
 
         [Test]
@@ -47,11 +47,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "background-attachment : initial";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("background-attachment", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("initial", property.Value);
+            Assert.That(property.Name, Is.EqualTo("background-attachment"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("initial"));
         }
 
         [Test]
@@ -59,11 +59,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "background-attachment : Fixed ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("background-attachment", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("fixed", property.Value);
+            Assert.That(property.Name, Is.EqualTo("background-attachment"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("fixed"));
         }
 
         [Test]
@@ -71,11 +71,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "background-attachment : fixed  ,  local ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("background-attachment", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("fixed, local", property.Value);
+            Assert.That(property.Name, Is.EqualTo("background-attachment"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("fixed, local"));
         }
 
         [Test]
@@ -83,11 +83,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "background-attachment : fixed  ,  local,scroll,scroll ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("background-attachment", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("fixed, local, scroll, scroll", property.Value);
+            Assert.That(property.Name, Is.EqualTo("background-attachment"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("fixed, local, scroll, scroll"));
         }
 
         [Test]
@@ -95,10 +95,10 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "background-attachment : none ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("background-attachment", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsFalse(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("background-attachment"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.False);
         }
 
         [Test]
@@ -106,11 +106,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "background-clip : Padding-Box ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("background-clip", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("padding-box", property.Value);
+            Assert.That(property.Name, Is.EqualTo("background-clip"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("padding-box"));
         }
 
         [Test]
@@ -118,11 +118,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "background-clip : Padding-Box, border-box ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("background-clip", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("padding-box, border-box", property.Value);
+            Assert.That(property.Name, Is.EqualTo("background-clip"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("padding-box, border-box"));
         }
 
         [Test]
@@ -130,11 +130,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "background-clip : content-box";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("background-clip", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("content-box", property.Value);
+            Assert.That(property.Name, Is.EqualTo("background-clip"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("content-box"));
         }
 
         [Test]
@@ -142,11 +142,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "background-color : teal";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("background-color", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("rgba(0, 128, 128, 1)", property.Value);
+            Assert.That(property.Name, Is.EqualTo("background-color"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("rgba(0, 128, 128, 1)"));
         }
 
         [Test]
@@ -154,11 +154,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "background-color : rgb(255  ,  255  ,  128)";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("background-color", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("rgba(255, 255, 128, 1)", property.Value);
+            Assert.That(property.Name, Is.EqualTo("background-color"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("rgba(255, 255, 128, 1)"));
         }
 
         [Test]
@@ -166,11 +166,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "background-color : hsla(50, 33%, 25%, 0.75)";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("background-color", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("rgba(85, 78, 42, 0.75)", property.Value);
+            Assert.That(property.Name, Is.EqualTo("background-color"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("rgba(85, 78, 42, 0.75)"));
         }
 
         [Test]
@@ -178,11 +178,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "background-color : Transparent";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("background-color", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("rgba(0, 0, 0, 0)", property.Value);
+            Assert.That(property.Name, Is.EqualTo("background-color"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("rgba(0, 0, 0, 0)"));
         }
 
         [Test]
@@ -190,11 +190,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "background-color : #bbff00";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("background-color", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("rgba(187, 255, 0, 1)", property.Value);
+            Assert.That(property.Name, Is.EqualTo("background-color"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("rgba(187, 255, 0, 1)"));
         }
 
         [Test]
@@ -202,10 +202,10 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "background-color : #bbff00, transparent, red, #ff00ff";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("background-color", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsFalse(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("background-color"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.False);
         }
 
         [Test]
@@ -213,11 +213,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "background-image: NONE";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("background-image", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("none", property.Value);
+            Assert.That(property.Name, Is.EqualTo("background-image"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("none"));
         }
 
         [Test]
@@ -225,11 +225,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "background-image: url(\"img/sprites.svg?v=1bc768be1b3c\"),none";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("background-image", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("url(\"img/sprites.svg?v=1bc768be1b3c\"), none", property.Value);
+            Assert.That(property.Name, Is.EqualTo("background-image"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("url(\"img/sprites.svg?v=1bc768be1b3c\"), none"));
         }
 
         [Test]
@@ -237,11 +237,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "background-image: url(image.png)";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("background-image", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("url(\"image.png\")", property.Value);
+            Assert.That(property.Name, Is.EqualTo("background-image"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("url(\"image.png\")"));
         }
 
         [Test]
@@ -249,11 +249,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "background-image: url(http://www.example.com/images/bck.png)";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("background-image", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("url(\"http://www.example.com/images/bck.png\")", property.Value);
+            Assert.That(property.Name, Is.EqualTo("background-image"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("url(\"http://www.example.com/images/bck.png\")"));
         }
 
         [Test]
@@ -261,11 +261,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "background-image: url(image.png),url('bla.png')";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("background-image", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("url(\"image.png\"), url(\"bla.png\")", property.Value);
+            Assert.That(property.Name, Is.EqualTo("background-image"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("url(\"image.png\"), url(\"bla.png\")"));
         }
 
         [Test]
@@ -273,11 +273,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "background-image: url(image.png),none, url(foo.gif)";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("background-image", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("url(\"image.png\"), none, url(\"foo.gif\")", property.Value);
+            Assert.That(property.Name, Is.EqualTo("background-image"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("url(\"image.png\"), none, url(\"foo.gif\")"));
         }
 
         [Test]
@@ -285,11 +285,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "background-origin: CONTENT-BOX";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("background-origin", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("content-box", property.Value);
+            Assert.That(property.Name, Is.EqualTo("background-origin"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("content-box"));
         }
 
         [Test]
@@ -297,11 +297,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "background-origin: CONTENT-BOX, Padding-Box";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("background-origin", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("content-box, padding-box", property.Value);
+            Assert.That(property.Name, Is.EqualTo("background-origin"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("content-box, padding-box"));
         }
 
         [Test]
@@ -309,11 +309,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "background-origin: border-box";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("background-origin", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("border-box", property.Value);
+            Assert.That(property.Name, Is.EqualTo("background-origin"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("border-box"));
         }
 
         [Test]
@@ -321,11 +321,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "background-position: top";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("background-position", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("top", property.Value);
+            Assert.That(property.Name, Is.EqualTo("background-position"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("top"));
         }
 
         [Test]
@@ -333,11 +333,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "background-position: 25% 75%";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("background-position", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("25% 75%", property.Value);
+            Assert.That(property.Name, Is.EqualTo("background-position"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("25% 75%"));
         }
 
         [Test]
@@ -345,11 +345,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "background-position: center 75%";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("background-position", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("50% 75%", property.Value);
+            Assert.That(property.Name, Is.EqualTo("background-position"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("50% 75%"));
         }
 
         [Test]
@@ -357,10 +357,10 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "background-position: right 20px bottom 20px";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("background-position", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsFalse(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("background-position"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.False);
         }
 
         [Test]
@@ -368,11 +368,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "background-position: 10px 20px, center";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("background-position", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("10px 20px, center", property.Value);
+            Assert.That(property.Name, Is.EqualTo("background-position"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("10px 20px, center"));
         }
 
         [Test]
@@ -380,11 +380,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "background-position: 0 0, 0 0";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("background-position", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("left top, left top", property.Value);
+            Assert.That(property.Name, Is.EqualTo("background-position"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("left top, left top"));
         }
 
         [Test]
@@ -392,11 +392,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "background-repeat: repeat-x";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("background-repeat", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("repeat-x", property.Value);
+            Assert.That(property.Name, Is.EqualTo("background-repeat"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("repeat-x"));
         }
 
         [Test]
@@ -404,11 +404,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "background-repeat: repeat-y";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("background-repeat", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("repeat-y", property.Value);
+            Assert.That(property.Name, Is.EqualTo("background-repeat"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("repeat-y"));
         }
 
         [Test]
@@ -416,11 +416,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "background-repeat: REPEAT";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("background-repeat", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("repeat", property.Value);
+            Assert.That(property.Name, Is.EqualTo("background-repeat"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("repeat"));
         }
 
         [Test]
@@ -428,11 +428,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "background-repeat: rounD";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("background-repeat", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("round", property.Value);
+            Assert.That(property.Name, Is.EqualTo("background-repeat"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("round"));
         }
 
         [Test]
@@ -440,11 +440,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "background-repeat: repeat space";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("background-repeat", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("repeat space", property.Value);
+            Assert.That(property.Name, Is.EqualTo("background-repeat"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("repeat space"));
         }
 
         [Test]
@@ -452,10 +452,10 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "background-repeat: repeat-x space";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("background-repeat", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsFalse(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("background-repeat"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.False);
         }
 
         [Test]
@@ -463,11 +463,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "background-repeat: repeat-X, repeat-Y";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("background-repeat", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("repeat-x, repeat-y", property.Value);
+            Assert.That(property.Name, Is.EqualTo("background-repeat"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("repeat-x, repeat-y"));
         }
 
         [Test]
@@ -475,11 +475,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "background-repeat: space round";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("background-repeat", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("space round", property.Value);
+            Assert.That(property.Name, Is.EqualTo("background-repeat"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("space round"));
         }
 
         [Test]
@@ -487,10 +487,10 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "background-repeat: no-repeat repeat-x";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("background-repeat", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsFalse(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("background-repeat"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.False);
         }
 
         [Test]
@@ -498,11 +498,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "background-repeat: repeat repeat, no-repeat repeat";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("background-repeat", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("repeat, repeat-y", property.Value);
+            Assert.That(property.Name, Is.EqualTo("background-repeat"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("repeat, repeat-y"));
         }
 
         [Test]
@@ -510,11 +510,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "background-size: 2em";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("background-size", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("2em", property.Value);
+            Assert.That(property.Name, Is.EqualTo("background-size"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("2em"));
         }
 
         [Test]
@@ -522,11 +522,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "background-size: 20%";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("background-size", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("20%", property.Value);
+            Assert.That(property.Name, Is.EqualTo("background-size"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("20%"));
         }
 
         [Test]
@@ -534,11 +534,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "background-size: auto auto";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("background-size", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("auto", property.Value);
+            Assert.That(property.Name, Is.EqualTo("background-size"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("auto"));
         }
 
         [Test]
@@ -546,11 +546,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "background-size: auto 50px";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("background-size", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("auto 50px", property.Value);
+            Assert.That(property.Name, Is.EqualTo("background-size"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("auto 50px"));
         }
 
         [Test]
@@ -558,11 +558,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "background-size: 25px 50px";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("background-size", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("25px 50px", property.Value);
+            Assert.That(property.Name, Is.EqualTo("background-size"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("25px 50px"));
         }
 
         [Test]
@@ -570,11 +570,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "background-size: 50% 50%";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("background-size", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("50% 50%", property.Value);
+            Assert.That(property.Name, Is.EqualTo("background-size"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("50% 50%"));
         }
 
         [Test]
@@ -582,11 +582,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "background-size: AUTO";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("background-size", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("auto", property.Value);
+            Assert.That(property.Name, Is.EqualTo("background-size"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("auto"));
         }
 
         [Test]
@@ -594,11 +594,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "background-size: cover";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("background-size", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("cover", property.Value);
+            Assert.That(property.Name, Is.EqualTo("background-size"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("cover"));
         }
 
         [Test]
@@ -606,11 +606,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "background-size: contain,cover";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("background-size", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("contain, cover", property.Value);
+            Assert.That(property.Name, Is.EqualTo("background-size"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("contain, cover"));
         }
 
         [Test]
@@ -618,11 +618,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "background-size: contain,100px,auto,20%";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("background-size", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("contain, 100px, auto, 20%", property.Value);
+            Assert.That(property.Name, Is.EqualTo("background-size"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("contain, 100px, auto, 20%"));
         }
 
         [Test]
@@ -630,11 +630,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "background: red";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("background", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("rgba(255, 0, 0, 1)", property.Value);
+            Assert.That(property.Name, Is.EqualTo("background"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("rgba(255, 0, 0, 1)"));
         }
 
         [Test]
@@ -642,11 +642,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "background: none";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("background", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("none", property.Value);
+            Assert.That(property.Name, Is.EqualTo("background"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("none"));
         }
 
         [Test]
@@ -654,11 +654,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "background: none rgb(1, 2, 3)";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("background", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("none rgba(1, 2, 3, 1)", property.Value);
+            Assert.That(property.Name, Is.EqualTo("background"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("none rgba(1, 2, 3, 1)"));
         }
 
         [Test]
@@ -666,11 +666,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "background: white url(\"pendant.png\");";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("background", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("url(\"pendant.png\") rgba(255, 255, 255, 1)", property.Value);
+            Assert.That(property.Name, Is.EqualTo("background"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("url(\"pendant.png\") rgba(255, 255, 255, 1)"));
         }
 
         [Test]
@@ -678,11 +678,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "background: url(\"topbanner.png\") #00d repeat-y fixed";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("background", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("url(\"topbanner.png\") repeat-y fixed rgba(0, 0, 221, 1)", property.Value);
+            Assert.That(property.Name, Is.EqualTo("background"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("url(\"topbanner.png\") repeat-y fixed rgba(0, 0, 221, 1)"));
         }
 
         [Test]
@@ -690,11 +690,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "background: url(\"img_tree.png\") no-repeat right top";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("background", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("url(\"img_tree.png\") right top no-repeat", property.Value);
+            Assert.That(property.Name, Is.EqualTo("background"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("url(\"img_tree.png\") right top no-repeat"));
         }
 
         [Test]
@@ -703,11 +703,11 @@ namespace AngleSharp.Css.Tests.Declarations
             var url = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEcAAAAcCAMAAAAEJ1IZAAAABGdBTUEAALGPC/xhBQAAVAI/VAI/VAI/VAI/VAI/VAI/VAAAA////AI/VRZ0U8AAAAFJ0Uk5TYNV4S2UbgT/Gk6uQt585w2wGXS0zJO2lhGttJK6j4YqZSobH1AAAAAElFTkSuQmCC";
             var snippet = "background-image: url('" + url + "')";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("background-image", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("url(\"" + url + "\")", property.Value);
+            Assert.That(property.Name, Is.EqualTo("background-image"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("url(\"" + url + "\")"));
         }
 
         [Test]
@@ -715,10 +715,10 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var source = "background-image: linear-gradient(to right, rgba(255, 0, 0, 1), rgba(0, 0, 255, 1))";
             var property = ParseDeclaration(source);
-            Assert.IsTrue(property.HasValue);
+            Assert.That(property.HasValue, Is.True);
 
             var expected = "linear-gradient(90deg, rgba(255, 0, 0, 1), rgba(0, 0, 255, 1))";
-            Assert.AreEqual(expected, property.Value);
+            Assert.That(property.Value, Is.EqualTo(expected));
         }
 
         [Test]
@@ -726,10 +726,10 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var source = "background-image: linear-gradient(top,#FFFFFF,#FFFFFF,#f8f8f8,#eeeeee)";
             var property = ParseDeclaration(source);
-            Assert.IsTrue(property.HasValue);
+            Assert.That(property.HasValue, Is.True);
 
             var expected = "linear-gradient(0deg, rgba(255, 255, 255, 1), rgba(255, 255, 255, 1), rgba(248, 248, 248, 1), rgba(238, 238, 238, 1))";
-            Assert.AreEqual(expected, property.Value);
+            Assert.That(property.Value, Is.EqualTo(expected));
         }
 
         [Test]
@@ -737,11 +737,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "background: center / cover";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("background", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("center / cover", property.Value);
+            Assert.That(property.Name, Is.EqualTo("background"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("center / cover"));
         }
     }
 }

--- a/src/AngleSharp.Css.Tests/Declarations/CssBorderImageProperty.cs
+++ b/src/AngleSharp.Css.Tests/Declarations/CssBorderImageProperty.cs
@@ -11,11 +11,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-image-source: none    ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border-image-source", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("none", property.Value);
+            Assert.That(property.Name, Is.EqualTo("border-image-source"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("none"));
         }
 
         [Test]
@@ -23,11 +23,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-image-source: url(image.jpg)";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border-image-source", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("url(\"image.jpg\")", property.Value);
+            Assert.That(property.Name, Is.EqualTo("border-image-source"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("url(\"image.jpg\")"));
         }
 
         [Test]
@@ -35,11 +35,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-image-source: linear-gradient(to top, red, yellow)";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border-image-source", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("linear-gradient(0deg, rgba(255, 0, 0, 1), rgba(255, 255, 0, 1))", property.Value);
+            Assert.That(property.Name, Is.EqualTo("border-image-source"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("linear-gradient(0deg, rgba(255, 0, 0, 1), rgba(255, 255, 0, 1))"));
         }
 
         [Test]
@@ -47,11 +47,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-image-outset: 0";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border-image-outset", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("0", property.Value);
+            Assert.That(property.Name, Is.EqualTo("border-image-outset"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("0"));
         }
 
         [Test]
@@ -59,11 +59,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-image-outset: 10px   25%";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border-image-outset", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("10px 25%", property.Value);
+            Assert.That(property.Name, Is.EqualTo("border-image-outset"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("10px 25%"));
         }
 
         [Test]
@@ -71,11 +71,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-image-outset: 10px   25% 0";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border-image-outset", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("10px 25% 0", property.Value);
+            Assert.That(property.Name, Is.EqualTo("border-image-outset"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("10px 25% 0"));
         }
 
         [Test]
@@ -83,11 +83,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-image-outset: 10px   25% 0 10%";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border-image-outset", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("10px 25% 0 10%", property.Value);
+            Assert.That(property.Name, Is.EqualTo("border-image-outset"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("10px 25% 0 10%"));
         }
 
         [Test]
@@ -95,10 +95,10 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-image-outset: 0 0 0 0 0";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border-image-outset", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsFalse(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("border-image-outset"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.False);
         }
 
         [Test]
@@ -106,11 +106,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-image-width: 0";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border-image-width", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("0", property.Value);
+            Assert.That(property.Name, Is.EqualTo("border-image-width"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("0"));
         }
 
         [Test]
@@ -118,11 +118,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-image-width: auto";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border-image-width", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("auto", property.Value);
+            Assert.That(property.Name, Is.EqualTo("border-image-width"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("auto"));
         }
 
         [Test]
@@ -130,11 +130,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-image-width: 5";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border-image-width", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("5", property.Value);
+            Assert.That(property.Name, Is.EqualTo("border-image-width"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("5"));
         }
 
         [Test]
@@ -142,11 +142,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-image-width: 10px   25%";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border-image-width", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("10px 25%", property.Value);
+            Assert.That(property.Name, Is.EqualTo("border-image-width"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("10px 25%"));
         }
 
         [Test]
@@ -154,11 +154,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-image-width: 10px   25% 0";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border-image-width", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("10px 25% 0", property.Value);
+            Assert.That(property.Name, Is.EqualTo("border-image-width"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("10px 25% 0"));
         }
 
         [Test]
@@ -166,11 +166,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-image-width: 10px   25% auto 10%";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border-image-width", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("10px 25% auto 10%", property.Value);
+            Assert.That(property.Name, Is.EqualTo("border-image-width"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("10px 25% auto 10%"));
         }
 
         [Test]
@@ -178,10 +178,10 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-image-width: 0 0 0 0 0";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border-image-width", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsFalse(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("border-image-width"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.False);
         }
 
         [Test]
@@ -189,11 +189,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-image-repeat:   StRETCH";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border-image-repeat", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("stretch", property.Value);
+            Assert.That(property.Name, Is.EqualTo("border-image-repeat"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("stretch"));
         }
 
         [Test]
@@ -201,11 +201,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-image-repeat:   repeat";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border-image-repeat", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("repeat", property.Value);
+            Assert.That(property.Name, Is.EqualTo("border-image-repeat"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("repeat"));
         }
 
         [Test]
@@ -213,11 +213,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-image-repeat:   round";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border-image-repeat", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("round", property.Value);
+            Assert.That(property.Name, Is.EqualTo("border-image-repeat"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("round"));
         }
 
         [Test]
@@ -225,11 +225,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-image-repeat: stretch round";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border-image-repeat", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("stretch round", property.Value);
+            Assert.That(property.Name, Is.EqualTo("border-image-repeat"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("stretch round"));
         }
 
         [Test]
@@ -237,10 +237,10 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-image-repeat: no-repeat";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border-image-repeat", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsFalse(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("border-image-repeat"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.False);
         }
 
         [Test]
@@ -248,11 +248,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-image-slice: 3";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border-image-slice", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("3", property.Value);
+            Assert.That(property.Name, Is.EqualTo("border-image-slice"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("3"));
         }
 
         [Test]
@@ -260,11 +260,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-image-slice: 10%";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border-image-slice", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("10%", property.Value);
+            Assert.That(property.Name, Is.EqualTo("border-image-slice"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("10%"));
         }
 
         [Test]
@@ -272,10 +272,10 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-image-slice: fill";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border-image-slice", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("border-image-slice"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
         }
 
         [Test]
@@ -283,11 +283,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-image-slice: 10% fill";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border-image-slice", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("10% fill", property.Value);
+            Assert.That(property.Name, Is.EqualTo("border-image-slice"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("10% fill"));
         }
 
         [Test]
@@ -295,11 +295,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-image-slice: 10% 30 fill";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border-image-slice", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("10% 30 fill", property.Value);
+            Assert.That(property.Name, Is.EqualTo("border-image-slice"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("10% 30 fill"));
         }
 
         [Test]
@@ -307,11 +307,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-image-slice: 10% 30 fill 0 0";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border-image-slice", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("10% 30 0 0 fill", property.Value);
+            Assert.That(property.Name, Is.EqualTo("border-image-slice"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("10% 30 0 0 fill"));
         }
 
         [Test]
@@ -319,10 +319,10 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-image-slice: 10% 30 fill 0 0 0";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border-image-slice", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsFalse(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("border-image-slice"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.False);
         }
 
         [Test]
@@ -330,10 +330,10 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-image-slice: 10% 30  0 0 0 fill";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border-image-slice", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsFalse(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("border-image-slice"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.False);
         }
 
         [Test]
@@ -341,11 +341,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-image: none    ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border-image", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("none", property.Value);
+            Assert.That(property.Name, Is.EqualTo("border-image"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("none"));
         }
 
         [Test]
@@ -353,11 +353,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-image: url(image.png) 50 50";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border-image", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("url(\"image.png\") 50 50", property.Value);
+            Assert.That(property.Name, Is.EqualTo("border-image"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("url(\"image.png\") 50 50"));
         }
 
         [Test]
@@ -365,11 +365,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-image: url(image.png) 30 30 repeat";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border-image", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("url(\"image.png\") 30 30 repeat", property.Value);
+            Assert.That(property.Name, Is.EqualTo("border-image"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("url(\"image.png\") 30 30 repeat"));
         }
 
         [Test]
@@ -377,11 +377,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-image: url(image.png) STRETCH";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border-image", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("url(\"image.png\") stretch", property.Value);
+            Assert.That(property.Name, Is.EqualTo("border-image"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("url(\"image.png\") stretch"));
         }
 
         [Test]
@@ -389,11 +389,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-image: url(image.png) 30 30 / 15px 15px";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border-image", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("url(\"image.png\") 30 30 / 15px", property.Value);
+            Assert.That(property.Name, Is.EqualTo("border-image"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("url(\"image.png\") 30 30 / 15px"));
         }
 
         [Test]
@@ -401,11 +401,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-image: url(image.png) 30 30 0 10 / 15px 0 15px 2em";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border-image", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("url(\"image.png\") 30 30 0 10 / 15px 0 15px 2em", property.Value);
+            Assert.That(property.Name, Is.EqualTo("border-image"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("url(\"image.png\") 30 30 0 10 / 15px 0 15px 2em"));
         }
 
         [Test]
@@ -413,11 +413,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-image: url(image.png) 30 30 / 15px 15px / 5% 2% 0 10%";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border-image", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("url(\"image.png\") 30 30 / 15px / 5% 2% 0 10%", property.Value);
+            Assert.That(property.Name, Is.EqualTo("border-image"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("url(\"image.png\") 30 30 / 15px / 5% 2% 0 10%"));
         }
     }
 }

--- a/src/AngleSharp.Css.Tests/Declarations/CssBorderProperty.cs
+++ b/src/AngleSharp.Css.Tests/Declarations/CssBorderProperty.cs
@@ -15,11 +15,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-spacing: 20px";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border-spacing", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("20px", property.Value);
+            Assert.That(property.Name, Is.EqualTo("border-spacing"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("20px"));
         }
 
         [Test]
@@ -27,11 +27,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-spacing: 0";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border-spacing", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("0", property.Value);
+            Assert.That(property.Name, Is.EqualTo("border-spacing"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("0"));
         }
 
         [Test]
@@ -39,11 +39,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-spacing: 15px 3em";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border-spacing", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("15px 3em", property.Value);
+            Assert.That(property.Name, Is.EqualTo("border-spacing"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("15px 3em"));
         }
 
         [Test]
@@ -51,11 +51,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-spacing: 15px 0";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border-spacing", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("15px 0", property.Value);
+            Assert.That(property.Name, Is.EqualTo("border-spacing"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("15px 0"));
         }
 
         [Test]
@@ -63,10 +63,10 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-spacing: 15%";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border-spacing", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsTrue(property.IsInherited);
-            Assert.IsFalse(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("border-spacing"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.True);
+            Assert.That(property.HasValue, Is.False);
         }
 
         [Test]
@@ -74,11 +74,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-bottom-color: red";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border-bottom-color", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("rgba(255, 0, 0, 1)", property.Value);
+            Assert.That(property.Name, Is.EqualTo("border-bottom-color"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("rgba(255, 0, 0, 1)"));
         }
 
         [Test]
@@ -86,11 +86,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-top-color: #0F0";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border-top-color", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("rgba(0, 255, 0, 1)", property.Value);
+            Assert.That(property.Name, Is.EqualTo("border-top-color"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("rgba(0, 255, 0, 1)"));
         }
 
         [Test]
@@ -98,11 +98,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-right-color: rgba(1, 1, 1, 0)";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border-right-color", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("rgba(1, 1, 1, 0)", property.Value);
+            Assert.That(property.Name, Is.EqualTo("border-right-color"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("rgba(1, 1, 1, 0)"));
         }
 
         [Test]
@@ -110,11 +110,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-left-color: rgb(1, 255, 100)  !important";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border-left-color", property.Name);
-            Assert.IsTrue(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("rgba(1, 255, 100, 1)", property.Value);
+            Assert.That(property.Name, Is.EqualTo("border-left-color"));
+            Assert.That(property.IsImportant, Is.True);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("rgba(1, 255, 100, 1)"));
         }
 
         [Test]
@@ -122,11 +122,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-color: transparent";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border-color", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("rgba(0, 0, 0, 0)", property.Value);
+            Assert.That(property.Name, Is.EqualTo("border-color"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("rgba(0, 0, 0, 0)"));
         }
 
         [Test]
@@ -134,11 +134,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-color: red   green";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border-color", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("rgba(255, 0, 0, 1) rgba(0, 128, 0, 1)", property.Value);
+            Assert.That(property.Name, Is.EqualTo("border-color"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("rgba(255, 0, 0, 1) rgba(0, 128, 0, 1)"));
         }
 
         [Test]
@@ -146,11 +146,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-color: red   rgb(0,0,0)";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border-color", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("rgba(255, 0, 0, 1) rgba(0, 0, 0, 1)", property.Value);
+            Assert.That(property.Name, Is.EqualTo("border-color"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("rgba(255, 0, 0, 1) rgba(0, 0, 0, 1)"));
         }
 
         [Test]
@@ -158,11 +158,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-color: red blue green";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border-color", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("rgba(255, 0, 0, 1) rgba(0, 0, 255, 1) rgba(0, 128, 0, 1)", property.Value);
+            Assert.That(property.Name, Is.EqualTo("border-color"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("rgba(255, 0, 0, 1) rgba(0, 0, 255, 1) rgba(0, 128, 0, 1)"));
         }
 
         [Test]
@@ -170,11 +170,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-color: red blue green   BLACK";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border-color", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("rgba(255, 0, 0, 1) rgba(0, 0, 255, 1) rgba(0, 128, 0, 1) rgba(0, 0, 0, 1)", property.Value);
+            Assert.That(property.Name, Is.EqualTo("border-color"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("rgba(255, 0, 0, 1) rgba(0, 0, 255, 1) rgba(0, 128, 0, 1) rgba(0, 0, 0, 1)"));
         }
 
         [Test]
@@ -182,7 +182,7 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-color: red blue green black transparent";
             var property = ParseDeclaration(snippet);
-            Assert.IsFalse(property.HasValue);
+            Assert.That(property.HasValue, Is.False);
         }
 
         [Test]
@@ -190,11 +190,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-style: dotted";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border-style", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("dotted", property.Value);
+            Assert.That(property.Name, Is.EqualTo("border-style"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("dotted"));
         }
 
         [Test]
@@ -202,11 +202,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-style: INSET   OUTset";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border-style", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("inset outset", property.Value);
+            Assert.That(property.Name, Is.EqualTo("border-style"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("inset outset"));
         }
 
         [Test]
@@ -214,11 +214,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-style: double   groove";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border-style", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("double groove", property.Value);
+            Assert.That(property.Name, Is.EqualTo("border-style"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("double groove"));
         }
 
         [Test]
@@ -226,11 +226,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-style: ridge solid dashed";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border-style", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("ridge solid dashed", property.Value);
+            Assert.That(property.Name, Is.EqualTo("border-style"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("ridge solid dashed"));
         }
 
         [Test]
@@ -238,11 +238,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-style   :   hidden  dotted  NONE   nONe";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border-style", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("hidden dotted none none", property.Value);
+            Assert.That(property.Name, Is.EqualTo("border-style"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("hidden dotted none none"));
         }
 
         [Test]
@@ -255,10 +255,10 @@ namespace AngleSharp.Css.Tests.Declarations
 </html>";
             var document = source.ToHtmlDocument(Configuration.Default.WithCss());
             var styleDeclaration = document.Body.ComputeCurrentStyle();
-            Assert.AreEqual("hidden", styleDeclaration.GetBorderTopStyle());
-            Assert.AreEqual("double", styleDeclaration.GetBorderLeftStyle());
-            Assert.AreEqual("double", styleDeclaration.GetBorderRightStyle());
-            Assert.AreEqual("dashed", styleDeclaration.GetBorderBottomStyle());
+            Assert.That(styleDeclaration.GetBorderTopStyle(), Is.EqualTo("hidden"));
+            Assert.That(styleDeclaration.GetBorderLeftStyle(), Is.EqualTo("double"));
+            Assert.That(styleDeclaration.GetBorderRightStyle(), Is.EqualTo("double"));
+            Assert.That(styleDeclaration.GetBorderBottomStyle(), Is.EqualTo("dashed"));
         }
 
         [Test]
@@ -266,7 +266,7 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-style: wavy";
             var property = ParseDeclaration(snippet);
-            Assert.IsFalse(property.HasValue);
+            Assert.That(property.HasValue, Is.False);
         }
 
         [Test]
@@ -274,11 +274,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-bottom-style: GROOVE";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border-bottom-style", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("groove", property.Value);
+            Assert.That(property.Name, Is.EqualTo("border-bottom-style"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("groove"));
         }
 
         [Test]
@@ -286,11 +286,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-top-style:none";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border-top-style", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("none", property.Value);
+            Assert.That(property.Name, Is.EqualTo("border-top-style"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("none"));
         }
 
         [Test]
@@ -298,11 +298,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-right-style:double";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border-right-style", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("double", property.Value);
+            Assert.That(property.Name, Is.EqualTo("border-right-style"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("double"));
         }
 
         [Test]
@@ -310,11 +310,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-left-style: hidden  !important";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border-left-style", property.Name);
-            Assert.IsTrue(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("hidden", property.Value);
+            Assert.That(property.Name, Is.EqualTo("border-left-style"));
+            Assert.That(property.IsImportant, Is.True);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("hidden"));
         }
 
         [Test]
@@ -322,11 +322,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-bottom-width: THIN";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border-bottom-width", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("1px", property.Value);
+            Assert.That(property.Name, Is.EqualTo("border-bottom-width"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("1px"));
         }
 
         [Test]
@@ -334,11 +334,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-top-width: 0";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border-top-width", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("0", property.Value);
+            Assert.That(property.Name, Is.EqualTo("border-top-width"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("0"));
         }
 
         [Test]
@@ -346,11 +346,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-right-width: 3em";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border-right-width", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("3em", property.Value);
+            Assert.That(property.Name, Is.EqualTo("border-right-width"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("3em"));
         }
 
         [Test]
@@ -358,11 +358,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-left-width: thick !important";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border-left-width", property.Name);
-            Assert.IsTrue(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("5px", property.Value);
+            Assert.That(property.Name, Is.EqualTo("border-left-width"));
+            Assert.That(property.IsImportant, Is.True);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("5px"));
         }
 
         [Test]
@@ -370,11 +370,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-width: medium";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border-width", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("3px", property.Value);
+            Assert.That(property.Name, Is.EqualTo("border-width"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("3px"));
         }
 
         [Test]
@@ -382,11 +382,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-width: 3px   0";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border-width", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("3px 0", property.Value);
+            Assert.That(property.Name, Is.EqualTo("border-width"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("3px 0"));
         }
 
         [Test]
@@ -394,11 +394,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-width: THIN   1px";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border-width", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("1px", property.Value);
+            Assert.That(property.Name, Is.EqualTo("border-width"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("1px"));
         }
 
         [Test]
@@ -406,11 +406,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-width: medium thin thick";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border-width", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("3px 1px 5px", property.Value);
+            Assert.That(property.Name, Is.EqualTo("border-width"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("3px 1px 5px"));
         }
 
         [Test]
@@ -418,11 +418,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-width:  1px  2px   3px  4px  !important ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border-width", property.Name);
-            Assert.IsTrue(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("1px 2px 3px 4px", property.Value);
+            Assert.That(property.Name, Is.EqualTo("border-width"));
+            Assert.That(property.IsImportant, Is.True);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("1px 2px 3px 4px"));
         }
 
         [Test]
@@ -430,11 +430,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-width:  0.3em 0 ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border-width", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("0.3em 0", property.Value);
+            Assert.That(property.Name, Is.EqualTo("border-width"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("0.3em 0"));
         }
 
         [Test]
@@ -442,11 +442,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-width:   medium 0 1px thick ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border-width", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("3px 0 1px 5px", property.Value);
+            Assert.That(property.Name, Is.EqualTo("border-width"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("3px 0 1px 5px"));
         }
 
         [Test]
@@ -454,7 +454,7 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-width: 0 0 0 0 0";
             var property = ParseDeclaration(snippet);
-            Assert.IsFalse(property.HasValue);
+            Assert.That(property.HasValue, Is.False);
         }
 
         [Test]
@@ -462,11 +462,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-left:   0 ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border-left", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("0", property.Value);
+            Assert.That(property.Name, Is.EqualTo("border-left"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("0"));
         }
 
         [Test]
@@ -474,11 +474,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-right :   dotted ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border-right", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("dotted", property.Value);
+            Assert.That(property.Name, Is.EqualTo("border-right"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("dotted"));
         }
 
         [Test]
@@ -486,11 +486,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-top :  2px red ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border-top", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("2px rgba(255, 0, 0, 1)", property.Value);
+            Assert.That(property.Name, Is.EqualTo("border-top"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("2px rgba(255, 0, 0, 1)"));
         }
 
         [Test]
@@ -498,11 +498,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-bottom :  rgb(255, 100, 0) ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border-bottom", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("rgba(255, 100, 0, 1)", property.Value);
+            Assert.That(property.Name, Is.EqualTo("border-bottom"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("rgba(255, 100, 0, 1)"));
         }
 
         [Test]
@@ -510,10 +510,10 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border :  GROOVE rgb(255, 100, 0) ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("border"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
         }
 
         [Test]
@@ -521,11 +521,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border :  inset  green 3em ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("3em inset rgba(0, 128, 0, 1)", property.Value);
+            Assert.That(property.Name, Is.EqualTo("border"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("3em inset rgba(0, 128, 0, 1)"));
         }
 
         [Test]
@@ -533,10 +533,10 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border :  red  SOLID 1px ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("border"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
         }
 
         [Test]
@@ -544,11 +544,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border :  0.5px black double ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("0.5px double rgba(0, 0, 0, 1)", property.Value);
+            Assert.That(property.Name, Is.EqualTo("border"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("0.5px double rgba(0, 0, 0, 1)"));
         }
 
         [Test]
@@ -556,11 +556,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border: 1px outset currentColor";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("1px outset currentColor", property.Value);
+            Assert.That(property.Name, Is.EqualTo("border"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("1px outset currentColor"));
         }
 
         [Test]
@@ -568,11 +568,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border: 1px outset";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("1px outset", property.Value);
+            Assert.That(property.Name, Is.EqualTo("border"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("1px outset"));
         }
 
         [Test]
@@ -584,7 +584,7 @@ namespace AngleSharp.Css.Tests.Declarations
             style.SetBorderWidth("1px");
             style.SetBorderStyle("solid");
             style.SetBorderColor("black");
-            Assert.AreEqual(expectedCss, style.CssText);
+            Assert.That(style.CssText, Is.EqualTo(expectedCss));
         }
     }
 }

--- a/src/AngleSharp.Css.Tests/Declarations/CssBorderRadiusProperty.cs
+++ b/src/AngleSharp.Css.Tests/Declarations/CssBorderRadiusProperty.cs
@@ -11,11 +11,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-bottom-left-radius: 40px  40px";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border-bottom-left-radius", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("40px", property.Value);
+            Assert.That(property.Name, Is.EqualTo("border-bottom-left-radius"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("40px"));
         }
 
         [Test]
@@ -23,11 +23,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-bottom-left-radius  : 40px 20em";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border-bottom-left-radius", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("40px 20em", property.Value);
+            Assert.That(property.Name, Is.EqualTo("border-bottom-left-radius"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("40px 20em"));
         }
 
         [Test]
@@ -35,11 +35,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-bottom-left-radius: 10px 5%";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border-bottom-left-radius", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("10px 5%", property.Value);
+            Assert.That(property.Name, Is.EqualTo("border-bottom-left-radius"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("10px 5%"));
         }
 
         [Test]
@@ -47,11 +47,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-bottom-left-radius: 10%";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border-bottom-left-radius", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("10%", property.Value);
+            Assert.That(property.Name, Is.EqualTo("border-bottom-left-radius"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("10%"));
         }
 
         [Test]
@@ -59,11 +59,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-bottom-right-radius: 0";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border-bottom-right-radius", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("0", property.Value);
+            Assert.That(property.Name, Is.EqualTo("border-bottom-right-radius"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("0"));
         }
 
         [Test]
@@ -71,11 +71,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-bottom-right-radius: 20px";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border-bottom-right-radius", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("20px", property.Value);
+            Assert.That(property.Name, Is.EqualTo("border-bottom-right-radius"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("20px"));
         }
 
         [Test]
@@ -83,11 +83,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-top-left-radius: 3.5cm";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border-top-left-radius", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("3.5cm", property.Value);
+            Assert.That(property.Name, Is.EqualTo("border-top-left-radius"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("3.5cm"));
         }
 
         [Test]
@@ -95,11 +95,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-top-right-radius: 15% 3.5%";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border-top-right-radius", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("15% 3.5%", property.Value);
+            Assert.That(property.Name, Is.EqualTo("border-top-right-radius"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("15% 3.5%"));
         }
 
         [Test]
@@ -107,11 +107,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-radius: 15% 3.5%";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border-radius", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("15% 3.5%", property.Value);
+            Assert.That(property.Name, Is.EqualTo("border-radius"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("15% 3.5%"));
         }
 
         [Test]
@@ -119,11 +119,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-radius: 0";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border-radius", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("0", property.Value);
+            Assert.That(property.Name, Is.EqualTo("border-radius"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("0"));
         }
 
         [Test]
@@ -131,11 +131,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-radius: 2px 4px 3px";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border-radius", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("2px 4px 3px", property.Value);
+            Assert.That(property.Name, Is.EqualTo("border-radius"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("2px 4px 3px"));
         }
 
         [Test]
@@ -143,11 +143,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-radius: 2px 4px 3px 0";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border-radius", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("2px 4px 3px 0", property.Value);
+            Assert.That(property.Name, Is.EqualTo("border-radius"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("2px 4px 3px 0"));
         }
 
         [Test]
@@ -155,7 +155,7 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-radius: 2px 4px 3px 0 1px";
             var property = ParseDeclaration(snippet);
-            Assert.IsFalse(property.HasValue);
+            Assert.That(property.HasValue, Is.False);
         }
 
         [Test]
@@ -163,11 +163,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-radius: 1em/5em";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border-radius", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("1em / 5em", property.Value);
+            Assert.That(property.Name, Is.EqualTo("border-radius"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("1em / 5em"));
         }
 
         [Test]
@@ -175,11 +175,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-radius: 4px 3px 6px / 2px 4px";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border-radius", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("4px 3px 6px / 2px 4px", property.Value);
+            Assert.That(property.Name, Is.EqualTo("border-radius"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("4px 3px 6px / 2px 4px"));
         }
 
         [Test]
@@ -187,11 +187,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-radius: 4px 3px 6px 1em / 2px 4px 0 20%";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("border-radius", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("4px 3px 6px 1em / 2px 4px 0 20%", property.Value);
+            Assert.That(property.Name, Is.EqualTo("border-radius"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("4px 3px 6px 1em / 2px 4px 0 20%"));
         }
 
         [Test]
@@ -199,7 +199,7 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-radius: 4px 3px 6px 1em / 2px 4px 0 20% 0";
             var property = ParseDeclaration(snippet);
-            Assert.IsFalse(property.HasValue);
+            Assert.That(property.HasValue, Is.False);
         }
 
         [Test]
@@ -207,7 +207,7 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "border-radius: 4px 3px 6px 1em 0 / 2px 4px 0 20%";
             var property = ParseDeclaration(snippet);
-            Assert.IsFalse(property.HasValue);
+            Assert.That(property.HasValue, Is.False);
         }
 
         [Test]
@@ -217,7 +217,7 @@ namespace AngleSharp.Css.Tests.Declarations
             var expected = ".centered { border-radius: 5px }";
             var result = ParseRule(snippet);
             var actual = result.CssText;
-            Assert.AreEqual(expected, actual);
+            Assert.That(actual, Is.EqualTo(expected));
         }
 
         [Test]
@@ -227,7 +227,7 @@ namespace AngleSharp.Css.Tests.Declarations
             var expected = ".centered { border-radius: 5px / 3px }";
             var result = ParseRule(snippet);
             var actual = result.CssText;
-            Assert.AreEqual(expected, actual);
+            Assert.That(actual, Is.EqualTo(expected));
         }
 
         [Test]
@@ -237,7 +237,7 @@ namespace AngleSharp.Css.Tests.Declarations
             var expected = ".centered { border-radius: 0 0 1px 1px / 1px 3px 4px 2px }";
             var result = ParseRule(snippet);
             var actual = result.CssText;
-            Assert.AreEqual(expected, actual);
+            Assert.That(actual, Is.EqualTo(expected));
         }
 
         [Test]
@@ -247,7 +247,7 @@ namespace AngleSharp.Css.Tests.Declarations
             var expected = ".centered { border-radius: 0 1px 0 0 / 1px }";
             var result = ParseRule(snippet);
             var actual = result.CssText;
-            Assert.AreEqual(expected, actual);
+            Assert.That(actual, Is.EqualTo(expected));
         }
 
         [Test]
@@ -257,7 +257,7 @@ namespace AngleSharp.Css.Tests.Declarations
             var expected = ".test { border-radius: 15px 0 0 15px }";
             var result = ParseRule(snippet);
             var actual = result.CssText;
-            Assert.AreEqual(expected, actual);
+            Assert.That(actual, Is.EqualTo(expected));
         }
     }
 }

--- a/src/AngleSharp.Css.Tests/Declarations/CssBoxSizingProperty.cs
+++ b/src/AngleSharp.Css.Tests/Declarations/CssBoxSizingProperty.cs
@@ -14,7 +14,7 @@ namespace AngleSharp.Css.Tests.Declarations
             var text = css.Rules[0].CssText;
 
             var expected = "* { box-sizing: border-box }";
-            Assert.AreEqual(expected, text);
+            Assert.That(text, Is.EqualTo(expected));
         }
     }
 }

--- a/src/AngleSharp.Css.Tests/Declarations/CssColumnsProperty.cs
+++ b/src/AngleSharp.Css.Tests/Declarations/CssColumnsProperty.cs
@@ -11,11 +11,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "column-width: 300px";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("column-width", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("300px", property.Value);
+            Assert.That(property.Name, Is.EqualTo("column-width"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("300px"));
         }
 
         [Test]
@@ -23,10 +23,10 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "column-width: 30%";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("column-width", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsFalse(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("column-width"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.False);
         }
 
         [Test]
@@ -34,11 +34,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "column-width: 0.3vw";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("column-width", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("0.3vw", property.Value);
+            Assert.That(property.Name, Is.EqualTo("column-width"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("0.3vw"));
         }
 
         [Test]
@@ -46,11 +46,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "column-width: AUTO";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("column-width", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("auto", property.Value);
+            Assert.That(property.Name, Is.EqualTo("column-width"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("auto"));
         }
 
         [Test]
@@ -58,11 +58,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "column-count: auto";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("column-count", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("auto", property.Value);
+            Assert.That(property.Name, Is.EqualTo("column-count"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("auto"));
         }
 
         [Test]
@@ -70,11 +70,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "column-count: 3";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("column-count", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("3", property.Value);
+            Assert.That(property.Name, Is.EqualTo("column-count"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("3"));
         }
 
         [Test]
@@ -82,11 +82,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "column-count: 0";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("column-count", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("0", property.Value);
+            Assert.That(property.Name, Is.EqualTo("column-count"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("0"));
         }
 
         [Test]
@@ -94,11 +94,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "columns: 0";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("columns", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("0", property.Value);
+            Assert.That(property.Name, Is.EqualTo("columns"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("0"));
         }
 
         [Test]
@@ -106,11 +106,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "columns: 10px";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("columns", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("10px", property.Value);
+            Assert.That(property.Name, Is.EqualTo("columns"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("10px"));
         }
 
         [Test]
@@ -118,11 +118,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "columns: 4";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("columns", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("4", property.Value);
+            Assert.That(property.Name, Is.EqualTo("columns"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("4"));
         }
 
         [Test]
@@ -130,11 +130,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "columns: 25em 5";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("columns", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("25em 5", property.Value);
+            Assert.That(property.Name, Is.EqualTo("columns"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("25em 5"));
         }
 
         [Test]
@@ -142,11 +142,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "columns : 5   25em  ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("columns", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("25em 5", property.Value);
+            Assert.That(property.Name, Is.EqualTo("columns"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("25em 5"));
         }
 
         [Test]
@@ -154,11 +154,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "columns : auto auto";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("columns", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("auto auto", property.Value);
+            Assert.That(property.Name, Is.EqualTo("columns"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("auto auto"));
         }
 
         [Test]
@@ -166,11 +166,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "columns : auto  ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("columns", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("auto", property.Value);
+            Assert.That(property.Name, Is.EqualTo("columns"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("auto"));
         }
 
         [Test]
@@ -178,7 +178,7 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "columns : 5   25%  ";
             var property = ParseDeclaration(snippet);
-            Assert.IsFalse(property.HasValue);
+            Assert.That(property.HasValue, Is.False);
         }
 
         [Test]
@@ -186,11 +186,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "column-span: all";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("column-span", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("all", property.Value);
+            Assert.That(property.Name, Is.EqualTo("column-span"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("all"));
         }
 
         [Test]
@@ -198,11 +198,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "column-span: None";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("column-span", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("none", property.Value);
+            Assert.That(property.Name, Is.EqualTo("column-span"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("none"));
         }
 
         [Test]
@@ -210,10 +210,10 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "column-span: 10px";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("column-span", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsFalse(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("column-span"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.False);
         }
 
         [Test]
@@ -221,11 +221,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "column-gap: 20px";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("column-gap", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("20px", property.Value);
+            Assert.That(property.Name, Is.EqualTo("column-gap"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("20px"));
         }
 
         [Test]
@@ -233,11 +233,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "column-gap: normal";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("column-gap", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("normal", property.Value);
+            Assert.That(property.Name, Is.EqualTo("column-gap"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("normal"));
         }
 
         [Test]
@@ -245,11 +245,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "column-gap: 0";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("column-gap", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("0", property.Value);
+            Assert.That(property.Name, Is.EqualTo("column-gap"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("0"));
         }
 
         [Test]
@@ -257,11 +257,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "column-gap: 20%";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("column-gap", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("20%", property.Value);
+            Assert.That(property.Name, Is.EqualTo("column-gap"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("20%"));
         }
 
         [Test]
@@ -269,11 +269,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "column-fill: balance;";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("column-fill", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("balance", property.Value);
+            Assert.That(property.Name, Is.EqualTo("column-fill"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("balance"));
         }
 
         [Test]
@@ -281,11 +281,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "column-fill: auto;";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("column-fill", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("auto", property.Value);
+            Assert.That(property.Name, Is.EqualTo("column-fill"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("auto"));
         }
 
         [Test]
@@ -293,11 +293,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "column-rule-color: transparent";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("column-rule-color", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("rgba(0, 0, 0, 0)", property.Value);
+            Assert.That(property.Name, Is.EqualTo("column-rule-color"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("rgba(0, 0, 0, 0)"));
         }
 
         [Test]
@@ -305,11 +305,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "column-rule-color: rgb(192, 56, 78)";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("column-rule-color", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("rgba(192, 56, 78, 1)", property.Value);
+            Assert.That(property.Name, Is.EqualTo("column-rule-color"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("rgba(192, 56, 78, 1)"));
         }
 
         [Test]
@@ -317,11 +317,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "column-rule-color: red";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("column-rule-color", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("rgba(255, 0, 0, 1)", property.Value);
+            Assert.That(property.Name, Is.EqualTo("column-rule-color"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("rgba(255, 0, 0, 1)"));
         }
 
         [Test]
@@ -329,10 +329,10 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "column-rule-color: none";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("column-rule-color", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsFalse(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("column-rule-color"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.False);
         }
 
         [Test]
@@ -340,11 +340,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "column-rule-style: inSET";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("column-rule-style", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("inset", property.Value);
+            Assert.That(property.Name, Is.EqualTo("column-rule-style"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("inset"));
         }
 
         [Test]
@@ -352,11 +352,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "column-rule-style: none";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("column-rule-style", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("none", property.Value);
+            Assert.That(property.Name, Is.EqualTo("column-rule-style"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("none"));
         }
 
         [Test]
@@ -364,10 +364,10 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "column-rule-style: auto ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("column-rule-style", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsFalse(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("column-rule-style"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.False);
         }
 
         [Test]
@@ -375,11 +375,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "column-rule-width: 2px";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("column-rule-width", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("2px", property.Value);
+            Assert.That(property.Name, Is.EqualTo("column-rule-width"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("2px"));
         }
 
         [Test]
@@ -387,11 +387,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "column-rule-width: thick";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("column-rule-width", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("5px", property.Value);
+            Assert.That(property.Name, Is.EqualTo("column-rule-width"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("5px"));
         }
 
         [Test]
@@ -399,11 +399,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "column-rule-width : medium !important ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("column-rule-width", property.Name);
-            Assert.IsTrue(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("3px", property.Value);
+            Assert.That(property.Name, Is.EqualTo("column-rule-width"));
+            Assert.That(property.IsImportant, Is.True);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("3px"));
         }
 
         [Test]
@@ -411,11 +411,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "column-rule-width: THIN";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("column-rule-width", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("1px", property.Value);
+            Assert.That(property.Name, Is.EqualTo("column-rule-width"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("1px"));
         }
 
         [Test]
@@ -423,11 +423,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "column-rule: dotted";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("column-rule", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("dotted", property.Value);
+            Assert.That(property.Name, Is.EqualTo("column-rule"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("dotted"));
         }
 
         [Test]
@@ -435,11 +435,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "column-rule: solid  blue";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("column-rule", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("rgba(0, 0, 255, 1) solid", property.Value);
+            Assert.That(property.Name, Is.EqualTo("column-rule"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("rgba(0, 0, 255, 1) solid"));
         }
 
         [Test]
@@ -447,11 +447,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "column-rule: solid 8px";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("column-rule", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("8px solid", property.Value);
+            Assert.That(property.Name, Is.EqualTo("column-rule"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("8px solid"));
         }
 
         [Test]
@@ -459,11 +459,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "column-rule: thick inset blue";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("column-rule", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("rgba(0, 0, 255, 1) 5px inset", property.Value);
+            Assert.That(property.Name, Is.EqualTo("column-rule"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("rgba(0, 0, 255, 1) 5px inset"));
         }
     }
 }

--- a/src/AngleSharp.Css.Tests/Declarations/CssContentProperty.cs
+++ b/src/AngleSharp.Css.Tests/Declarations/CssContentProperty.cs
@@ -12,7 +12,7 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var source = "a{content:\"\\\"\"}";
             var parsed = ParseStyle(source);
-            Assert.AreEqual("\"\\\"\"", parsed.Style.GetContent());
+            Assert.That(parsed.Style.GetContent(), Is.EqualTo("\"\\\"\""));
         }
 
         [Test]
@@ -20,7 +20,7 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var source = "a{content:'\\''}";
             var parsed = ParseStyle(source);
-            Assert.AreEqual("\"'\"", parsed.Style.GetContent());
+            Assert.That(parsed.Style.GetContent(), Is.EqualTo("\"'\""));
         }
 
         [Test]
@@ -28,7 +28,7 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var source = "a{content:\"abc\\\"\\\"d\\\"ef\"}";
             var parsed = ParseStyle(source);
-            Assert.AreEqual("\"abc\\\"\\\"d\\\"ef\"", parsed.Style.GetContent());
+            Assert.That(parsed.Style.GetContent(), Is.EqualTo("\"abc\\\"\\\"d\\\"ef\""));
         }
 
         [Test]
@@ -36,7 +36,7 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var source = "a{content:'abc\\'\\'d\\'ef'}";
             var parsed = ParseStyle(source);
-            Assert.AreEqual("\"abc''d'ef\"", parsed.Style.GetContent());
+            Assert.That(parsed.Style.GetContent(), Is.EqualTo("\"abc''d'ef\""));
         }
 
         [Test]
@@ -44,7 +44,7 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var source = "a{content: counter(h1) \".\\00A0\"}";
             var parsed = ParseStyle(source);
-            Assert.AreEqual("counter(h1) \". \"", parsed.Style.GetContent());
+            Assert.That(parsed.Style.GetContent(), Is.EqualTo("counter(h1) \". \""));
         }
     }
 }

--- a/src/AngleSharp.Css.Tests/Declarations/CssContentVisibilityProperty.cs
+++ b/src/AngleSharp.Css.Tests/Declarations/CssContentVisibilityProperty.cs
@@ -11,7 +11,7 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var source = "a{content-visibility:hidden}";
             var parsed = ParseStyle(source);
-            Assert.AreEqual("content-visibility: hidden", parsed.Style.CssText);
+            Assert.That(parsed.Style.CssText, Is.EqualTo("content-visibility: hidden"));
         }
 
         [Test]
@@ -19,7 +19,7 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var source = "a{content-visibility:aa}";
             var parsed = ParseStyle(source);
-            Assert.AreEqual("", parsed.Style.CssText);
+            Assert.That(parsed.Style.CssText, Is.EqualTo(""));
         }
     }
 }

--- a/src/AngleSharp.Css.Tests/Declarations/CssCoordinateProperty.cs
+++ b/src/AngleSharp.Css.Tests/Declarations/CssCoordinateProperty.cs
@@ -1,4 +1,4 @@
-﻿namespace AngleSharp.Css.Tests.Declarations
+namespace AngleSharp.Css.Tests.Declarations
 {
     using AngleSharp.Css.Dom;
     using NUnit.Framework;
@@ -13,11 +13,11 @@
         {
             var snippet = "height:   28% ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("height", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.AreEqual("28%", property.Value);
+            Assert.That(property.Name, Is.EqualTo("height"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.Value, Is.EqualTo("28%"));
         }
 
         [Test]
@@ -25,11 +25,11 @@
         {
             var snippet = "height:   0.3em ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("height", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.AreEqual("0.3em", property.Value);
+            Assert.That(property.Name, Is.EqualTo("height"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.Value, Is.EqualTo("0.3em"));
         }
 
         [Test]
@@ -37,11 +37,11 @@
         {
             var snippet = "height:   144px ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("height", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.AreEqual("144px", property.Value);
+            Assert.That(property.Name, Is.EqualTo("height"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.Value, Is.EqualTo("144px"));
         }
 
         [Test]
@@ -49,11 +49,11 @@
         {
             var snippet = "height: AUTO ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("height", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.AreEqual("auto", property.Value);
+            Assert.That(property.Name, Is.EqualTo("height"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.Value, Is.EqualTo("auto"));
         }
 
         [Test]
@@ -61,11 +61,11 @@
         {
             var snippet = "width:0.5cm";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("width", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.AreEqual("0.5cm", property.Value);
+            Assert.That(property.Name, Is.EqualTo("width"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.Value, Is.EqualTo("0.5cm"));
         }
 
         [Test]
@@ -73,11 +73,11 @@
         {
             var snippet = "width:1.5mm";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("width", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.AreEqual("1.5mm", property.Value);
+            Assert.That(property.Name, Is.EqualTo("width"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.Value, Is.EqualTo("1.5mm"));
         }
 
         [Test]
@@ -85,10 +85,10 @@
         {
             var snippet = "width:1.5 meter";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("width", property.Name);
-            Assert.IsFalse(property.HasValue);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
+            Assert.That(property.Name, Is.EqualTo("width"));
+            Assert.That(property.HasValue, Is.False);
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
             Assert.IsNotNull(property);
         }
 
@@ -97,10 +97,10 @@
         {
             var snippet = "left: 25px";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("left", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("left"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
         }
 
         [Test]
@@ -108,10 +108,10 @@
         {
             var snippet = "top:  0.7em ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("top", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("top"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
         }
 
         [Test]
@@ -119,10 +119,10 @@
         {
             var snippet = "right:  1.5mm";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("right", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("right"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
         }
 
         [Test]
@@ -130,10 +130,10 @@
         {
             var snippet = "bottom:  50%";
             var style = ParseDeclarations(snippet);
-            Assert.AreEqual(1, style.Length);
+            Assert.That(style.Length, Is.EqualTo(1));
             var bottom = style.Declarations.First();
-            Assert.AreEqual("bottom", bottom.Name);
-            Assert.AreEqual("50%", ((ICssStyleDeclaration)style).GetBottom());
+            Assert.That(bottom.Name, Is.EqualTo("bottom"));
+            Assert.That(((ICssStyleDeclaration)style).GetBottom(), Is.EqualTo("50%"));
         }
 
         [Test]
@@ -141,10 +141,10 @@
         {
             var snippet = "bottom:  50%";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("bottom", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("bottom"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
         }
 
         [Test]
@@ -152,10 +152,10 @@
         {
             var snippet = "height:0";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("height", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("height"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
         }
 
         [Test]
@@ -163,10 +163,10 @@
         {
             var snippet = "width  :  0";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("width", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("width"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
         }
 
         [Test]
@@ -174,10 +174,10 @@
         {
             var snippet = "width  :  20.5%";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("width", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("width"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
         }
 
         [Test]
@@ -185,9 +185,9 @@
         {
             var snippet = "width  :  3in";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("width", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
+            Assert.That(property.Name, Is.EqualTo("width"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
         }
 
         [Test]
@@ -195,10 +195,10 @@
         {
             var snippet = "height  :  3deg";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("height", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.HasValue);
-            Assert.IsFalse(property.IsInherited);
+            Assert.That(property.Name, Is.EqualTo("height"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.HasValue, Is.False);
+            Assert.That(property.IsInherited, Is.False);
         }
 
         [Test]
@@ -206,10 +206,10 @@
         {
             var snippet = "height  :  3dpi";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("height", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.HasValue);
-            Assert.IsFalse(property.IsInherited);
+            Assert.That(property.Name, Is.EqualTo("height"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.HasValue, Is.False);
+            Assert.That(property.IsInherited, Is.False);
         }
 
         [Test]
@@ -217,10 +217,10 @@
         {
             var snippet = "top:  1.2rem ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("top", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("top"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
         }
 
         [Test]
@@ -228,10 +228,10 @@
         {
             var snippet = "right:  0.5cm";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("right", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("right"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
         }
 
         [Test]
@@ -239,10 +239,10 @@
         {
             var snippet = "bottom:  0.50%";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("bottom", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("bottom"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
         }
 
         [Test]
@@ -250,10 +250,10 @@
         {
             var snippet = "bottom:  0";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("bottom", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("bottom"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
         }
 
         [Test]
@@ -261,10 +261,10 @@
         {
             var snippet = "bottom:  20";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("bottom", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsFalse(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("bottom"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.False);
         }
 
         [Test]
@@ -272,10 +272,10 @@
         {
             var snippet = "min-height:  0";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("min-height", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("min-height"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
         }
 
         [Test]
@@ -283,10 +283,10 @@
         {
             var snippet = "max-height:  auto";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("max-height", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsFalse(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("max-height"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.False);
         }
 
         [Test]
@@ -294,11 +294,11 @@
         {
             var snippet = "max-width:  none";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("max-width", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("none", property.Value);
+            Assert.That(property.Name, Is.EqualTo("max-width"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("none"));
         }
 
         [Test]
@@ -306,11 +306,11 @@
         {
             var snippet = "max-width:  15px";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("max-width", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("15px", property.Value);
+            Assert.That(property.Name, Is.EqualTo("max-width"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("15px"));
         }
 
         [Test]
@@ -318,11 +318,11 @@
         {
             var snippet = "min-width:  15%";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("min-width", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("15%", property.Value);
+            Assert.That(property.Name, Is.EqualTo("min-width"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("15%"));
         }
     }
 }

--- a/src/AngleSharp.Css.Tests/Declarations/CssFillProperty.cs
+++ b/src/AngleSharp.Css.Tests/Declarations/CssFillProperty.cs
@@ -11,9 +11,9 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "fill:#AFAA96";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("fill", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("rgba(175, 170, 150, 1)", property.Value);
+            Assert.That(property.Name, Is.EqualTo("fill"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("rgba(175, 170, 150, 1)"));
         }
 
         [Test]
@@ -21,9 +21,9 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "fill:none";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("fill", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("none", property.Value);
+            Assert.That(property.Name, Is.EqualTo("fill"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("none"));
         }
     }
 }

--- a/src/AngleSharp.Css.Tests/Declarations/CssFlexProperty.cs
+++ b/src/AngleSharp.Css.Tests/Declarations/CssFlexProperty.cs
@@ -11,9 +11,9 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "flex-shrink : 5";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("flex-shrink", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("5", property.Value);
+            Assert.That(property.Name, Is.EqualTo("flex-shrink"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("5"));
         }
 
         [Test]
@@ -21,9 +21,9 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "flex-shrink : -1";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("flex-shrink", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("-1", property.Value);
+            Assert.That(property.Name, Is.EqualTo("flex-shrink"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("-1"));
         }
 
         [Test]
@@ -31,8 +31,8 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "flex-shrink : none";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("flex-shrink", property.Name);
-            Assert.IsFalse(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("flex-shrink"));
+            Assert.That(property.HasValue, Is.False);
         }
 
         [Test]
@@ -40,9 +40,9 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "flex-grow : 7";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("flex-grow", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("7", property.Value);
+            Assert.That(property.Name, Is.EqualTo("flex-grow"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("7"));
         }
 
         [Test]
@@ -50,9 +50,9 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "flex-basis:100px";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("flex-basis", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("100px", property.Value);
+            Assert.That(property.Name, Is.EqualTo("flex-basis"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("100px"));
         }
 
         [Test]
@@ -60,9 +60,9 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "flex: 1 0 100%";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("flex", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("1 0 100%", property.Value);
+            Assert.That(property.Name, Is.EqualTo("flex"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("1 0 100%"));
         }
 
         [Test]
@@ -70,9 +70,9 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "flex: 10em";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("flex", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("10em", property.Value);
+            Assert.That(property.Name, Is.EqualTo("flex"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("10em"));
         }
 
         [Test]
@@ -80,9 +80,9 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "flex: 1 10em";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("flex", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("1 10em", property.Value);
+            Assert.That(property.Name, Is.EqualTo("flex"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("1 10em"));
         }
 
         [Test]
@@ -90,9 +90,9 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "flex: 1 2";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("flex", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("1 2", property.Value);
+            Assert.That(property.Name, Is.EqualTo("flex"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("1 2"));
         }
 
         [Test]
@@ -100,9 +100,9 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "flex-wrap: wrap-reverse";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("flex-wrap", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("wrap-reverse", property.Value);
+            Assert.That(property.Name, Is.EqualTo("flex-wrap"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("wrap-reverse"));
         }
 
         [Test]
@@ -110,8 +110,8 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "flex-wrap: none";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("flex-wrap", property.Name);
-            Assert.IsFalse(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("flex-wrap"));
+            Assert.That(property.HasValue, Is.False);
         }
 
         [Test]
@@ -119,9 +119,9 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "flex-direction: column-REVERSE";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("flex-direction", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("column-reverse", property.Value);
+            Assert.That(property.Name, Is.EqualTo("flex-direction"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("column-reverse"));
         }
 
         [Test]
@@ -129,8 +129,8 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "flex-direction: inverse-row";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("flex-direction", property.Name);
-            Assert.IsFalse(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("flex-direction"));
+            Assert.That(property.HasValue, Is.False);
         }
     }
 }

--- a/src/AngleSharp.Css.Tests/Declarations/CssFontProperty.cs
+++ b/src/AngleSharp.Css.Tests/Declarations/CssFontProperty.cs
@@ -14,11 +14,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "font-family: Gill Sans Extrabold, sans-serif ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("font-family", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("Gill Sans Extrabold, sans-serif", property.Value);
+            Assert.That(property.Name, Is.EqualTo("font-family"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("Gill Sans Extrabold, sans-serif"));
         }
 
         [Test]
@@ -26,11 +26,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "font-family: initial ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("font-family", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsTrue(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("initial", property.Value);
+            Assert.That(property.Name, Is.EqualTo("font-family"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.True);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("initial"));
         }
 
         [Test]
@@ -38,11 +38,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "font-family: Courier, \"Lucida Console\", monospace ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("font-family", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("Courier, \"Lucida Console\", monospace", property.Value);
+            Assert.That(property.Name, Is.EqualTo("font-family"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("Courier, \"Lucida Console\", monospace"));
         }
 
         [Test]
@@ -50,11 +50,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "font-family: \"Goudy Bookletter 1911\", sans-serif ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("font-family", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("\"Goudy Bookletter 1911\", sans-serif", property.Value);
+            Assert.That(property.Name, Is.EqualTo("font-family"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("\"Goudy Bookletter 1911\", sans-serif"));
         }
 
         [Test]
@@ -62,10 +62,10 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "font-family: Goudy Bookletter 1911, sans-serif  ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("font-family", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsTrue(property.IsInherited);
-            Assert.IsFalse(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("font-family"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.True);
+            Assert.That(property.HasValue, Is.False);
         }
 
         [Test]
@@ -73,10 +73,10 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "font-family: Red/Black, sans-serif  ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("font-family", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsTrue(property.IsInherited);
-            Assert.IsFalse(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("font-family"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.True);
+            Assert.That(property.HasValue, Is.False);
         }
 
         [Test]
@@ -84,10 +84,10 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "font-family: \"Lucida\" Grande, sans-serif ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("font-family", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsTrue(property.IsInherited);
-            Assert.IsFalse(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("font-family"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.True);
+            Assert.That(property.HasValue, Is.False);
         }
 
         [Test]
@@ -95,10 +95,10 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "font-family: Ahem!, sans-serif ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("font-family", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsTrue(property.IsInherited);
-            Assert.IsFalse(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("font-family"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.True);
+            Assert.That(property.HasValue, Is.False);
         }
 
         [Test]
@@ -106,10 +106,10 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "font-family: test@foo, sans-serif ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("font-family", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsTrue(property.IsInherited);
-            Assert.IsFalse(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("font-family"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.True);
+            Assert.That(property.HasValue, Is.False);
         }
 
         [Test]
@@ -117,10 +117,10 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "font-family: #POUND ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("font-family", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsTrue(property.IsInherited);
-            Assert.IsFalse(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("font-family"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.True);
+            Assert.That(property.HasValue, Is.False);
         }
 
         [Test]
@@ -128,10 +128,10 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "font-family: Hawaii 5-0 ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("font-family", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsTrue(property.IsInherited);
-            Assert.IsFalse(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("font-family"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.True);
+            Assert.That(property.HasValue, Is.False);
         }
 
         [Test]
@@ -139,11 +139,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "font-variant : NORMAL";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("font-variant", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("normal", property.Value);
+            Assert.That(property.Name, Is.EqualTo("font-variant"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("normal"));
         }
 
         [Test]
@@ -151,11 +151,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "font-variant : small-caps ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("font-variant", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("small-caps", property.Value);
+            Assert.That(property.Name, Is.EqualTo("font-variant"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("small-caps"));
         }
 
         [Test]
@@ -163,10 +163,10 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "font-variant : smallCaps ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("font-variant", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsTrue(property.IsInherited);
-            Assert.IsFalse(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("font-variant"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.True);
+            Assert.That(property.HasValue, Is.False);
         }
 
         [Test]
@@ -174,11 +174,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "font-style : italic";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("font-style", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("italic", property.Value);
+            Assert.That(property.Name, Is.EqualTo("font-style"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("italic"));
         }
 
         [Test]
@@ -186,11 +186,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "font-style : oblique ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("font-style", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("oblique", property.Value);
+            Assert.That(property.Name, Is.EqualTo("font-style"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("oblique"));
         }
 
         [Test]
@@ -198,11 +198,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "font-style : normal !important";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("font-style", property.Name);
-            Assert.IsTrue(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("normal", property.Value);
+            Assert.That(property.Name, Is.EqualTo("font-style"));
+            Assert.That(property.IsImportant, Is.True);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("normal"));
         }
 
         [Test]
@@ -210,11 +210,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "font-size : xx-small !important";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("font-size", property.Name);
-            Assert.IsTrue(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("xx-small", property.Value);
+            Assert.That(property.Name, Is.EqualTo("font-size"));
+            Assert.That(property.IsImportant, Is.True);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("xx-small"));
         }
 
         [Test]
@@ -222,11 +222,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "font-size : xxx-large !important";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("font-size", property.Name);
-            Assert.IsTrue(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("xxx-large", property.Value);
+            Assert.That(property.Name, Is.EqualTo("font-size"));
+            Assert.That(property.IsImportant, Is.True);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("xxx-large"));
         }
 
         [Test]
@@ -234,11 +234,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "font-size : medium";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("font-size", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("medium", property.Value);
+            Assert.That(property.Name, Is.EqualTo("font-size"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("medium"));
         }
 
         [Test]
@@ -246,11 +246,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "font-size : large !important";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("font-size", property.Name);
-            Assert.IsTrue(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("large", property.Value);
+            Assert.That(property.Name, Is.EqualTo("font-size"));
+            Assert.That(property.IsImportant, Is.True);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("large"));
         }
 
         [Test]
@@ -258,11 +258,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "font-size : larger ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("font-size", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("larger", property.Value);
+            Assert.That(property.Name, Is.EqualTo("font-size"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("larger"));
         }
 
         [Test]
@@ -270,10 +270,10 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "font-size : largest ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("font-size", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsTrue(property.IsInherited);
-            Assert.IsFalse(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("font-size"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.True);
+            Assert.That(property.HasValue, Is.False);
         }
 
         [Test]
@@ -281,11 +281,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "font-size : 120% ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("font-size", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("120%", property.Value);
+            Assert.That(property.Name, Is.EqualTo("font-size"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("120%"));
         }
 
         [Test]
@@ -293,11 +293,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "font-size : 0 ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("font-size", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("0", property.Value);
+            Assert.That(property.Name, Is.EqualTo("font-size"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("0"));
         }
 
         [Test]
@@ -305,11 +305,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "font-size : 3.5em ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("font-size", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("3.5em", property.Value);
+            Assert.That(property.Name, Is.EqualTo("font-size"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("3.5em"));
         }
 
         [Test]
@@ -317,10 +317,10 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "font-size : 120.3 ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("font-size", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsTrue(property.IsInherited);
-            Assert.IsFalse(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("font-size"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.True);
+            Assert.That(property.HasValue, Is.False);
         }
 
         [Test]
@@ -328,10 +328,10 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "font-weight : 100% ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("font-weight", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsTrue(property.IsInherited);
-            Assert.IsFalse(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("font-weight"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.True);
+            Assert.That(property.HasValue, Is.False);
         }
 
         [Test]
@@ -339,11 +339,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "font-weight : bolder !important";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("font-weight", property.Name);
-            Assert.IsTrue(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("bolder", property.Value);
+            Assert.That(property.Name, Is.EqualTo("font-weight"));
+            Assert.That(property.IsImportant, Is.True);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("bolder"));
         }
 
         [Test]
@@ -351,11 +351,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "font-weight : bold";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("font-weight", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("bold", property.Value);
+            Assert.That(property.Name, Is.EqualTo("font-weight"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("bold"));
         }
 
         [Test]
@@ -363,11 +363,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "font-weight : 400 ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("font-weight", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("400", property.Value);
+            Assert.That(property.Name, Is.EqualTo("font-weight"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("400"));
         }
 
         [Test]
@@ -375,11 +375,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "font-stretch : NORMAL !important";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("font-stretch", property.Name);
-            Assert.IsTrue(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("normal", property.Value);
+            Assert.That(property.Name, Is.EqualTo("font-stretch"));
+            Assert.That(property.IsImportant, Is.True);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("normal"));
         }
 
         [Test]
@@ -387,11 +387,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "font-stretch : extra-condensed ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("font-stretch", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("extra-condensed", property.Value);
+            Assert.That(property.Name, Is.EqualTo("font-stretch"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("extra-condensed"));
         }
 
         [Test]
@@ -399,10 +399,10 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "font-stretch : semi expanded ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("font-stretch", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsTrue(property.IsInherited);
-            Assert.IsFalse(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("font-stretch"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.True);
+            Assert.That(property.HasValue, Is.False);
         }
 
         [Test]
@@ -410,11 +410,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "font : 12px/14px sans-serif ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("font", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("12px / 14px sans-serif", property.Value);
+            Assert.That(property.Name, Is.EqualTo("font"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("12px / 14px sans-serif"));
         }
 
         [Test]
@@ -422,11 +422,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "font : 80% sans-serif ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("font", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("80% sans-serif", property.Value);
+            Assert.That(property.Name, Is.EqualTo("font"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("80% sans-serif"));
         }
 
         [Test]
@@ -434,11 +434,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "font : bold italic large serif ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("font", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("italic bold 1.2em serif", property.Value);
+            Assert.That(property.Name, Is.EqualTo("font"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("italic bold 1.2em serif"));
         }
 
         [Test]
@@ -446,11 +446,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "font : status-bar ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("font", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("status-bar", property.Value);
+            Assert.That(property.Name, Is.EqualTo("font"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("status-bar"));
         }
 
         [Test]
@@ -458,11 +458,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "font : 15px arial,sans-serif ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("font", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("15px arial, sans-serif", property.Value);
+            Assert.That(property.Name, Is.EqualTo("font"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("15px arial, sans-serif"));
         }
 
         [Test]
@@ -470,11 +470,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "font : italic bold 12px/30px Georgia, serif";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("font", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("italic bold 12px / 30px Georgia, serif", property.Value);
+            Assert.That(property.Name, Is.EqualTo("font"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("italic bold 12px / 30px Georgia, serif"));
         }
 
         [Test]
@@ -482,11 +482,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "letter-spacing: 3px ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("letter-spacing", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("3px", property.Value);
+            Assert.That(property.Name, Is.EqualTo("letter-spacing"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("3px"));
         }
 
         [Test]
@@ -494,11 +494,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "letter-spacing: .3px ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("letter-spacing", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("0.3px", property.Value);
+            Assert.That(property.Name, Is.EqualTo("letter-spacing"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("0.3px"));
         }
 
         [Test]
@@ -506,11 +506,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "letter-spacing: 0.3em ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("letter-spacing", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("0.3em", property.Value);
+            Assert.That(property.Name, Is.EqualTo("letter-spacing"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("0.3em"));
         }
 
         [Test]
@@ -518,11 +518,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "letter-spacing: normal ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("letter-spacing", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("normal", property.Value);
+            Assert.That(property.Name, Is.EqualTo("letter-spacing"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("normal"));
         }
 
         [Test]
@@ -530,11 +530,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "font-size-adjust : NONE";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("font-size-adjust", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("none", property.Value);
+            Assert.That(property.Name, Is.EqualTo("font-size-adjust"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("none"));
         }
 
         [Test]
@@ -542,11 +542,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "font-size-adjust : 0.5";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("font-size-adjust", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("0.5", property.Value);
+            Assert.That(property.Name, Is.EqualTo("font-size-adjust"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("0.5"));
         }
 
         [Test]
@@ -554,10 +554,10 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "font-size-adjust : 1.1em ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("font-size-adjust", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsTrue(property.IsInherited);
-            Assert.IsFalse(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("font-size-adjust"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.True);
+            Assert.That(property.HasValue, Is.False);
         }
 
         [Test]
@@ -565,11 +565,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "font: 12pt/14pt sans-serif ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("font", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("12pt / 14pt sans-serif", property.Value);
+            Assert.That(property.Name, Is.EqualTo("font"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("12pt / 14pt sans-serif"));
         }
 
         [Test]
@@ -577,11 +577,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "font: 80% sans-serif ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("font", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("80% sans-serif", property.Value);
+            Assert.That(property.Name, Is.EqualTo("font"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("80% sans-serif"));
         }
 
         [Test]
@@ -589,11 +589,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "font: x-large/110% 'New Century Schoolbook', serif ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("font", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("1.5em / 110% \"New Century Schoolbook\", serif", property.Value);
+            Assert.That(property.Name, Is.EqualTo("font"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("1.5em / 110% \"New Century Schoolbook\", serif"));
         }
 
         [Test]
@@ -601,11 +601,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "font: bold italic large Palatino, serif ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("font", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("italic bold 1.2em Palatino, serif", property.Value);
+            Assert.That(property.Name, Is.EqualTo("font"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("italic bold 1.2em Palatino, serif"));
         }
 
         [Test]
@@ -613,11 +613,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "font: normal small-caps 120%/120% Fantasy ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("font", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("normal small-caps 120% / 120% Fantasy", property.Value);
+            Assert.That(property.Name, Is.EqualTo("font"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("normal small-caps 120% / 120% Fantasy"));
         }
 
         [Test]
@@ -625,11 +625,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "font: condensed oblique 12pt \"Helvetica Neue\", serif ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("font", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("oblique condensed 12pt \"Helvetica Neue\", serif", property.Value);
+            Assert.That(property.Name, Is.EqualTo("font"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("oblique condensed 12pt \"Helvetica Neue\", serif"));
         }
 
         [Test]
@@ -637,11 +637,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "font: status-bar ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("font", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("status-bar", property.Value);
+            Assert.That(property.Name, Is.EqualTo("font"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("status-bar"));
         }
 
         [Test]
@@ -653,8 +653,8 @@ namespace AngleSharp.Css.Tests.Declarations
            font-weight: bold;
     }";
             var rule = ParseRule(snippet);
-            Assert.AreEqual(CssRuleType.FontFace, rule.Type);
-            Assert.AreEqual("@font-face { font-family: FrutigerLTStd; src: url(\"https://example.com/FrutigerLTStd-Light.otf\") format(\"opentype\"); font-weight: bold }", rule.ToCss());
+            Assert.That(rule.Type, Is.EqualTo(CssRuleType.FontFace));
+            Assert.That(rule.ToCss(), Is.EqualTo("@font-face { font-family: FrutigerLTStd; src: url(\"https://example.com/FrutigerLTStd-Light.otf\") format(\"opentype\"); font-weight: bold }"));
         }
 
         [Test]
@@ -665,8 +665,8 @@ namespace AngleSharp.Css.Tests.Declarations
             src: url(""https://example.com/FrutigerLTStd-Light.otf"") format(""opentype"");
     }";
             var rule = ParseRule(snippet);
-            Assert.AreEqual(CssRuleType.FontFace, rule.Type);
-            Assert.AreEqual("@font-face { font-family: FrutigerLTStd; src: url(\"https://example.com/FrutigerLTStd-Light.otf\") format(\"opentype\") }", rule.ToCss());
+            Assert.That(rule.Type, Is.EqualTo(CssRuleType.FontFace));
+            Assert.That(rule.ToCss(), Is.EqualTo("@font-face { font-family: FrutigerLTStd; src: url(\"https://example.com/FrutigerLTStd-Light.otf\") format(\"opentype\") }"));
         }
 
         [Test]
@@ -676,8 +676,8 @@ namespace AngleSharp.Css.Tests.Declarations
         font-family: FrutigerLTStd;
     }";
             var rule = ParseRule(snippet);
-            Assert.AreEqual(CssRuleType.FontFace, rule.Type);
-            Assert.AreEqual("@font-face { font-family: FrutigerLTStd }", rule.ToCss());
+            Assert.That(rule.Type, Is.EqualTo(CssRuleType.FontFace));
+            Assert.That(rule.ToCss(), Is.EqualTo("@font-face { font-family: FrutigerLTStd }"));
         }
 
         [Test]
@@ -685,11 +685,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "font: italic bold 12px/30px Georgia, serif";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("font", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("italic bold 12px / 30px Georgia, serif", property.Value);
+            Assert.That(property.Name, Is.EqualTo("font"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("italic bold 12px / 30px Georgia, serif"));
         }
 
         [Test]
@@ -697,11 +697,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "font: 400 12px Georgia, serif";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("font", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("400 12px Georgia, serif", property.Value);
+            Assert.That(property.Name, Is.EqualTo("font"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("400 12px Georgia, serif"));
         }
 
         [Test]

--- a/src/AngleSharp.Css.Tests/Declarations/CssGridProperty.cs
+++ b/src/AngleSharp.Css.Tests/Declarations/CssGridProperty.cs
@@ -11,11 +11,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "grid-auto-flow : dense";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("grid-auto-flow", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("dense", property.Value);
+            Assert.That(property.Name, Is.EqualTo("grid-auto-flow"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("dense"));
         }
 
         [Test]
@@ -23,11 +23,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "grid-auto-flow : row";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("grid-auto-flow", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("row", property.Value);
+            Assert.That(property.Name, Is.EqualTo("grid-auto-flow"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("row"));
         }
 
         [Test]
@@ -35,11 +35,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "grid-auto-flow : column";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("grid-auto-flow", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("column", property.Value);
+            Assert.That(property.Name, Is.EqualTo("grid-auto-flow"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("column"));
         }
 
         [Test]
@@ -47,11 +47,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "grid-auto-flow : column dense";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("grid-auto-flow", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("column dense", property.Value);
+            Assert.That(property.Name, Is.EqualTo("grid-auto-flow"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("column dense"));
         }
 
         [Test]
@@ -59,11 +59,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "grid-auto-flow : row dense";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("grid-auto-flow", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("row dense", property.Value);
+            Assert.That(property.Name, Is.EqualTo("grid-auto-flow"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("row dense"));
         }
 
         [Test]
@@ -71,8 +71,8 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "grid-auto-flow : dense dense";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("grid-auto-flow", property.Name);
-            Assert.IsFalse(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("grid-auto-flow"));
+            Assert.That(property.HasValue, Is.False);
         }
 
         [Test]
@@ -80,9 +80,9 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "grid-template-rows: 100px 1fr";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("grid-template-rows", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("100px 1fr", property.Value);
+            Assert.That(property.Name, Is.EqualTo("grid-template-rows"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("100px 1fr"));
         }
 
         [Test]
@@ -90,9 +90,9 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "grid-template-rows: [linename] 100px";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("grid-template-rows", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("[linename] 100px", property.Value);
+            Assert.That(property.Name, Is.EqualTo("grid-template-rows"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("[linename] 100px"));
         }
 
         [Test]
@@ -100,9 +100,9 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "grid-template-rows: [linename1] 100px [linename2 linename3]";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("grid-template-rows", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("[linename1] 100px [linename2 linename3]", property.Value);
+            Assert.That(property.Name, Is.EqualTo("grid-template-rows"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("[linename1] 100px [linename2 linename3]"));
         }
 
         [Test]
@@ -110,9 +110,9 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "grid-template-rows: fit-content(40%)";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("grid-template-rows", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("fit-content(40%)", property.Value);
+            Assert.That(property.Name, Is.EqualTo("grid-template-rows"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("fit-content(40%)"));
         }
 
         [Test]
@@ -120,9 +120,9 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "grid-template-rows: repeat(3, 200px)";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("grid-template-rows", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("repeat(3, 200px)", property.Value);
+            Assert.That(property.Name, Is.EqualTo("grid-template-rows"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("repeat(3, 200px)"));
         }
 
         [Test]
@@ -130,9 +130,9 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "grid-template-rows: minmax(100px, max-content) repeat(auto-fill, 200px) 20%";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("grid-template-rows", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("minmax(100px, max-content) repeat(auto-fill, 200px) 20%", property.Value);
+            Assert.That(property.Name, Is.EqualTo("grid-template-rows"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("minmax(100px, max-content) repeat(auto-fill, 200px) 20%"));
         }
 
         [Test]
@@ -140,9 +140,9 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "grid-template-columns: minmax(100px, 1fr)";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("grid-template-columns", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("minmax(100px, 1fr)", property.Value);
+            Assert.That(property.Name, Is.EqualTo("grid-template-columns"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("minmax(100px, 1fr)"));
         }
 
         [Test]
@@ -150,9 +150,9 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "grid-template-columns: 200px repeat(auto-fill, 100px) 300px";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("grid-template-columns", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("200px repeat(auto-fill, 100px) 300px", property.Value);
+            Assert.That(property.Name, Is.EqualTo("grid-template-columns"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("200px repeat(auto-fill, 100px) 300px"));
         }
 
         [Test]
@@ -160,9 +160,9 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "grid-template-columns: [linename1] 100px [linename2]\n repeat(auto-fit, [linename3 linename4] 300px)\n 100px";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("grid-template-columns", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("[linename1] 100px [linename2] repeat(auto-fit, [linename3 linename4] 300px) 100px", property.Value);
+            Assert.That(property.Name, Is.EqualTo("grid-template-columns"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("[linename1] 100px [linename2] repeat(auto-fit, [linename3 linename4] 300px) 100px"));
         }
 
         [Test]
@@ -171,9 +171,9 @@ namespace AngleSharp.Css.Tests.Declarations
             var snippet = @"grid-template-columns: [linename1 linename2] 100px
                        repeat(auto-fit, [linename1] 300px) [linename3]";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("grid-template-columns", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("[linename1 linename2] 100px repeat(auto-fit, [linename1] 300px) [linename3]", property.Value);
+            Assert.That(property.Name, Is.EqualTo("grid-template-columns"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("[linename1 linename2] 100px repeat(auto-fit, [linename1] 300px) [linename3]"));
         }
 
         [Test]
@@ -181,9 +181,9 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = @"grid-template-areas: none";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("grid-template-areas", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("none", property.Value);
+            Assert.That(property.Name, Is.EqualTo("grid-template-areas"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("none"));
         }
 
         [Test]
@@ -191,9 +191,9 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = @"grid-template-areas: ""a b""";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("grid-template-areas", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("\"a b\"", property.Value);
+            Assert.That(property.Name, Is.EqualTo("grid-template-areas"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("\"a b\""));
         }
 
         [Test]
@@ -202,9 +202,9 @@ namespace AngleSharp.Css.Tests.Declarations
             var snippet = @"grid-template-areas: ""a b b""
                      ""a c d""";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("grid-template-areas", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("\"a b b\" \"a c d\"", property.Value);
+            Assert.That(property.Name, Is.EqualTo("grid-template-areas"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("\"a b b\" \"a c d\""));
         }
 
         [Test]
@@ -212,9 +212,9 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = @"grid-auto-columns: min-content";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("grid-auto-columns", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("min-content", property.Value);
+            Assert.That(property.Name, Is.EqualTo("grid-auto-columns"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("min-content"));
         }
 
         [Test]
@@ -222,9 +222,9 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = @"grid-auto-columns: max-content";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("grid-auto-columns", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("max-content", property.Value);
+            Assert.That(property.Name, Is.EqualTo("grid-auto-columns"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("max-content"));
         }
 
         [Test]
@@ -232,9 +232,9 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = @"grid-auto-rows: AUTO";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("grid-auto-rows", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("auto", property.Value);
+            Assert.That(property.Name, Is.EqualTo("grid-auto-rows"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("auto"));
         }
 
         [Test]
@@ -242,9 +242,9 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = @"grid-auto-columns: 100px";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("grid-auto-columns", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("100px", property.Value);
+            Assert.That(property.Name, Is.EqualTo("grid-auto-columns"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("100px"));
         }
 
         [Test]
@@ -252,9 +252,9 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = @"  grid-auto-columns  : 20cm";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("grid-auto-columns", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("20cm", property.Value);
+            Assert.That(property.Name, Is.EqualTo("grid-auto-columns"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("20cm"));
         }
 
         [Test]
@@ -262,9 +262,9 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = @"grid-auto-rows: 50vmax";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("grid-auto-rows", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("50vmax", property.Value);
+            Assert.That(property.Name, Is.EqualTo("grid-auto-rows"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("50vmax"));
         }
 
         [Test]
@@ -272,9 +272,9 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = @"grid-auto-columns: 10%";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("grid-auto-columns", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("10%", property.Value);
+            Assert.That(property.Name, Is.EqualTo("grid-auto-columns"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("10%"));
         }
 
         [Test]
@@ -282,9 +282,9 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = @"grid-auto-rows: 33.3%";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("grid-auto-rows", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("33.3%", property.Value);
+            Assert.That(property.Name, Is.EqualTo("grid-auto-rows"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("33.3%"));
         }
 
         [Test]
@@ -292,9 +292,9 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = @"grid-auto-rows: 0.5fr";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("grid-auto-rows", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("0.5fr", property.Value);
+            Assert.That(property.Name, Is.EqualTo("grid-auto-rows"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("0.5fr"));
         }
 
         [Test]
@@ -302,9 +302,9 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = @"grid-auto-columns: 3fr;";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("grid-auto-columns", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("3fr", property.Value);
+            Assert.That(property.Name, Is.EqualTo("grid-auto-columns"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("3fr"));
         }
 
         [Test]
@@ -312,9 +312,9 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = @"grid-auto-columns: minmax(100px, auto)";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("grid-auto-columns", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("minmax(100px, auto)", property.Value);
+            Assert.That(property.Name, Is.EqualTo("grid-auto-columns"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("minmax(100px, auto)"));
         }
 
         [Test]
@@ -322,9 +322,9 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = @"grid-auto-columns: minmax(max-content, 2fr)";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("grid-auto-columns", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("minmax(max-content, 2fr)", property.Value);
+            Assert.That(property.Name, Is.EqualTo("grid-auto-columns"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("minmax(max-content, 2fr)"));
         }
 
         [Test]
@@ -332,9 +332,9 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = @"grid-auto-columns: minmax(20%, 80vmax)";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("grid-auto-columns", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("minmax(20%, 80vmax)", property.Value);
+            Assert.That(property.Name, Is.EqualTo("grid-auto-columns"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("minmax(20%, 80vmax)"));
         }
 
         [Test]
@@ -342,9 +342,9 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = @"grid-auto-rows: fit-content(400px)";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("grid-auto-rows", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("fit-content(400px)", property.Value);
+            Assert.That(property.Name, Is.EqualTo("grid-auto-rows"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("fit-content(400px)"));
         }
 
         [Test]
@@ -352,9 +352,9 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = @"grid-auto-columns: fit-content(5cm)";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("grid-auto-columns", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("fit-content(5cm)", property.Value);
+            Assert.That(property.Name, Is.EqualTo("grid-auto-columns"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("fit-content(5cm)"));
         }
 
         [Test]
@@ -362,9 +362,9 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = @"grid-auto-columns: fit-content(20%)";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("grid-auto-columns", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("fit-content(20%)", property.Value);
+            Assert.That(property.Name, Is.EqualTo("grid-auto-columns"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("fit-content(20%)"));
         }
 
         [Test]
@@ -372,9 +372,9 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = @"grid-auto-columns: min-content max-content auto";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("grid-auto-columns", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("min-content max-content auto", property.Value);
+            Assert.That(property.Name, Is.EqualTo("grid-auto-columns"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("min-content max-content auto"));
         }
 
         [Test]
@@ -382,9 +382,9 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = @"grid-auto-columns: 100px 150px 390px";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("grid-auto-columns", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("100px 150px 390px", property.Value);
+            Assert.That(property.Name, Is.EqualTo("grid-auto-columns"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("100px 150px 390px"));
         }
 
         [Test]
@@ -392,9 +392,9 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = @"grid-auto-columns: 100px minmax(100px, auto) 10% 0.5fr fit-content(400px)";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("grid-auto-columns", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("100px minmax(100px, auto) 10% 0.5fr fit-content(400px)", property.Value);
+            Assert.That(property.Name, Is.EqualTo("grid-auto-columns"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("100px minmax(100px, auto) 10% 0.5fr fit-content(400px)"));
         }
 
         [Test]
@@ -402,9 +402,9 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = @"grid-auto-rows: 10% 33.3%";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("grid-auto-rows", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("10% 33.3%", property.Value);
+            Assert.That(property.Name, Is.EqualTo("grid-auto-rows"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("10% 33.3%"));
         }
 
         [Test]
@@ -412,9 +412,9 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = @"grid-auto-columns: 0.5fr 3fr 1fr";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("grid-auto-columns", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("0.5fr 3fr 1fr", property.Value);
+            Assert.That(property.Name, Is.EqualTo("grid-auto-columns"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("0.5fr 3fr 1fr"));
         }
 
         [Test]
@@ -422,9 +422,9 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = @"grid-auto-rows: minmax(100px, auto) minmax(max-content, 2fr) minmax(20%, 80vmax)";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("grid-auto-rows", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("minmax(100px, auto) minmax(max-content, 2fr) minmax(20%, 80vmax)", property.Value);
+            Assert.That(property.Name, Is.EqualTo("grid-auto-rows"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("minmax(100px, auto) minmax(max-content, 2fr) minmax(20%, 80vmax)"));
         }
 
         [Test]
@@ -432,9 +432,9 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = @"grid-row-end: 5 somegridarea span";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("grid-row-end", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("span 5 somegridarea", property.Value);
+            Assert.That(property.Name, Is.EqualTo("grid-row-end"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("span 5 somegridarea"));
         }
 
         [Test]
@@ -442,9 +442,9 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = @"grid-column-start: span somegridarea";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("grid-column-start", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("span somegridarea", property.Value);
+            Assert.That(property.Name, Is.EqualTo("grid-column-start"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("span somegridarea"));
         }
 
         [Test]
@@ -452,9 +452,9 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = @"grid-row-start: span 3";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("grid-row-start", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("span 3", property.Value);
+            Assert.That(property.Name, Is.EqualTo("grid-row-start"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("span 3"));
         }
 
         [Test]
@@ -462,9 +462,9 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = @"grid-column-end: somegridarea 4";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("grid-column-end", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("4 somegridarea", property.Value);
+            Assert.That(property.Name, Is.EqualTo("grid-column-end"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("4 somegridarea"));
         }
 
         [Test]
@@ -472,9 +472,9 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = @"grid-column-start: 2";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("grid-column-start", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("2", property.Value);
+            Assert.That(property.Name, Is.EqualTo("grid-column-start"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("2"));
         }
 
         [Test]
@@ -482,9 +482,9 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = @"grid-row-end: somegridarea";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("grid-row-end", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("somegridarea", property.Value);
+            Assert.That(property.Name, Is.EqualTo("grid-row-end"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("somegridarea"));
         }
 
         [Test]
@@ -492,9 +492,9 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = @"grid-row-start: auto";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("grid-row-start", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("auto", property.Value);
+            Assert.That(property.Name, Is.EqualTo("grid-row-start"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("auto"));
         }
 
         [Test]
@@ -502,9 +502,9 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = @"grid-area: 2 / 2 / auto / span 3";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("grid-area", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("2 / 2 / auto / span 3", property.Value);
+            Assert.That(property.Name, Is.EqualTo("grid-area"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("2 / 2 / auto / span 3"));
         }
 
         [Test]
@@ -512,9 +512,9 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = @"grid-area: 2 / foobar / auto";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("grid-area", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("2 / foobar / auto / foobar", property.Value);
+            Assert.That(property.Name, Is.EqualTo("grid-area"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("2 / foobar / auto / foobar"));
         }
 
         [Test]
@@ -522,9 +522,9 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = @"grid-area: 2";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("grid-area", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("2 / auto / auto / auto", property.Value);
+            Assert.That(property.Name, Is.EqualTo("grid-area"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("2 / auto / auto / auto"));
         }
 
         [Test]
@@ -535,7 +535,7 @@ namespace AngleSharp.Css.Tests.Declarations
             var text = css.Rules[0].CssText;
 
             var expected = "#nav-header { grid-area: aaa }";
-            Assert.AreEqual(expected, text);
+            Assert.That(text, Is.EqualTo(expected));
         }
 
 
@@ -547,7 +547,7 @@ namespace AngleSharp.Css.Tests.Declarations
             var text = css.Rules[0].CssText;
 
             var expected = "#nav-header { grid-area: aaa / bbb / aaa / bbb }";
-            Assert.AreEqual(expected, text);
+            Assert.That(text, Is.EqualTo(expected));
         }
 
         [Test]
@@ -558,7 +558,7 @@ namespace AngleSharp.Css.Tests.Declarations
             var text = css.Rules[0].CssText;
 
             var expected = "#nav-header { grid-area: 1 / 2 / auto / auto }";
-            Assert.AreEqual(expected, text);
+            Assert.That(text, Is.EqualTo(expected));
         }
 
         [Test]
@@ -569,7 +569,7 @@ namespace AngleSharp.Css.Tests.Declarations
             var text = css.Rules[0].CssText;
 
             var expected = "#nav-header { grid-area: aaa / 2 / aaa / auto }";
-            Assert.AreEqual(expected, text);
+            Assert.That(text, Is.EqualTo(expected));
         }
 
         [Test]
@@ -580,7 +580,7 @@ namespace AngleSharp.Css.Tests.Declarations
             var text = css.Rules[0].CssText;
 
             var expected = "#nav-header { grid-area: aaa / bbb / ccc / bbb }";
-            Assert.AreEqual(expected, text);
+            Assert.That(text, Is.EqualTo(expected));
         }
 
         [Test]
@@ -591,7 +591,7 @@ namespace AngleSharp.Css.Tests.Declarations
             var text = css.Rules[0].CssText;
 
             var expected = "#nav-header { grid-area: aaa / bbb / ccc / bbb }";
-            Assert.AreEqual(expected, text);
+            Assert.That(text, Is.EqualTo(expected));
         }
 
         [Test]
@@ -602,7 +602,7 @@ namespace AngleSharp.Css.Tests.Declarations
             var text = css.Rules[0].CssText;
 
             var expected = "#nav-header { grid-area: 1 / auto / auto / auto }";
-            Assert.AreEqual(expected, text);
+            Assert.That(text, Is.EqualTo(expected));
         }
 
         [Test]
@@ -613,7 +613,7 @@ namespace AngleSharp.Css.Tests.Declarations
             var text = css.Rules[0].CssText;
 
             var expected = "#nav-header { grid-area: 2 / aaa / auto / aaa }";
-            Assert.AreEqual(expected, text);
+            Assert.That(text, Is.EqualTo(expected));
         }
 
         [Test]
@@ -624,7 +624,7 @@ namespace AngleSharp.Css.Tests.Declarations
             var text = css.Rules[0].CssText;
 
             var expected = "#nav-header { }";
-            Assert.AreEqual(expected, text);
+            Assert.That(text, Is.EqualTo(expected));
         }
 
         [Test]
@@ -635,7 +635,7 @@ namespace AngleSharp.Css.Tests.Declarations
             var text = css.Rules[0].CssText;
 
             var expected = "#nav-header { }";
-            Assert.AreEqual(expected, text);
+            Assert.That(text, Is.EqualTo(expected));
         }
 
         [Test]
@@ -646,7 +646,7 @@ namespace AngleSharp.Css.Tests.Declarations
             var text = css.Rules[0].CssText;
 
             var expected = "#nav-header { grid-area: 10000 / auto / auto / auto }";
-            Assert.AreEqual(expected, text);
+            Assert.That(text, Is.EqualTo(expected));
         }
 
         [Test]
@@ -657,7 +657,7 @@ namespace AngleSharp.Css.Tests.Declarations
             var text = css.Rules[0].CssText;
 
             var expected = "#nav-header { grid-area: 10000 / 10000 / auto / auto }";
-            Assert.AreEqual(expected, text);
+            Assert.That(text, Is.EqualTo(expected));
         }
 
         [Test]
@@ -665,9 +665,9 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = @"grid: auto-flow 300px / repeat(3, [line1 line2 line3] 200px)";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("grid", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("auto-flow 300px / repeat(3, [line1 line2 line3] 200px)", property.Value);
+            Assert.That(property.Name, Is.EqualTo("grid"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("auto-flow 300px / repeat(3, [line1 line2 line3] 200px)"));
         }
 
         [Test]
@@ -675,9 +675,9 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = @"grid: auto-flow dense / 30%";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("grid", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("auto-flow dense / 30%", property.Value);
+            Assert.That(property.Name, Is.EqualTo("grid"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("auto-flow dense / 30%"));
         }
 
         [Test]
@@ -685,9 +685,9 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = @"grid: auto-flow dense 40% / [line1] minmax(20em, max-content)";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("grid", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("auto-flow dense 40% / [line1] minmax(20em, max-content)", property.Value);
+            Assert.That(property.Name, Is.EqualTo("grid"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("auto-flow dense 40% / [line1] minmax(20em, max-content)"));
         }
 
         [Test]
@@ -695,9 +695,9 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = @"grid: auto-flow / 200px";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("grid", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("auto-flow / 200px", property.Value);
+            Assert.That(property.Name, Is.EqualTo("grid"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("auto-flow / 200px"));
         }
 
         [Test]
@@ -705,9 +705,9 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = @"grid: repeat(3, [line1 line2 line3] 200px) / auto-flow 300px";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("grid", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("repeat(3, [line1 line2 line3] 200px) / auto-flow 300px", property.Value);
+            Assert.That(property.Name, Is.EqualTo("grid"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("repeat(3, [line1 line2 line3] 200px) / auto-flow 300px"));
         }
 
         [Test]
@@ -715,9 +715,9 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = @"grid: 30% / auto-flow dense";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("grid", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("30% / auto-flow dense", property.Value);
+            Assert.That(property.Name, Is.EqualTo("grid"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("30% / auto-flow dense"));
         }
 
         [Test]
@@ -725,9 +725,9 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = @"grid: minmax(400px, min-content) / repeat(auto-fill, 50px)";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("grid", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("minmax(400px, min-content) / repeat(auto-fill, 50px)", property.Value);
+            Assert.That(property.Name, Is.EqualTo("grid"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("minmax(400px, min-content) / repeat(auto-fill, 50px)"));
         }
 
         [Test]
@@ -735,9 +735,9 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = @"grid: [line1] minmax(20em, max-content) / auto-flow dense 40%";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("grid", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("[line1] minmax(20em, max-content) / auto-flow dense 40%", property.Value);
+            Assert.That(property.Name, Is.EqualTo("grid"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("[line1] minmax(20em, max-content) / auto-flow dense 40%"));
         }
 
         [Test]
@@ -745,9 +745,9 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = @"grid: 200px / auto-flow";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("grid", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("200px / auto-flow", property.Value);
+            Assert.That(property.Name, Is.EqualTo("grid"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("200px / auto-flow"));
         }
 
         [Test]
@@ -755,9 +755,9 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = @"grid: 100px / 200px";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("grid", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("100px / 200px", property.Value);
+            Assert.That(property.Name, Is.EqualTo("grid"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("100px / 200px"));
         }
 
         [Test]
@@ -765,9 +765,9 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = @"grid: ""a"" minmax(100px, max-content) ""b"" 20%";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("grid", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("\"a\" minmax(100px, max-content) \"b\" 20%", property.Value);
+            Assert.That(property.Name, Is.EqualTo("grid"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("\"a\" minmax(100px, max-content) \"b\" 20%"));
         }
 
         [Test]
@@ -775,9 +775,9 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = @"grid: ""a"" 200px ""b"" min-content";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("grid", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("\"a\" 200px \"b\" min-content", property.Value);
+            Assert.That(property.Name, Is.EqualTo("grid"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("\"a\" 200px \"b\" min-content"));
         }
 
         [Test]
@@ -785,9 +785,9 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = @"grid: [linename1] ""a"" 100px [linename2]";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("grid", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("[linename1] \"a\" 100px [linename2]", property.Value);
+            Assert.That(property.Name, Is.EqualTo("grid"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("[linename1] \"a\" 100px [linename2]"));
         }
 
         [Test]
@@ -795,9 +795,9 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = @"grid: ""a"" 100px ""b"" 1fr";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("grid", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("\"a\" 100px \"b\" 1fr", property.Value);
+            Assert.That(property.Name, Is.EqualTo("grid"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("\"a\" 100px \"b\" 1fr"));
         }
 
         [Test]
@@ -805,9 +805,9 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = @"grid: none";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("grid", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("none", property.Value);
+            Assert.That(property.Name, Is.EqualTo("grid"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("none"));
         }
 
         [Test]
@@ -815,9 +815,9 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = @"grid-template: none";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("grid-template", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("none", property.Value);
+            Assert.That(property.Name, Is.EqualTo("grid-template"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("none"));
         }
 
         [Test]
@@ -826,9 +826,9 @@ namespace AngleSharp.Css.Tests.Declarations
             var snippet = @"grid-template: [header-top] ""a a a""     [header-bottom]
                  [main-top] ""b b b"" 1fr [main-bottom] / auto 1fr auto";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("grid-template", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("[header-top] \"a a a\" [header-bottom] [main-top] \"b b b\" 1fr [main-bottom] / auto 1fr auto", property.Value);
+            Assert.That(property.Name, Is.EqualTo("grid-template"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("[header-top] \"a a a\" [header-bottom] [main-top] \"b b b\" 1fr [main-bottom] / auto 1fr auto"));
         }
 
         [Test]
@@ -837,9 +837,9 @@ namespace AngleSharp.Css.Tests.Declarations
             var snippet = @"grid-template: ""a a a"" 20%
                ""b b b"" auto";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("grid-template", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("\"a a a\" 20% \"b b b\" auto", property.Value);
+            Assert.That(property.Name, Is.EqualTo("grid-template"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("\"a a a\" 20% \"b b b\" auto"));
         }
 
         [Test]
@@ -848,9 +848,9 @@ namespace AngleSharp.Css.Tests.Declarations
             var snippet = @"grid-template: ""a a a""
                ""b b b""";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("grid-template", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("\"a a a\" \"b b b\"", property.Value);
+            Assert.That(property.Name, Is.EqualTo("grid-template"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("\"a a a\" \"b b b\""));
         }
 
         [Test]
@@ -858,9 +858,9 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = @"grid-template: fit-content(100px) / fit-content(40%)";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("grid-template", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("fit-content(100px) / fit-content(40%)", property.Value);
+            Assert.That(property.Name, Is.EqualTo("grid-template"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("fit-content(100px) / fit-content(40%)"));
         }
 
         [Test]
@@ -868,9 +868,9 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = @"grid-template: [linename] 100px / [columnname1] 30% [columnname2] 70%";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("grid-template", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("[linename] 100px / [columnname1] 30% [columnname2] 70%", property.Value);
+            Assert.That(property.Name, Is.EqualTo("grid-template"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("[linename] 100px / [columnname1] 30% [columnname2] 70%"));
         }
 
         [Test]
@@ -878,9 +878,9 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = @"grid-template: auto 1fr / auto 1fr auto";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("grid-template", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("auto 1fr / auto 1fr auto", property.Value);
+            Assert.That(property.Name, Is.EqualTo("grid-template"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("auto 1fr / auto 1fr auto"));
         }
 
         [Test]
@@ -888,9 +888,9 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = @"grid-template: 100px 1fr / 50px 1fr";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("grid-template", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("100px 1fr / 50px 1fr", property.Value);
+            Assert.That(property.Name, Is.EqualTo("grid-template"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("100px 1fr / 50px 1fr"));
         }
 
         [Test]
@@ -899,7 +899,7 @@ namespace AngleSharp.Css.Tests.Declarations
             var snippet = @"div#A { grid-template-areas: ""a b b"" ""a c d"" }";
             var rule = ParseRule(snippet);
             var text = rule.CssText;
-            Assert.AreEqual(snippet, text);
+            Assert.That(text, Is.EqualTo(snippet));
         }
 
         [Test]
@@ -907,7 +907,7 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "grid-template-areas: none; grid-template-columns: none; grid-template-rows: none";
             var style = ParseDeclarations(snippet);
-            Assert.AreEqual("grid-template: none", style.CssText);
+            Assert.That(style.CssText, Is.EqualTo("grid-template: none"));
         }
 
         [Test]
@@ -915,7 +915,7 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "grid: 10px / 80px";
             var style = ParseDeclarations(snippet);
-            Assert.AreEqual("grid: 10px / 80px", style.CssText);
+            Assert.That(style.CssText, Is.EqualTo("grid: 10px / 80px"));
         }
 
         [Test]
@@ -923,7 +923,7 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "grid-gap: 10px 80px";
             var style = ParseDeclarations(snippet);
-            Assert.AreEqual("grid-gap: 10px 80px", style.CssText);
+            Assert.That(style.CssText, Is.EqualTo("grid-gap: 10px 80px"));
         }
     }
 }

--- a/src/AngleSharp.Css.Tests/Declarations/CssListProperty.cs
+++ b/src/AngleSharp.Css.Tests/Declarations/CssListProperty.cs
@@ -11,11 +11,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "list-style-position: outside ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("list-style-position", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("outside", property.Value);
+            Assert.That(property.Name, Is.EqualTo("list-style-position"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("outside"));
         }
 
         [Test]
@@ -23,10 +23,10 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "list-style-position: out-side ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("list-style-position", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsTrue(property.IsInherited);
-            Assert.IsFalse(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("list-style-position"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.True);
+            Assert.That(property.HasValue, Is.False);
         }
 
         [Test]
@@ -34,10 +34,10 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "list-style-position: none ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("list-style-position", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsTrue(property.IsInherited);
-            Assert.IsFalse(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("list-style-position"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.True);
+            Assert.That(property.HasValue, Is.False);
         }
 
         [Test]
@@ -45,11 +45,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "list-style-position: insiDe ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("list-style-position", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("inside", property.Value);
+            Assert.That(property.Name, Is.EqualTo("list-style-position"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("inside"));
         }
 
         [Test]
@@ -57,11 +57,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "list-style-image: none ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("list-style-image", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("none", property.Value);
+            Assert.That(property.Name, Is.EqualTo("list-style-image"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("none"));
         }
 
         [Test]
@@ -69,11 +69,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "list-style-image: url(http://www.example.com/images/list.png)";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("list-style-image", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("url(\"http://www.example.com/images/list.png\")", property.Value);
+            Assert.That(property.Name, Is.EqualTo("list-style-image"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("url(\"http://www.example.com/images/list.png\")"));
         }
 
         [Test]
@@ -81,11 +81,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "list-style-type: disc ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("list-style-type", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("disc", property.Value);
+            Assert.That(property.Name, Is.EqualTo("list-style-type"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("disc"));
         }
 
         [Test]
@@ -93,11 +93,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "list-style-type: lower-ALPHA ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("list-style-type", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("lower-alpha", property.Value);
+            Assert.That(property.Name, Is.EqualTo("list-style-type"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("lower-alpha"));
         }
 
         [Test]
@@ -105,11 +105,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "list-style-type: georgian ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("list-style-type", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("georgian", property.Value);
+            Assert.That(property.Name, Is.EqualTo("list-style-type"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("georgian"));
         }
 
         [Test]
@@ -117,11 +117,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "list-style-type: decimal-leading-zerO ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("list-style-type", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("decimal-leading-zero", property.Value);
+            Assert.That(property.Name, Is.EqualTo("list-style-type"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("decimal-leading-zero"));
         }
 
         [Test]
@@ -129,11 +129,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "list-style-type: number ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("list-style-type", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("number", property.Value);
+            Assert.That(property.Name, Is.EqualTo("list-style-type"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("number"));
         }
 
         [Test]
@@ -141,11 +141,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "list-style: circle ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("list-style", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("circle", property.Value);
+            Assert.That(property.Name, Is.EqualTo("list-style"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("circle"));
         }
 
         [Test]
@@ -153,11 +153,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "list-style: none";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("list-style", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("none", property.Value);
+            Assert.That(property.Name, Is.EqualTo("list-style"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("none"));
         }
 
         [Test]
@@ -165,11 +165,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "list-style: square inside ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("list-style", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("square inside", property.Value);
+            Assert.That(property.Name, Is.EqualTo("list-style"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("square inside"));
         }
 
         [Test]
@@ -177,11 +177,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "list-style: square url('image.png') inside ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("list-style", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("square inside url(\"image.png\")", property.Value);
+            Assert.That(property.Name, Is.EqualTo("list-style"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("square inside url(\"image.png\")"));
         }
 
         [Test]
@@ -189,11 +189,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "counter-reset: chapter section 1 page;";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("counter-reset", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("chapter 0 section 1 page 0", property.Value);
+            Assert.That(property.Name, Is.EqualTo("counter-reset"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("chapter 0 section 1 page 0"));
         }
 
         [Test]
@@ -201,11 +201,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "counter-reset: counter-name";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("counter-reset", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("counter-name 0", property.Value);
+            Assert.That(property.Name, Is.EqualTo("counter-reset"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("counter-name 0"));
         }
 
         [Test]
@@ -213,11 +213,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "counter-reset: none";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("counter-reset", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("none", property.Value);
+            Assert.That(property.Name, Is.EqualTo("counter-reset"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("none"));
         }
 
         [Test]
@@ -225,10 +225,10 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "counter-reset: 3";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("counter-reset", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsFalse(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("counter-reset"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.False);
         }
 
         [Test]
@@ -236,11 +236,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "counter-reset  :  counter-name   -1";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("counter-reset", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("counter-name -1", property.Value);
+            Assert.That(property.Name, Is.EqualTo("counter-reset"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("counter-name -1"));
         }
 
         [Test]
@@ -248,11 +248,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "counter-reset  :  counter1   1   counter2   4  ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("counter-reset", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("counter1 1 counter2 4", property.Value);
+            Assert.That(property.Name, Is.EqualTo("counter-reset"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("counter1 1 counter2 4"));
         }
 
         [Test]
@@ -260,11 +260,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "counter-increment: none";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("counter-increment", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("none", property.Value);
+            Assert.That(property.Name, Is.EqualTo("counter-increment"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("none"));
         }
 
         [Test]
@@ -272,11 +272,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "counter-increment: chapter section 2 page";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("counter-increment", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("chapter 1 section 2 page 1", property.Value);
+            Assert.That(property.Name, Is.EqualTo("counter-increment"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("chapter 1 section 2 page 1"));
         }
 
         [Test]
@@ -284,9 +284,9 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "list-style-type: \"-\"";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("list-style-type", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("\"-\"", property.Value);
+            Assert.That(property.Name, Is.EqualTo("list-style-type"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("\"-\""));
         }
 
         [Test]
@@ -294,9 +294,9 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "list-style-type: kannada";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("list-style-type", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("kannada", property.Value);
+            Assert.That(property.Name, Is.EqualTo("list-style-type"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("kannada"));
         }
 
         [Test]
@@ -304,9 +304,9 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "list-style-type: trad-chinese-informal;";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("list-style-type", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("trad-chinese-informal", property.Value);
+            Assert.That(property.Name, Is.EqualTo("list-style-type"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("trad-chinese-informal"));
         }
 
         [Test]
@@ -314,9 +314,9 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "list-style-type: georgian";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("list-style-type", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("georgian", property.Value);
+            Assert.That(property.Name, Is.EqualTo("list-style-type"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("georgian"));
         }
 
         [Test]
@@ -324,9 +324,9 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "list-style-type: decimal";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("list-style-type", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("decimal", property.Value);
+            Assert.That(property.Name, Is.EqualTo("list-style-type"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("decimal"));
         }
 
         [Test]
@@ -334,9 +334,9 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "list-style-type: square";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("list-style-type", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("square", property.Value);
+            Assert.That(property.Name, Is.EqualTo("list-style-type"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("square"));
         }
 
         [Test]
@@ -344,9 +344,9 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "list-style-type: circle";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("list-style-type", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("circle", property.Value);
+            Assert.That(property.Name, Is.EqualTo("list-style-type"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("circle"));
         }
 
         [Test]
@@ -354,9 +354,9 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "list-style-type: symbols(cyclic \"*\" \"†\" \"‡\")";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("list-style-type", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("symbols(cyclic \"*\" \"†\" \"‡\")", property.Value);
+            Assert.That(property.Name, Is.EqualTo("list-style-type"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("symbols(cyclic \"*\" \"†\" \"‡\")"));
         }
 
         [Test]
@@ -364,8 +364,8 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "list-style-type: symbols(foo \"*\" \"†\" \"‡\")";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("list-style-type", property.Name);
-            Assert.IsFalse(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("list-style-type"));
+            Assert.That(property.HasValue, Is.False);
         }
     }
 }

--- a/src/AngleSharp.Css.Tests/Declarations/CssMarginProperty.cs
+++ b/src/AngleSharp.Css.Tests/Declarations/CssMarginProperty.cs
@@ -11,11 +11,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "margin-left: 15px ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("margin-left", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("15px", property.Value);
+            Assert.That(property.Name, Is.EqualTo("margin-left"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("15px"));
         }
 
         [Test]
@@ -23,11 +23,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "margin-left: 0.00001px";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("margin-left", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("0.00001px", property.Value);
+            Assert.That(property.Name, Is.EqualTo("margin-left"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("0.00001px"));
         }
 
         [Test]
@@ -35,11 +35,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "margin-left: 1E5px";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("margin-left", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("100000px", property.Value);
+            Assert.That(property.Name, Is.EqualTo("margin-left"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("100000px"));
         }
 
         [Test]
@@ -47,11 +47,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "margin-left: 1E+5px";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("margin-left", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("100000px", property.Value);
+            Assert.That(property.Name, Is.EqualTo("margin-left"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("100000px"));
         }
 
         [Test]
@@ -59,11 +59,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "margin-left: 1E-2px";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("margin-left", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("0.01px", property.Value);
+            Assert.That(property.Name, Is.EqualTo("margin-left"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("0.01px"));
         }
 
         [Test]
@@ -71,11 +71,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "margin-left: initial ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("margin-left", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("initial", property.Value);
+            Assert.That(property.Name, Is.EqualTo("margin-left"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("initial"));
         }
 
         [Test]
@@ -83,11 +83,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "margin-right: 3em!important";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("margin-right", property.Name);
-            Assert.IsTrue(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("3em", property.Value);
+            Assert.That(property.Name, Is.EqualTo("margin-right"));
+            Assert.That(property.IsImportant, Is.True);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("3em"));
         }
 
         [Test]
@@ -95,11 +95,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "margin-right: 10%";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("margin-right", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("10%", property.Value);
+            Assert.That(property.Name, Is.EqualTo("margin-right"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("10%"));
         }
 
         [Test]
@@ -107,11 +107,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "margin-top: 4% ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("margin-top", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("4%", property.Value);
+            Assert.That(property.Name, Is.EqualTo("margin-top"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("4%"));
         }
 
         [Test]
@@ -119,11 +119,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "margin-bottom: 0 ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("margin-bottom", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("0", property.Value);
+            Assert.That(property.Name, Is.EqualTo("margin-bottom"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("0"));
         }
 
         [Test]
@@ -131,11 +131,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "margin-bottom: -3px ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("margin-bottom", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("-3px", property.Value);
+            Assert.That(property.Name, Is.EqualTo("margin-bottom"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("-3px"));
         }
 
         [Test]
@@ -143,11 +143,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "margin-bottom: auto ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("margin-bottom", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("auto", property.Value);
+            Assert.That(property.Name, Is.EqualTo("margin-bottom"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("auto"));
         }
 
         [Test]
@@ -155,11 +155,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "margin: 0 ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("margin", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("0", property.Value);
+            Assert.That(property.Name, Is.EqualTo("margin"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("0"));
         }
 
         [Test]
@@ -167,11 +167,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "margin: 25% ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("margin", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("25%", property.Value);
+            Assert.That(property.Name, Is.EqualTo("margin"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("25%"));
         }
 
         [Test]
@@ -179,11 +179,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "margin: 10px 3em ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("margin", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("10px 3em", property.Value);
+            Assert.That(property.Name, Is.EqualTo("margin"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("10px 3em"));
         }
 
         [Test]
@@ -191,11 +191,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "margin: 10px auto ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("margin", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("10px auto", property.Value);
+            Assert.That(property.Name, Is.EqualTo("margin"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("10px auto"));
         }
 
         [Test]
@@ -203,11 +203,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "margin: auto ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("margin", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("auto", property.Value);
+            Assert.That(property.Name, Is.EqualTo("margin"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("auto"));
         }
 
         [Test]
@@ -215,11 +215,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "margin: 10px 3em 5px";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("margin", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("10px 3em 5px", property.Value);
+            Assert.That(property.Name, Is.EqualTo("margin"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("10px 3em 5px"));
         }
 
         [Test]
@@ -227,11 +227,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "margin: 10px 5% auto 2% ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("margin", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("10px 5% auto 2%", property.Value);
+            Assert.That(property.Name, Is.EqualTo("margin"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("10px 5% auto 2%"));
         }
 
         [Test]
@@ -239,7 +239,7 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "margin: 10px 5% 8px 2% 3px auto";
             var property = ParseDeclaration(snippet);
-            Assert.IsFalse(property.HasValue);
+            Assert.That(property.HasValue, Is.False);
         }
 
         [Test]
@@ -249,7 +249,7 @@ namespace AngleSharp.Css.Tests.Declarations
             var expected = ".centered { margin: 2px 4px 1px 3px }";
             var result = ParseRule(snippet);
             var actual = result.CssText;
-            Assert.AreEqual(expected, actual);
+            Assert.That(actual, Is.EqualTo(expected));
         }
 
         [Test]
@@ -259,7 +259,7 @@ namespace AngleSharp.Css.Tests.Declarations
             var expected = ".centered { margin: 0 auto; text-align: left }";
             var result = ParseRule(snippet);
             var actual = result.CssText;
-            Assert.AreEqual(expected, actual);
+            Assert.That(actual, Is.EqualTo(expected));
         }
 
         [Test]
@@ -269,7 +269,7 @@ namespace AngleSharp.Css.Tests.Declarations
             var expected = ".centered { margin: 0 }";
             var result = ParseRule(snippet);
             var actual = result.CssText;
-            Assert.AreEqual(expected, actual);
+            Assert.That(actual, Is.EqualTo(expected));
         }
 
         [Test]
@@ -279,7 +279,7 @@ namespace AngleSharp.Css.Tests.Declarations
             var expected = "p { margin: 0 auto }";
             var result = ParseRule(snippet);
             var actual = result.CssText;
-            Assert.AreEqual(expected, actual);
+            Assert.That(actual, Is.EqualTo(expected));
         }
     }
 }

--- a/src/AngleSharp.Css.Tests/Declarations/CssObjectSizing.cs
+++ b/src/AngleSharp.Css.Tests/Declarations/CssObjectSizing.cs
@@ -1,4 +1,4 @@
-﻿namespace AngleSharp.Css.Tests.Declarations
+namespace AngleSharp.Css.Tests.Declarations
 {
     using NUnit.Framework;
     using static CssConstructionFunctions;
@@ -11,12 +11,12 @@
         {
             var snippet = "object-fit : none";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("object-fit", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsAnimatable);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("none", property.Value);
+            Assert.That(property.Name, Is.EqualTo("object-fit"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsAnimatable, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("none"));
         }
 
         [Test]
@@ -24,11 +24,11 @@
         {
             var snippet = "object-fit : scaledown";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("object-fit", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsAnimatable);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsFalse(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("object-fit"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsAnimatable, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.False);
         }
 
         [Test]
@@ -36,12 +36,12 @@
         {
             var snippet = "object-fit : scale-DOWN";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("object-fit", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsAnimatable);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("scale-down", property.Value);
+            Assert.That(property.Name, Is.EqualTo("object-fit"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsAnimatable, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("scale-down"));
         }
 
         [Test]
@@ -49,12 +49,12 @@
         {
             var snippet = "object-fit : cover";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("object-fit", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsAnimatable);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("cover", property.Value);
+            Assert.That(property.Name, Is.EqualTo("object-fit"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsAnimatable, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("cover"));
         }
 
         [Test]
@@ -62,12 +62,12 @@
         {
             var snippet = "object-fit : contain";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("object-fit", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsAnimatable);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("contain", property.Value);
+            Assert.That(property.Name, Is.EqualTo("object-fit"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsAnimatable, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("contain"));
         }
 
         [Test]
@@ -75,12 +75,12 @@
         {
             var snippet = "object-position : center";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("object-position", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsTrue(property.IsAnimatable);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("center", property.Value);
+            Assert.That(property.Name, Is.EqualTo("object-position"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsAnimatable, Is.True);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("center"));
         }
 
         [Test]
@@ -88,11 +88,11 @@
         {
             var snippet = "object-position : top-left";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("object-position", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsTrue(property.IsAnimatable);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsFalse(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("object-position"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsAnimatable, Is.True);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.False);
         }
 
         [Test]
@@ -100,12 +100,12 @@
         {
             var snippet = "object-position : top left";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("object-position", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsTrue(property.IsAnimatable);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("left top", property.Value);
+            Assert.That(property.Name, Is.EqualTo("object-position"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsAnimatable, Is.True);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("left top"));
         }
 
         [Test]
@@ -113,12 +113,12 @@
         {
             var snippet = "object-position : 50%   50% ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("object-position", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsTrue(property.IsAnimatable);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("center", property.Value);
+            Assert.That(property.Name, Is.EqualTo("object-position"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsAnimatable, Is.True);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("center"));
         }
 
         [Test]
@@ -126,12 +126,12 @@
         {
             var snippet = "object-position : left  30px";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("object-position", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsTrue(property.IsAnimatable);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("0 30px", property.Value);
+            Assert.That(property.Name, Is.EqualTo("object-position"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsAnimatable, Is.True);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("0 30px"));
         }
     }
 }

--- a/src/AngleSharp.Css.Tests/Declarations/CssOutlineProperty.cs
+++ b/src/AngleSharp.Css.Tests/Declarations/CssOutlineProperty.cs
@@ -11,11 +11,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "outline-style   :  dotTED";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("outline-style", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("dotted", property.Value);
+            Assert.That(property.Name, Is.EqualTo("outline-style"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("dotted"));
         }
 
         [Test]
@@ -23,11 +23,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "outline-style   :  solid";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("outline-style", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("solid", property.Value);
+            Assert.That(property.Name, Is.EqualTo("outline-style"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("solid"));
         }
 
         [Test]
@@ -35,10 +35,10 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "outline-style   :  no";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("outline-style", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsFalse(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("outline-style"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.False);
         }
 
         [Test]
@@ -46,11 +46,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "outline-color :  invert ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("outline-color", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("invert", property.Value);
+            Assert.That(property.Name, Is.EqualTo("outline-color"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("invert"));
         }
 
         [Test]
@@ -58,11 +58,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "outline-color :  hsl(320, 80%, 50%) ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("outline-color", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("rgba(230, 25, 162, 1)", property.Value);
+            Assert.That(property.Name, Is.EqualTo("outline-color"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("rgba(230, 25, 162, 1)"));
         }
 
         [Test]
@@ -70,11 +70,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "outline-color :  #0000FF ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("outline-color", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("rgba(0, 0, 255, 1)", property.Value);
+            Assert.That(property.Name, Is.EqualTo("outline-color"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("rgba(0, 0, 255, 1)"));
         }
 
         [Test]
@@ -82,11 +82,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "outline-color :  red ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("outline-color", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("rgba(255, 0, 0, 1)", property.Value);
+            Assert.That(property.Name, Is.EqualTo("outline-color"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("rgba(255, 0, 0, 1)"));
         }
 
         [Test]
@@ -94,10 +94,10 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "outline-color :  blau ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("outline-color", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsFalse(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("outline-color"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.False);
         }
 
         [Test]
@@ -105,11 +105,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "outline-width :  thin !important";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("outline-width", property.Name);
-            Assert.IsTrue(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("1px", property.Value);
+            Assert.That(property.Name, Is.EqualTo("outline-width"));
+            Assert.That(property.IsImportant, Is.True);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("1px"));
         }
 
         [Test]
@@ -117,10 +117,10 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "outline-width :  3";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("outline-width", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsFalse(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("outline-width"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.False);
         }
 
         [Test]
@@ -128,11 +128,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "outline-width :  0.1em";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("outline-width", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("0.1em", property.Value);
+            Assert.That(property.Name, Is.EqualTo("outline-width"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("0.1em"));
         }
 
         [Test]
@@ -140,11 +140,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "outline :  thin";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("outline", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("1px", property.Value);
+            Assert.That(property.Name, Is.EqualTo("outline"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("1px"));
         }
 
         [Test]
@@ -152,11 +152,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "outline :  thin   invert";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("outline", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("1px invert", property.Value);
+            Assert.That(property.Name, Is.EqualTo("outline"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("1px invert"));
         }
 
         [Test]
@@ -164,11 +164,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "outline :  dotted 0.3em rgb(255, 255, 255)";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("outline", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("0.3em dotted rgba(255, 255, 255, 1)", property.Value);
+            Assert.That(property.Name, Is.EqualTo("outline"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("0.3em dotted rgba(255, 255, 255, 1)"));
         }
 
         [Test]
@@ -176,7 +176,7 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "outline :  dotted #123456 rgb(255, 255, 255)";
             var property = ParseDeclaration(snippet);
-            Assert.IsFalse(property.HasValue);
+            Assert.That(property.HasValue, Is.False);
         }
 
         [Test]
@@ -184,11 +184,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "outline :  1px solid #000";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("outline", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("1px solid rgba(0, 0, 0, 1)", property.Value);
+            Assert.That(property.Name, Is.EqualTo("outline"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("1px solid rgba(0, 0, 0, 1)"));
         }
 
         [Test]
@@ -196,11 +196,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "outline :  solid black 1px";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("outline", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("1px solid rgba(0, 0, 0, 1)", property.Value);
+            Assert.That(property.Name, Is.EqualTo("outline"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("1px solid rgba(0, 0, 0, 1)"));
         }
     }
 }

--- a/src/AngleSharp.Css.Tests/Declarations/CssPaddingProperty.cs
+++ b/src/AngleSharp.Css.Tests/Declarations/CssPaddingProperty.cs
@@ -11,11 +11,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "padding-left: 15px ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("padding-left", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("15px", property.Value);
+            Assert.That(property.Name, Is.EqualTo("padding-left"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("15px"));
         }
 
         [Test]
@@ -23,11 +23,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "padding-right: 3em!important";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("padding-right", property.Name);
-            Assert.IsTrue(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("3em", property.Value);
+            Assert.That(property.Name, Is.EqualTo("padding-right"));
+            Assert.That(property.IsImportant, Is.True);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("3em"));
         }
 
         [Test]
@@ -35,11 +35,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "padding-top: 4% ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("padding-top", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("4%", property.Value);
+            Assert.That(property.Name, Is.EqualTo("padding-top"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("4%"));
         }
 
         [Test]
@@ -47,11 +47,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "padding-bottom: 0 ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("padding-bottom", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("0", property.Value);
+            Assert.That(property.Name, Is.EqualTo("padding-bottom"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("0"));
         }
 
         [Test]
@@ -59,11 +59,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "padding: 0 ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("padding", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("0", property.Value);
+            Assert.That(property.Name, Is.EqualTo("padding"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("0"));
         }
 
         [Test]
@@ -71,11 +71,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "padding: 25% ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("padding", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("25%", property.Value);
+            Assert.That(property.Name, Is.EqualTo("padding"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("25%"));
         }
 
         [Test]
@@ -83,11 +83,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "padding: 10px 3em ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("padding", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("10px 3em", property.Value);
+            Assert.That(property.Name, Is.EqualTo("padding"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("10px 3em"));
         }
 
         [Test]
@@ -95,7 +95,7 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "padding: auto ";
             var property = ParseDeclaration(snippet);
-            Assert.IsFalse(property.HasValue);
+            Assert.That(property.HasValue, Is.False);
         }
 
         [Test]
@@ -103,11 +103,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "padding: 10px 3em 5px";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("padding", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("10px 3em 5px", property.Value);
+            Assert.That(property.Name, Is.EqualTo("padding"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("10px 3em 5px"));
         }
 
         [Test]
@@ -115,11 +115,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "padding: 10px 5% 8px 2% ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("padding", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("10px 5% 8px 2%", property.Value);
+            Assert.That(property.Name, Is.EqualTo("padding"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("10px 5% 8px 2%"));
         }
 
         [Test]
@@ -127,7 +127,7 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "padding: 10px 5% 8px 2% 3px";
             var property = ParseDeclaration(snippet);
-            Assert.IsFalse(property.HasValue);
+            Assert.That(property.HasValue, Is.False);
         }
 
         [Test]
@@ -137,7 +137,7 @@ namespace AngleSharp.Css.Tests.Declarations
             var expected = ".centered { padding: 2.5em 0 2em }";
             var result = ParseRule(snippet);
             var actual = result.CssText;
-            Assert.AreEqual(expected, actual);
+            Assert.That(actual, Is.EqualTo(expected));
         }
     }
 }

--- a/src/AngleSharp.Css.Tests/Declarations/CssProperty.cs
+++ b/src/AngleSharp.Css.Tests/Declarations/CssProperty.cs
@@ -12,11 +12,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "break-after:avoid";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("break-after", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.AreEqual("avoid", property.Value);
+            Assert.That(property.Name, Is.EqualTo("break-after"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.Value, Is.EqualTo("avoid"));
         }
 
         [Test]
@@ -24,11 +24,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "page-break-after:avoid";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("page-break-after", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.AreEqual("avoid", property.Value);
+            Assert.That(property.Name, Is.EqualTo("page-break-after"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.Value, Is.EqualTo("avoid"));
         }
 
         [Test]
@@ -36,11 +36,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "break-after:Page";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("break-after", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.AreEqual("page", property.Value);
+            Assert.That(property.Name, Is.EqualTo("break-after"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.Value, Is.EqualTo("page"));
         }
 
         [Test]
@@ -48,10 +48,10 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "page-break-after:avoid-column";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("page-break-after", property.Name);
-            Assert.IsFalse(property.HasValue);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
+            Assert.That(property.Name, Is.EqualTo("page-break-after"));
+            Assert.That(property.HasValue, Is.False);
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
         }
 
         [Test]
@@ -59,11 +59,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "break-after:avoid-column";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("break-after", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.AreEqual("avoid-column", property.Value);
+            Assert.That(property.Name, Is.EqualTo("break-after"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.Value, Is.EqualTo("avoid-column"));
         }
 
         [Test]
@@ -71,11 +71,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "break-before:AUTO";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("break-before", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.AreEqual("auto", property.Value);
+            Assert.That(property.Name, Is.EqualTo("break-before"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.Value, Is.EqualTo("auto"));
         }
 
         [Test]
@@ -83,11 +83,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "page-break-before:AUTO";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("page-break-before", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.AreEqual("auto", property.Value);
+            Assert.That(property.Name, Is.EqualTo("page-break-before"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.Value, Is.EqualTo("auto"));
         }
 
         [Test]
@@ -95,11 +95,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "page-break-before:left";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("page-break-before", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.AreEqual("left", property.Value);
+            Assert.That(property.Name, Is.EqualTo("page-break-before"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.Value, Is.EqualTo("left"));
         }
 
         [Test]
@@ -107,9 +107,9 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "break-before:whatever";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("break-before", property.Name);
-            Assert.IsFalse(property.HasValue);
-            Assert.IsFalse(property.IsImportant);
+            Assert.That(property.Name, Is.EqualTo("break-before"));
+            Assert.That(property.HasValue, Is.False);
+            Assert.That(property.IsImportant, Is.False);
         }
 
         [Test]
@@ -117,9 +117,9 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "break-inside:page";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("break-inside", property.Name);
-            Assert.IsFalse(property.HasValue);
-            Assert.IsFalse(property.IsImportant);
+            Assert.That(property.Name, Is.EqualTo("break-inside"));
+            Assert.That(property.HasValue, Is.False);
+            Assert.That(property.IsImportant, Is.False);
             Assert.IsNotNull(property);
         }
 
@@ -128,11 +128,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "break-inside:avoid-REGION";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("break-inside", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.AreEqual("avoid-region", property.Value);
+            Assert.That(property.Name, Is.EqualTo("break-inside"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.Value, Is.EqualTo("avoid-region"));
         }
 
         [Test]
@@ -140,11 +140,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "page-break-inside:avoid";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("page-break-inside", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.AreEqual("avoid", property.Value);
+            Assert.That(property.Name, Is.EqualTo("page-break-inside"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.Value, Is.EqualTo("avoid"));
         }
 
         [Test]
@@ -152,11 +152,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "page-break-inside:AUTO";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("page-break-inside", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.AreEqual("auto", property.Value);
+            Assert.That(property.Name, Is.EqualTo("page-break-inside"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.Value, Is.EqualTo("auto"));
         }
 
         [Test]
@@ -164,11 +164,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "clear:left";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("clear", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.AreEqual("left", property.Value);
+            Assert.That(property.Name, Is.EqualTo("clear"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.Value, Is.EqualTo("left"));
         }
 
         [Test]
@@ -176,11 +176,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "clear:both";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("clear", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.AreEqual("both", property.Value);
+            Assert.That(property.Name, Is.EqualTo("clear"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.Value, Is.EqualTo("both"));
         }
 
         [Test]
@@ -188,10 +188,10 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "clear:inherit";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("clear", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.IsTrue(property.IsInherited);
-            Assert.IsFalse(property.IsImportant);
+            Assert.That(property.Name, Is.EqualTo("clear"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.IsInherited, Is.True);
+            Assert.That(property.IsImportant, Is.False);
             Assert.IsNotNull(property);
         }
 
@@ -200,9 +200,9 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "clear:yes";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("clear", property.Name);
-            Assert.IsFalse(property.HasValue);
-            Assert.IsFalse(property.IsImportant);
+            Assert.That(property.Name, Is.EqualTo("clear"));
+            Assert.That(property.HasValue, Is.False);
+            Assert.That(property.IsImportant, Is.False);
             Assert.IsNotNull(property);
         }
 
@@ -211,11 +211,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "position:absolute";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("position", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.AreEqual("absolute", property.Value);
+            Assert.That(property.Name, Is.EqualTo("position"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.Value, Is.EqualTo("absolute"));
         }
 
         [Test]
@@ -223,11 +223,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "display:   block ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("display", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.AreEqual("block", property.Value);
+            Assert.That(property.Name, Is.EqualTo("display"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.Value, Is.EqualTo("block"));
         }
 
         [Test]
@@ -235,11 +235,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "visibility:collapse";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("visibility", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.AreEqual("collapse", property.Value);
+            Assert.That(property.Name, Is.EqualTo("visibility"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.Value, Is.EqualTo("collapse"));
         }
 
         [Test]
@@ -247,11 +247,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "VISIBILITY:HIDDEN";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("visibility", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.AreEqual("hidden", property.Value);
+            Assert.That(property.Name, Is.EqualTo("visibility"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.Value, Is.EqualTo("hidden"));
         }
 
         [Test]
@@ -259,11 +259,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "overflow:auto";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("overflow", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.AreEqual("auto", property.Value);
+            Assert.That(property.Name, Is.EqualTo("overflow"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.Value, Is.EqualTo("auto"));
         }
 
         [Test]
@@ -271,11 +271,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "table-layout: fiXed";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("table-layout", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.AreEqual("fixed", property.Value);
+            Assert.That(property.Name, Is.EqualTo("table-layout"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.Value, Is.EqualTo("fixed"));
         }
 
         [Test]
@@ -283,11 +283,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "box-shadow:  5px 4px";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("box-shadow", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("5px 4px", property.Value);
+            Assert.That(property.Name, Is.EqualTo("box-shadow"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("5px 4px"));
         }
 
         [Test]
@@ -295,11 +295,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "box-shadow: inset 5px 4px";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("box-shadow", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("inset 5px 4px", property.Value);
+            Assert.That(property.Name, Is.EqualTo("box-shadow"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("inset 5px 4px"));
         }
 
         [Test]
@@ -307,11 +307,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "box-shadow: NONE";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("box-shadow", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("none", property.Value);
+            Assert.That(property.Name, Is.EqualTo("box-shadow"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("none"));
         }
 
         [Test]
@@ -319,11 +319,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "box-shadow: 60px -16px teal";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("box-shadow", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("60px -16px rgba(0, 128, 128, 1)", property.Value);
+            Assert.That(property.Name, Is.EqualTo("box-shadow"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("60px -16px rgba(0, 128, 128, 1)"));
         }
 
         [Test]
@@ -331,11 +331,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "box-shadow: 10px 5px 5px black";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("box-shadow", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("10px 5px 5px rgba(0, 0, 0, 1)", property.Value);
+            Assert.That(property.Name, Is.EqualTo("box-shadow"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("10px 5px 5px rgba(0, 0, 0, 1)"));
         }
 
         [Test]
@@ -343,11 +343,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "box-shadow: 3px 3px red, -1em 0 0.4em olive";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("box-shadow", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("3px 3px rgba(255, 0, 0, 1), -1em 0 0.4em rgba(128, 128, 0, 1)", property.Value);
+            Assert.That(property.Name, Is.EqualTo("box-shadow"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("3px 3px rgba(255, 0, 0, 1), -1em 0 0.4em rgba(128, 128, 0, 1)"));
         }
 
         [Test]
@@ -355,11 +355,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "box-shadow: inset 5em 1em gold";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("box-shadow", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("inset 5em 1em rgba(255, 215, 0, 1)", property.Value);
+            Assert.That(property.Name, Is.EqualTo("box-shadow"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("inset 5em 1em rgba(255, 215, 0, 1)"));
         }
 
         [Test]
@@ -367,11 +367,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "box-shadow: 0 0 1em gold";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("box-shadow", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("0 0 1em rgba(255, 215, 0, 1)", property.Value);
+            Assert.That(property.Name, Is.EqualTo("box-shadow"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("0 0 1em rgba(255, 215, 0, 1)"));
         }
 
         [Test]
@@ -379,11 +379,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "box-shadow: inset  0 0 1em gold";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("box-shadow", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("inset 0 0 1em rgba(255, 215, 0, 1)", property.Value);
+            Assert.That(property.Name, Is.EqualTo("box-shadow"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("inset 0 0 1em rgba(255, 215, 0, 1)"));
         }
 
         [Test]
@@ -391,11 +391,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "box-shadow: inset  0 0 1em  gold   ,  0 0   1em   red !important";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("box-shadow", property.Name);
-            Assert.IsTrue(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("inset 0 0 1em rgba(255, 215, 0, 1), 0 0 1em rgba(255, 0, 0, 1)", property.Value);
+            Assert.That(property.Name, Is.EqualTo("box-shadow"));
+            Assert.That(property.IsImportant, Is.True);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("inset 0 0 1em rgba(255, 215, 0, 1), 0 0 1em rgba(255, 0, 0, 1)"));
         }
 
         [Test]
@@ -403,11 +403,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "box-shadow:  5px 4px #000";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("box-shadow", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("5px 4px rgba(0, 0, 0, 1)", property.Value);
+            Assert.That(property.Name, Is.EqualTo("box-shadow"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("5px 4px rgba(0, 0, 0, 1)"));
         }
 
         [Test]
@@ -415,11 +415,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "box-shadow:  5px 4px 2px #000";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("box-shadow", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("5px 4px 2px rgba(0, 0, 0, 1)", property.Value);
+            Assert.That(property.Name, Is.EqualTo("box-shadow"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("5px 4px 2px rgba(0, 0, 0, 1)"));
         }
 
         [Test]
@@ -427,11 +427,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "box-shadow:  INITIAL";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("box-shadow", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("initial", property.Value);
+            Assert.That(property.Name, Is.EqualTo("box-shadow"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("initial"));
         }
 
         [Test]
@@ -439,10 +439,10 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "box-shadow:  5px 4px 2px 1px 3px #f00";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("box-shadow", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsFalse(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("box-shadow"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.False);
         }
 
         [Test]
@@ -450,11 +450,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "clip: rect( 2px, 3em, 1in, 0cm )";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("clip", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("rect(2px, 3em, 1in, 0)", property.Value);
+            Assert.That(property.Name, Is.EqualTo("clip"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("rect(2px, 3em, 1in, 0)"));
         }
 
         [Test]
@@ -462,11 +462,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "clip: rect( 2px 3em 1in 0cm )";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("clip", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("rect(2px, 3em, 1in, 0)", property.Value);
+            Assert.That(property.Name, Is.EqualTo("clip"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("rect(2px, 3em, 1in, 0)"));
         }
 
         [Test]
@@ -474,11 +474,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "clip: rect(0, 0, 0, 0)";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("clip", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("rect(0, 0, 0, 0)", property.Value);
+            Assert.That(property.Name, Is.EqualTo("clip"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("rect(0, 0, 0, 0)"));
         }
 
         [Test]
@@ -486,10 +486,10 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "clip: rect(0, 0, 0 0)";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("clip", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsFalse(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("clip"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.False);
         }
 
         [Test]
@@ -497,10 +497,10 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "clip: rect(2px, 1cm, 5mm)";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("clip", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsFalse(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("clip"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.False);
         }
 
         [Test]
@@ -508,10 +508,10 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "clip: rect(1em)";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("clip", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsFalse(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("clip"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.False);
         }
 
         [Test]
@@ -519,11 +519,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "cursor: DEFAULT";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("cursor", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("default", property.Value);
+            Assert.That(property.Name, Is.EqualTo("cursor"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("default"));
         }
 
         [Test]
@@ -531,11 +531,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "cursor: auto";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("cursor", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("auto", property.Value);
+            Assert.That(property.Name, Is.EqualTo("cursor"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("auto"));
         }
 
         [Test]
@@ -543,11 +543,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "cursor  : zoom-out";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("cursor", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("zoom-out", property.Value);
+            Assert.That(property.Name, Is.EqualTo("cursor"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("zoom-out"));
         }
 
         [Test]
@@ -555,10 +555,10 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "cursor  : url(foo.png)";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("cursor", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsTrue(property.IsInherited);
-            Assert.IsFalse(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("cursor"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.True);
+            Assert.That(property.HasValue, Is.False);
         }
 
         [Test]
@@ -566,11 +566,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "cursor  : url(foo.png), default";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("cursor", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("url(\"foo.png\"), default", property.Value);
+            Assert.That(property.Name, Is.EqualTo("cursor"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("url(\"foo.png\"), default"));
         }
 
         [Test]
@@ -578,11 +578,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "cursor  : url(foo.png) 0 5, auto";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("cursor", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("url(\"foo.png\") 0 5, auto", property.Value);
+            Assert.That(property.Name, Is.EqualTo("cursor"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("url(\"foo.png\") 0 5, auto"));
         }
 
         [Test]
@@ -590,10 +590,10 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "cursor  : url(foo.png) 0 5";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("cursor", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsTrue(property.IsInherited);
-            Assert.IsFalse(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("cursor"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.True);
+            Assert.That(property.HasValue, Is.False);
         }
 
         [Test]
@@ -601,11 +601,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "cursor  : url(foo.png), url(master.png), url(more.png), wait";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("cursor", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("url(\"foo.png\"), url(\"master.png\"), url(\"more.png\"), wait", property.Value);
+            Assert.That(property.Name, Is.EqualTo("cursor"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("url(\"foo.png\"), url(\"master.png\"), url(\"more.png\"), wait"));
         }
 
         [Test]
@@ -613,11 +613,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "color : #123456";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("color", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("rgba(18, 52, 86, 1)", property.Value);
+            Assert.That(property.Name, Is.EqualTo("color"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("rgba(18, 52, 86, 1)"));
         }
 
         [Test]
@@ -625,11 +625,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "color : rgb(121, 181, 201)";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("color", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("rgba(121, 181, 201, 1)", property.Value);
+            Assert.That(property.Name, Is.EqualTo("color"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("rgba(121, 181, 201, 1)"));
         }
 
         [Test]
@@ -637,11 +637,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "color : rgba(255, 255, 201, 0.7)";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("color", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("rgba(255, 255, 201, 0.7)", property.Value);
+            Assert.That(property.Name, Is.EqualTo("color"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("rgba(255, 255, 201, 0.7)"));
         }
 
         [Test]
@@ -649,11 +649,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "color : red";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("color", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("rgba(255, 0, 0, 1)", property.Value);
+            Assert.That(property.Name, Is.EqualTo("color"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("rgba(255, 0, 0, 1)"));
         }
 
         [Test]
@@ -661,11 +661,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "color : BLUE";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("color", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("rgba(0, 0, 255, 1)", property.Value);
+            Assert.That(property.Name, Is.EqualTo("color"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("rgba(0, 0, 255, 1)"));
         }
 
         [Test]
@@ -673,10 +673,10 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "color : horse";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("color", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsTrue(property.IsInherited);
-            Assert.IsFalse(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("color"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.True);
+            Assert.That(property.HasValue, Is.False);
         }
 
         [Test]
@@ -684,11 +684,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "orphans : 0 ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("orphans", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("0", property.Value);
+            Assert.That(property.Name, Is.EqualTo("orphans"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("0"));
         }
 
         [Test]
@@ -696,11 +696,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "orphans : 2 ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("orphans", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("2", property.Value);
+            Assert.That(property.Name, Is.EqualTo("orphans"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("2"));
         }
 
         [Test]
@@ -708,10 +708,10 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "orphans : -2 ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("orphans", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsTrue(property.IsInherited);
-            Assert.IsFalse(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("orphans"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.True);
+            Assert.That(property.HasValue, Is.False);
         }
 
         [Test]
@@ -719,10 +719,10 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "orphans : 1.5 ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("orphans", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsTrue(property.IsInherited);
-            Assert.IsFalse(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("orphans"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.True);
+            Assert.That(property.HasValue, Is.False);
         }
 
         [Test]
@@ -730,10 +730,10 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "box-decoration-break : 1.5 ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("box-decoration-break", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsFalse(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("box-decoration-break"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.False);
         }
 
         [Test]
@@ -741,11 +741,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "box-decoration-break : slice ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("box-decoration-break", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("slice", property.Value);
+            Assert.That(property.Name, Is.EqualTo("box-decoration-break"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("slice"));
         }
 
         [Test]
@@ -753,11 +753,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "box-decoration-break : Clone ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("box-decoration-break", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("clone", property.Value);
+            Assert.That(property.Name, Is.EqualTo("box-decoration-break"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("clone"));
         }
 
         [Test]
@@ -765,11 +765,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "box-decoration-break : inherit!important ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("box-decoration-break", property.Name);
-            Assert.IsTrue(property.IsImportant);
-            Assert.IsTrue(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("inherit", property.Value);
+            Assert.That(property.Name, Is.EqualTo("box-decoration-break"));
+            Assert.That(property.IsImportant, Is.True);
+            Assert.That(property.IsInherited, Is.True);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("inherit"));
         }
 
         [Test]
@@ -777,11 +777,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "content : normal ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("content", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("normal", property.Value);
+            Assert.That(property.Name, Is.EqualTo("content"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("normal"));
         }
 
         [Test]
@@ -789,11 +789,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "content : noNe ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("content", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("none", property.Value);
+            Assert.That(property.Name, Is.EqualTo("content"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("none"));
         }
 
         [Test]
@@ -801,11 +801,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "content : 'hi' ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("content", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("\"hi\"", property.Value);
+            Assert.That(property.Name, Is.EqualTo("content"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("\"hi\""));
         }
 
         [Test]
@@ -813,11 +813,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "content : no-open-quote no-close-quote ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("content", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("no-open-quote no-close-quote", property.Value);
+            Assert.That(property.Name, Is.EqualTo("content"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("no-open-quote no-close-quote"));
         }
 
         [Test]
@@ -825,11 +825,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "content : url(test.html) ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("content", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("url(\"test.html\")", property.Value);
+            Assert.That(property.Name, Is.EqualTo("content"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("url(\"test.html\")"));
         }
 
         [Test]
@@ -837,11 +837,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "content : 'how' 'are' 'you' ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("content", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("\"how\" \"are\" \"you\"", property.Value);
+            Assert.That(property.Name, Is.EqualTo("content"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("\"how\" \"are\" \"you\""));
         }
 
         [Test]
@@ -849,10 +849,10 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "quotes : '\"' ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("quotes", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsTrue(property.IsInherited);
-            Assert.IsFalse(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("quotes"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.True);
+            Assert.That(property.HasValue, Is.False);
         }
 
         [Test]
@@ -860,11 +860,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "quotes : '\"' '\"' ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("quotes", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("\"\\\"\" \"\\\"\"", property.Value);
+            Assert.That(property.Name, Is.EqualTo("quotes"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("\"\\\"\" \"\\\"\""));
         }
 
         [Test]
@@ -872,10 +872,10 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "quotes : \"'\"";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("quotes", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsTrue(property.IsInherited);
-            Assert.IsFalse(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("quotes"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.True);
+            Assert.That(property.HasValue, Is.False);
         }
 
         [Test]
@@ -883,11 +883,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "quotes : '\"' '\"' '`' '´' ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("quotes", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("\"\\\"\" \"\\\"\" \"`\" \"´\"", property.Value);
+            Assert.That(property.Name, Is.EqualTo("quotes"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("\"\\\"\" \"\\\"\" \"`\" \"´\""));
         }
 
         [Test]
@@ -895,10 +895,10 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "quotes : '\"' '\"' '`' ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("quotes", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsTrue(property.IsInherited);
-            Assert.IsFalse(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("quotes"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.True);
+            Assert.That(property.HasValue, Is.False);
         }
 
         [Test]
@@ -906,11 +906,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "quotes : none";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("quotes", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("none", property.Value);
+            Assert.That(property.Name, Is.EqualTo("quotes"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("none"));
         }
 
         [Test]
@@ -918,10 +918,10 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "quotes : 'none'";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("quotes", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsTrue(property.IsInherited);
-            Assert.IsFalse(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("quotes"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.True);
+            Assert.That(property.HasValue, Is.False);
         }
 
         [Test]
@@ -929,10 +929,10 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "quotes : normal ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("quotes", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsTrue(property.IsInherited);
-            Assert.IsFalse(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("quotes"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.True);
+            Assert.That(property.HasValue, Is.False);
         }
 
         [Test]
@@ -940,11 +940,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "widows: 0";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("widows", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("0", property.Value);
+            Assert.That(property.Name, Is.EqualTo("widows"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("0"));
         }
 
         [Test]
@@ -952,11 +952,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "widows: 3";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("widows", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("3", property.Value);
+            Assert.That(property.Name, Is.EqualTo("widows"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("3"));
         }
 
         [Test]
@@ -964,10 +964,10 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "widows: 5px";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("widows", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsTrue(property.IsInherited);
-            Assert.IsFalse(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("widows"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.True);
+            Assert.That(property.HasValue, Is.False);
         }
 
         [Test]
@@ -975,11 +975,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "unicode-BIDI: Embed";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("unicode-bidi", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("embed", property.Value);
+            Assert.That(property.Name, Is.EqualTo("unicode-bidi"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("embed"));
         }
 
         [Test]
@@ -987,11 +987,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "unicode-Bidi: isolate";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("unicode-bidi", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("isolate", property.Value);
+            Assert.That(property.Name, Is.EqualTo("unicode-bidi"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("isolate"));
         }
 
         [Test]
@@ -999,11 +999,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "unicode-Bidi: Bidi-Override";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("unicode-bidi", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("bidi-override", property.Value);
+            Assert.That(property.Name, Is.EqualTo("unicode-bidi"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("bidi-override"));
         }
 
         [Test]
@@ -1011,11 +1011,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "unicode-Bidi: PLAINTEXT";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("unicode-bidi", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("plaintext", property.Value);
+            Assert.That(property.Name, Is.EqualTo("unicode-bidi"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("plaintext"));
         }
 
         [Test]
@@ -1023,10 +1023,10 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "unicode-bidi: none";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("unicode-bidi", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsFalse(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("unicode-bidi"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.False);
         }
 
         [Test]
@@ -1037,7 +1037,7 @@ namespace AngleSharp.Css.Tests.Declarations
             var border = factory.Create("border");
             var color = factory.Create("color");
 
-            Assert.AreEqual(ValueConverters.Any, invalid.Converter);
+            Assert.That(invalid.Converter, Is.EqualTo(ValueConverters.Any));
             Assert.AreNotEqual(ValueConverters.Any, border.Converter);
             Assert.AreNotEqual(ValueConverters.Any, color.Converter);
         }
@@ -1047,7 +1047,7 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "my-Property: something";
             var property = ParseDeclaration(snippet, new CssParserOptions { IsIncludingUnknownDeclarations = true });
-            Assert.AreEqual("my-property", property.Name);
+            Assert.That(property.Name, Is.EqualTo("my-property"));
         }
     }
 }

--- a/src/AngleSharp.Css.Tests/Declarations/CssResizeProperty.cs
+++ b/src/AngleSharp.Css.Tests/Declarations/CssResizeProperty.cs
@@ -11,12 +11,12 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "resize: none";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("resize", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsAnimatable);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("none", property.Value);
+            Assert.That(property.Name, Is.EqualTo("resize"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsAnimatable, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("none"));
         }
 
         [Test]
@@ -24,11 +24,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "resize: scaledown";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("resize", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsAnimatable);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsFalse(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("resize"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsAnimatable, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.False);
         }
 
         [Test]
@@ -36,12 +36,12 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "resize : both";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("resize", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsAnimatable);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("both", property.Value);
+            Assert.That(property.Name, Is.EqualTo("resize"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsAnimatable, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("both"));
         }
 
         [Test]
@@ -49,12 +49,12 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "resize : horizontal";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("resize", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsAnimatable);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("horizontal", property.Value);
+            Assert.That(property.Name, Is.EqualTo("resize"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsAnimatable, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("horizontal"));
         }
 
         [Test]
@@ -62,12 +62,12 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "resize : vertical";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("resize", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsAnimatable);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("vertical", property.Value);
+            Assert.That(property.Name, Is.EqualTo("resize"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsAnimatable, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("vertical"));
         }
     }
 }

--- a/src/AngleSharp.Css.Tests/Declarations/CssStrokeProperty.cs
+++ b/src/AngleSharp.Css.Tests/Declarations/CssStrokeProperty.cs
@@ -11,11 +11,11 @@ namespace AngleSharp.Css.Tests.Declarations
 		{
 			var snippet = "stroke: red";
 			var property = ParseDeclaration(snippet);
-			Assert.AreEqual("stroke", property.Name);
-			Assert.IsFalse(property.IsImportant);
-			Assert.IsFalse(property.IsInherited);
-			Assert.IsTrue(property.HasValue);
-			Assert.AreEqual("rgba(255, 0, 0, 1)", property.Value);
+			Assert.That(property.Name, Is.EqualTo("stroke"));
+			Assert.That(property.IsImportant, Is.False);
+			Assert.That(property.IsInherited, Is.False);
+			Assert.That(property.HasValue, Is.True);
+			Assert.That(property.Value, Is.EqualTo("rgba(255, 0, 0, 1)"));
 		}
 
 		[Test]
@@ -23,11 +23,11 @@ namespace AngleSharp.Css.Tests.Declarations
 		{
 			var snippet = "stroke: #0F0";
 			var property = ParseDeclaration(snippet);
-			Assert.AreEqual("stroke", property.Name);
-			Assert.IsFalse(property.IsImportant);
-			Assert.IsFalse(property.IsInherited);
-			Assert.IsTrue(property.HasValue);
-			Assert.AreEqual("rgba(0, 255, 0, 1)", property.Value);
+			Assert.That(property.Name, Is.EqualTo("stroke"));
+			Assert.That(property.IsImportant, Is.False);
+			Assert.That(property.IsInherited, Is.False);
+			Assert.That(property.HasValue, Is.True);
+			Assert.That(property.Value, Is.EqualTo("rgba(0, 255, 0, 1)"));
 		}
 
 		[Test]
@@ -35,11 +35,11 @@ namespace AngleSharp.Css.Tests.Declarations
 		{
 			var snippet = "stroke: rgba(1, 1, 1, 0)";
 			var property = ParseDeclaration(snippet);
-			Assert.AreEqual("stroke", property.Name);
-			Assert.IsFalse(property.IsImportant);
-			Assert.IsFalse(property.IsInherited);
-			Assert.IsTrue(property.HasValue);
-			Assert.AreEqual("rgba(1, 1, 1, 0)", property.Value);
+			Assert.That(property.Name, Is.EqualTo("stroke"));
+			Assert.That(property.IsImportant, Is.False);
+			Assert.That(property.IsInherited, Is.False);
+			Assert.That(property.HasValue, Is.True);
+			Assert.That(property.Value, Is.EqualTo("rgba(1, 1, 1, 0)"));
 		}
 
 		[Test]
@@ -47,11 +47,11 @@ namespace AngleSharp.Css.Tests.Declarations
 		{
 			var snippet = "stroke: rgb(1, 255, 100)";
 			var property = ParseDeclaration(snippet);
-			Assert.AreEqual("stroke", property.Name);
-			Assert.IsFalse(property.IsImportant);
-			Assert.IsFalse(property.IsInherited);
-			Assert.IsTrue(property.HasValue);
-			Assert.AreEqual("rgba(1, 255, 100, 1)", property.Value);
+			Assert.That(property.Name, Is.EqualTo("stroke"));
+			Assert.That(property.IsImportant, Is.False);
+			Assert.That(property.IsInherited, Is.False);
+			Assert.That(property.HasValue, Is.True);
+			Assert.That(property.Value, Is.EqualTo("rgba(1, 255, 100, 1)"));
 		}
 
 		[Test]
@@ -59,11 +59,11 @@ namespace AngleSharp.Css.Tests.Declarations
 		{
 			var snippet = "stroke: none";
 			var property = ParseDeclaration(snippet);
-			Assert.AreEqual("stroke", property.Name);
-			Assert.IsFalse(property.IsImportant);
-			Assert.IsFalse(property.IsInherited);
-			Assert.IsTrue(property.HasValue);
-			Assert.AreEqual("none", property.Value);
+			Assert.That(property.Name, Is.EqualTo("stroke"));
+			Assert.That(property.IsImportant, Is.False);
+			Assert.That(property.IsInherited, Is.False);
+			Assert.That(property.HasValue, Is.True);
+			Assert.That(property.Value, Is.EqualTo("none"));
 		}
 
 		[Test]
@@ -71,10 +71,10 @@ namespace AngleSharp.Css.Tests.Declarations
 		{
 			var snippet = "stroke: red red";
 			var property = ParseDeclaration(snippet);
-			Assert.AreEqual("stroke", property.Name);
-			Assert.IsFalse(property.IsImportant);
-			Assert.IsFalse(property.IsInherited);
-			Assert.IsFalse(property.HasValue);
+			Assert.That(property.Name, Is.EqualTo("stroke"));
+			Assert.That(property.IsImportant, Is.False);
+			Assert.That(property.IsInherited, Is.False);
+			Assert.That(property.HasValue, Is.False);
 		}
 
 		[Test]
@@ -82,11 +82,11 @@ namespace AngleSharp.Css.Tests.Declarations
 		{
 			var snippet = "stroke: url(#linear)";
 			var property = ParseDeclaration(snippet);
-			Assert.AreEqual("stroke", property.Name);
-			Assert.IsFalse(property.IsImportant);
-			Assert.IsFalse(property.IsInherited);
-			Assert.IsTrue(property.HasValue);
-			Assert.AreEqual("url(\"#linear\")", property.Value);
+			Assert.That(property.Name, Is.EqualTo("stroke"));
+			Assert.That(property.IsImportant, Is.False);
+			Assert.That(property.IsInherited, Is.False);
+			Assert.That(property.HasValue, Is.True);
+			Assert.That(property.Value, Is.EqualTo("url(\"#linear\")"));
 		}
 
 
@@ -95,11 +95,11 @@ namespace AngleSharp.Css.Tests.Declarations
 		{
 			var snippet = "stroke-dasharray: 5 5";
 			var property = ParseDeclaration(snippet);
-			Assert.AreEqual("stroke-dasharray", property.Name);
-			Assert.IsFalse(property.IsImportant);
-			Assert.IsFalse(property.IsInherited);
-			Assert.IsTrue(property.HasValue);
-			Assert.AreEqual("5 5", property.Value);
+			Assert.That(property.Name, Is.EqualTo("stroke-dasharray"));
+			Assert.That(property.IsImportant, Is.False);
+			Assert.That(property.IsInherited, Is.False);
+			Assert.That(property.HasValue, Is.True);
+			Assert.That(property.Value, Is.EqualTo("5 5"));
 		}
 
 		[Test]
@@ -107,11 +107,11 @@ namespace AngleSharp.Css.Tests.Declarations
 		{
 			var snippet = "stroke-dasharray: 5px 5em";
 			var property = ParseDeclaration(snippet);
-			Assert.AreEqual("stroke-dasharray", property.Name);
-			Assert.IsFalse(property.IsImportant);
-			Assert.IsFalse(property.IsInherited);
-			Assert.IsTrue(property.HasValue);
-			Assert.AreEqual("5px 5em", property.Value);
+			Assert.That(property.Name, Is.EqualTo("stroke-dasharray"));
+			Assert.That(property.IsImportant, Is.False);
+			Assert.That(property.IsInherited, Is.False);
+			Assert.That(property.HasValue, Is.True);
+			Assert.That(property.Value, Is.EqualTo("5px 5em"));
 		}
 
 		[Test]
@@ -119,11 +119,11 @@ namespace AngleSharp.Css.Tests.Declarations
 		{
 			var snippet = "stroke-dasharray: 1px 2em 3vh 4vw 5 6";
 			var property = ParseDeclaration(snippet);
-			Assert.AreEqual("stroke-dasharray", property.Name);
-			Assert.IsFalse(property.IsImportant);
-			Assert.IsFalse(property.IsInherited);
-			Assert.IsTrue(property.HasValue);
-			Assert.AreEqual("1px 2em 3vh 4vw 5 6", property.Value);
+			Assert.That(property.Name, Is.EqualTo("stroke-dasharray"));
+			Assert.That(property.IsImportant, Is.False);
+			Assert.That(property.IsInherited, Is.False);
+			Assert.That(property.HasValue, Is.True);
+			Assert.That(property.Value, Is.EqualTo("1px 2em 3vh 4vw 5 6"));
 		}
 
 		[Test]
@@ -131,11 +131,11 @@ namespace AngleSharp.Css.Tests.Declarations
 		{
 			var snippet = "stroke-dasharray: none";
 			var property = ParseDeclaration(snippet);
-			Assert.AreEqual("stroke-dasharray", property.Name);
-			Assert.IsFalse(property.IsImportant);
-			Assert.IsFalse(property.IsInherited);
-			Assert.IsTrue(property.HasValue);
-			Assert.AreEqual("none", property.Value);
+			Assert.That(property.Name, Is.EqualTo("stroke-dasharray"));
+			Assert.That(property.IsImportant, Is.False);
+			Assert.That(property.IsInherited, Is.False);
+			Assert.That(property.HasValue, Is.True);
+			Assert.That(property.Value, Is.EqualTo("none"));
 		}
 
 		[Test]
@@ -143,11 +143,11 @@ namespace AngleSharp.Css.Tests.Declarations
 		{
 			var snippet = "stroke-dashoffset: 5px";
 			var property = ParseDeclaration(snippet);
-			Assert.AreEqual("stroke-dashoffset", property.Name);
-			Assert.IsFalse(property.IsImportant);
-			Assert.IsFalse(property.IsInherited);
-			Assert.IsTrue(property.HasValue);
-			Assert.AreEqual("5px", property.Value);
+			Assert.That(property.Name, Is.EqualTo("stroke-dashoffset"));
+			Assert.That(property.IsImportant, Is.False);
+			Assert.That(property.IsInherited, Is.False);
+			Assert.That(property.HasValue, Is.True);
+			Assert.That(property.Value, Is.EqualTo("5px"));
 		}
 
 		[Test]
@@ -155,10 +155,10 @@ namespace AngleSharp.Css.Tests.Declarations
 		{
 			var snippet = "stroke-dashoffset: 5px 5px";
 			var property = ParseDeclaration(snippet);
-			Assert.AreEqual("stroke-dashoffset", property.Name);
-			Assert.IsFalse(property.IsImportant);
-			Assert.IsFalse(property.IsInherited);
-			Assert.IsFalse(property.HasValue);
+			Assert.That(property.Name, Is.EqualTo("stroke-dashoffset"));
+			Assert.That(property.IsImportant, Is.False);
+			Assert.That(property.IsInherited, Is.False);
+			Assert.That(property.HasValue, Is.False);
 		}
 
 		[Test]
@@ -166,11 +166,11 @@ namespace AngleSharp.Css.Tests.Declarations
 		{
 			var snippet = "stroke-dashoffset: 50%";
 			var property = ParseDeclaration(snippet);
-			Assert.AreEqual("stroke-dashoffset", property.Name);
-			Assert.IsFalse(property.IsImportant);
-			Assert.IsFalse(property.IsInherited);
-			Assert.IsTrue(property.HasValue);
-			Assert.AreEqual("50%", property.Value);
+			Assert.That(property.Name, Is.EqualTo("stroke-dashoffset"));
+			Assert.That(property.IsImportant, Is.False);
+			Assert.That(property.IsInherited, Is.False);
+			Assert.That(property.HasValue, Is.True);
+			Assert.That(property.Value, Is.EqualTo("50%"));
 		}
 
 		[Test]
@@ -178,10 +178,10 @@ namespace AngleSharp.Css.Tests.Declarations
 		{
 			var snippet = "stroke-dashoffset: 50% 25%";
 			var property = ParseDeclaration(snippet);
-			Assert.AreEqual("stroke-dashoffset", property.Name);
-			Assert.IsFalse(property.IsImportant);
-			Assert.IsFalse(property.IsInherited);
-			Assert.IsFalse(property.HasValue);
+			Assert.That(property.Name, Is.EqualTo("stroke-dashoffset"));
+			Assert.That(property.IsImportant, Is.False);
+			Assert.That(property.IsInherited, Is.False);
+			Assert.That(property.HasValue, Is.False);
 		}
 
 		[Test]
@@ -189,11 +189,11 @@ namespace AngleSharp.Css.Tests.Declarations
 		{
 			var snippet = "stroke-linecap: butt";
 			var property = ParseDeclaration(snippet);
-			Assert.AreEqual("stroke-linecap", property.Name);
-			Assert.IsFalse(property.IsImportant);
-			Assert.IsFalse(property.IsInherited);
-			Assert.IsTrue(property.HasValue);
-			Assert.AreEqual("butt", property.Value);
+			Assert.That(property.Name, Is.EqualTo("stroke-linecap"));
+			Assert.That(property.IsImportant, Is.False);
+			Assert.That(property.IsInherited, Is.False);
+			Assert.That(property.HasValue, Is.True);
+			Assert.That(property.Value, Is.EqualTo("butt"));
 		}
 
 		[Test]
@@ -201,11 +201,11 @@ namespace AngleSharp.Css.Tests.Declarations
 		{
 			var snippet = "stroke-linecap: round";
 			var property = ParseDeclaration(snippet);
-			Assert.AreEqual("stroke-linecap", property.Name);
-			Assert.IsFalse(property.IsImportant);
-			Assert.IsFalse(property.IsInherited);
-			Assert.IsTrue(property.HasValue);
-			Assert.AreEqual("round", property.Value);
+			Assert.That(property.Name, Is.EqualTo("stroke-linecap"));
+			Assert.That(property.IsImportant, Is.False);
+			Assert.That(property.IsInherited, Is.False);
+			Assert.That(property.HasValue, Is.True);
+			Assert.That(property.Value, Is.EqualTo("round"));
 		}
 
 		[Test]
@@ -213,11 +213,11 @@ namespace AngleSharp.Css.Tests.Declarations
 		{
 			var snippet = "stroke-linecap: square";
 			var property = ParseDeclaration(snippet);
-			Assert.AreEqual("stroke-linecap", property.Name);
-			Assert.IsFalse(property.IsImportant);
-			Assert.IsFalse(property.IsInherited);
-			Assert.IsTrue(property.HasValue);
-			Assert.AreEqual("square", property.Value);
+			Assert.That(property.Name, Is.EqualTo("stroke-linecap"));
+			Assert.That(property.IsImportant, Is.False);
+			Assert.That(property.IsInherited, Is.False);
+			Assert.That(property.HasValue, Is.True);
+			Assert.That(property.Value, Is.EqualTo("square"));
 		}
 
 		[Test]
@@ -225,10 +225,10 @@ namespace AngleSharp.Css.Tests.Declarations
 		{
 			var snippet = "stroke-linecap: none";
 			var property = ParseDeclaration(snippet);
-			Assert.AreEqual("stroke-linecap", property.Name);
-			Assert.IsFalse(property.IsImportant);
-			Assert.IsFalse(property.IsInherited);
-			Assert.IsFalse(property.HasValue);
+			Assert.That(property.Name, Is.EqualTo("stroke-linecap"));
+			Assert.That(property.IsImportant, Is.False);
+			Assert.That(property.IsInherited, Is.False);
+			Assert.That(property.HasValue, Is.False);
 		}
 
 		[Test]
@@ -236,11 +236,11 @@ namespace AngleSharp.Css.Tests.Declarations
 		{
 			var snippet = "stroke-linejoin: miter";
 			var property = ParseDeclaration(snippet);
-			Assert.AreEqual("stroke-linejoin", property.Name);
-			Assert.IsFalse(property.IsImportant);
-			Assert.IsFalse(property.IsInherited);
-			Assert.IsTrue(property.HasValue);
-			Assert.AreEqual("miter", property.Value);
+			Assert.That(property.Name, Is.EqualTo("stroke-linejoin"));
+			Assert.That(property.IsImportant, Is.False);
+			Assert.That(property.IsInherited, Is.False);
+			Assert.That(property.HasValue, Is.True);
+			Assert.That(property.Value, Is.EqualTo("miter"));
 		}
 
 		[Test]
@@ -248,11 +248,11 @@ namespace AngleSharp.Css.Tests.Declarations
 		{
 			var snippet = "stroke-linejoin: round";
 			var property = ParseDeclaration(snippet);
-			Assert.AreEqual("stroke-linejoin", property.Name);
-			Assert.IsFalse(property.IsImportant);
-			Assert.IsFalse(property.IsInherited);
-			Assert.IsTrue(property.HasValue);
-			Assert.AreEqual("round", property.Value);
+			Assert.That(property.Name, Is.EqualTo("stroke-linejoin"));
+			Assert.That(property.IsImportant, Is.False);
+			Assert.That(property.IsInherited, Is.False);
+			Assert.That(property.HasValue, Is.True);
+			Assert.That(property.Value, Is.EqualTo("round"));
 		}
 
 		[Test]
@@ -260,11 +260,11 @@ namespace AngleSharp.Css.Tests.Declarations
 		{
 			var snippet = "stroke-linejoin: bevel";
 			var property = ParseDeclaration(snippet);
-			Assert.AreEqual("stroke-linejoin", property.Name);
-			Assert.IsFalse(property.IsImportant);
-			Assert.IsFalse(property.IsInherited);
-			Assert.IsTrue(property.HasValue);
-			Assert.AreEqual("bevel", property.Value);
+			Assert.That(property.Name, Is.EqualTo("stroke-linejoin"));
+			Assert.That(property.IsImportant, Is.False);
+			Assert.That(property.IsInherited, Is.False);
+			Assert.That(property.HasValue, Is.True);
+			Assert.That(property.Value, Is.EqualTo("bevel"));
 		}
 
 		[Test]
@@ -272,10 +272,10 @@ namespace AngleSharp.Css.Tests.Declarations
         {
 			var snippet = "stroke-linejoin: none";
 			var property = ParseDeclaration(snippet);
-			Assert.AreEqual("stroke-linejoin", property.Name);
-			Assert.IsFalse(property.IsImportant);
-			Assert.IsFalse(property.IsInherited);
-			Assert.IsFalse(property.HasValue);
+			Assert.That(property.Name, Is.EqualTo("stroke-linejoin"));
+			Assert.That(property.IsImportant, Is.False);
+			Assert.That(property.IsInherited, Is.False);
+			Assert.That(property.HasValue, Is.False);
 		}
 
 		[Test]
@@ -283,11 +283,11 @@ namespace AngleSharp.Css.Tests.Declarations
 		{
 			var snippet = "stroke-miterlimit: 2";
 			var property = ParseDeclaration(snippet);
-			Assert.AreEqual("stroke-miterlimit", property.Name);
-			Assert.IsFalse(property.IsImportant);
-			Assert.IsFalse(property.IsInherited);
-			Assert.IsTrue(property.HasValue);
-			Assert.AreEqual("2", property.Value);
+			Assert.That(property.Name, Is.EqualTo("stroke-miterlimit"));
+			Assert.That(property.IsImportant, Is.False);
+			Assert.That(property.IsInherited, Is.False);
+			Assert.That(property.HasValue, Is.True);
+			Assert.That(property.Value, Is.EqualTo("2"));
 		}
 
 		[Test]
@@ -295,10 +295,10 @@ namespace AngleSharp.Css.Tests.Declarations
 		{
 			var snippet = "stroke-miterlimit: 0.5";
 			var property = ParseDeclaration(snippet);
-			Assert.AreEqual("stroke-miterlimit", property.Name);
-			Assert.IsFalse(property.IsImportant);
-			Assert.IsFalse(property.IsInherited);
-			Assert.IsFalse(property.HasValue);
+			Assert.That(property.Name, Is.EqualTo("stroke-miterlimit"));
+			Assert.That(property.IsImportant, Is.False);
+			Assert.That(property.IsInherited, Is.False);
+			Assert.That(property.HasValue, Is.False);
 		}
 
 		[Test]
@@ -306,10 +306,10 @@ namespace AngleSharp.Css.Tests.Declarations
 		{
 			var snippet = "stroke-miterlimit: 2 0.5";
 			var property = ParseDeclaration(snippet);
-			Assert.AreEqual("stroke-miterlimit", property.Name);
-			Assert.IsFalse(property.IsImportant);
-			Assert.IsFalse(property.IsInherited);
-			Assert.IsFalse(property.HasValue);
+			Assert.That(property.Name, Is.EqualTo("stroke-miterlimit"));
+			Assert.That(property.IsImportant, Is.False);
+			Assert.That(property.IsInherited, Is.False);
+			Assert.That(property.HasValue, Is.False);
 		}
 
 		[Test]
@@ -317,11 +317,11 @@ namespace AngleSharp.Css.Tests.Declarations
 		{
 			var snippet = "stroke-opacity: 0.5";
 			var property = ParseDeclaration(snippet);
-			Assert.AreEqual("stroke-opacity", property.Name);
-			Assert.IsFalse(property.IsImportant);
-			Assert.IsFalse(property.IsInherited);
-			Assert.IsTrue(property.HasValue);
-			Assert.AreEqual("0.5", property.Value);
+			Assert.That(property.Name, Is.EqualTo("stroke-opacity"));
+			Assert.That(property.IsImportant, Is.False);
+			Assert.That(property.IsInherited, Is.False);
+			Assert.That(property.HasValue, Is.True);
+			Assert.That(property.Value, Is.EqualTo("0.5"));
 		}
 
 		[Test]
@@ -329,10 +329,10 @@ namespace AngleSharp.Css.Tests.Declarations
 		{
 			var snippet = "stroke-opacity: 0.5 0.5";
 			var property = ParseDeclaration(snippet);
-			Assert.AreEqual("stroke-opacity", property.Name);
-			Assert.IsFalse(property.IsImportant);
-			Assert.IsFalse(property.IsInherited);
-			Assert.IsFalse(property.HasValue);
+			Assert.That(property.Name, Is.EqualTo("stroke-opacity"));
+			Assert.That(property.IsImportant, Is.False);
+			Assert.That(property.IsInherited, Is.False);
+			Assert.That(property.HasValue, Is.False);
 		}
 		
 		[Test]
@@ -340,11 +340,11 @@ namespace AngleSharp.Css.Tests.Declarations
 		{
 			var snippet = "stroke-width: 5px";
 			var property = ParseDeclaration(snippet);
-			Assert.AreEqual("stroke-width", property.Name);
-			Assert.IsFalse(property.IsImportant);
-			Assert.IsFalse(property.IsInherited);
-			Assert.IsTrue(property.HasValue);
-			Assert.AreEqual("5px", property.Value);
+			Assert.That(property.Name, Is.EqualTo("stroke-width"));
+			Assert.That(property.IsImportant, Is.False);
+			Assert.That(property.IsInherited, Is.False);
+			Assert.That(property.HasValue, Is.True);
+			Assert.That(property.Value, Is.EqualTo("5px"));
 		}
 
 
@@ -353,11 +353,11 @@ namespace AngleSharp.Css.Tests.Declarations
 		{
 			var snippet = "stroke-width: 5%";
 			var property = ParseDeclaration(snippet);
-			Assert.AreEqual("stroke-width", property.Name);
-			Assert.IsFalse(property.IsImportant);
-			Assert.IsFalse(property.IsInherited);
-			Assert.IsTrue(property.HasValue);
-			Assert.AreEqual("5%", property.Value);
+			Assert.That(property.Name, Is.EqualTo("stroke-width"));
+			Assert.That(property.IsImportant, Is.False);
+			Assert.That(property.IsInherited, Is.False);
+			Assert.That(property.HasValue, Is.True);
+			Assert.That(property.Value, Is.EqualTo("5%"));
 		}
 
 		[Test]
@@ -365,10 +365,10 @@ namespace AngleSharp.Css.Tests.Declarations
 		{
 			var snippet = "stroke-width: none";
 			var property = ParseDeclaration(snippet);
-			Assert.AreEqual("stroke-width", property.Name);
-			Assert.IsFalse(property.IsImportant);
-			Assert.IsFalse(property.IsInherited);
-			Assert.IsFalse(property.HasValue);
+			Assert.That(property.Name, Is.EqualTo("stroke-width"));
+			Assert.That(property.IsImportant, Is.False);
+			Assert.That(property.IsInherited, Is.False);
+			Assert.That(property.HasValue, Is.False);
 		}
 
         [Test]
@@ -376,11 +376,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "stroke-width: 3";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("stroke-width", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("3", property.Value);
+            Assert.That(property.Name, Is.EqualTo("stroke-width"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("3"));
         }
 	}
 }

--- a/src/AngleSharp.Css.Tests/Declarations/CssTextProperty.cs
+++ b/src/AngleSharp.Css.Tests/Declarations/CssTextProperty.cs
@@ -13,11 +13,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "word-spacing: 0";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("word-spacing", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("0", property.Value);
+            Assert.That(property.Name, Is.EqualTo("word-spacing"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("0"));
         }
 
         [Test]
@@ -25,11 +25,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "word-spacing: .3rem ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("word-spacing", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("0.3rem", property.Value);
+            Assert.That(property.Name, Is.EqualTo("word-spacing"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("0.3rem"));
         }
 
         [Test]
@@ -37,11 +37,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "word-spacing: 0.3em ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("word-spacing", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("0.3em", property.Value);
+            Assert.That(property.Name, Is.EqualTo("word-spacing"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("0.3em"));
         }
 
         [Test]
@@ -49,11 +49,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "word-spacing: normal ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("word-spacing", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("normal", property.Value);
+            Assert.That(property.Name, Is.EqualTo("word-spacing"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("normal"));
         }
 
         [Test]
@@ -61,11 +61,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "text-shadow: 0 0 2px black inset";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("text-shadow", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.AreEqual("inset 0 0 2px rgba(0, 0, 0, 1)", property.Value);
+            Assert.That(property.Name, Is.EqualTo("text-shadow"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.Value, Is.EqualTo("inset 0 0 2px rgba(0, 0, 0, 1)"));
         }
 
         [Test]
@@ -73,11 +73,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "text-shadow: rgba(255,255,255,0.5) 0px 3px 3px";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("text-shadow", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.AreEqual("0 3px 3px rgba(255, 255, 255, 0.5)", property.Value);
+            Assert.That(property.Name, Is.EqualTo("text-shadow"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.Value, Is.EqualTo("0 3px 3px rgba(255, 255, 255, 0.5)"));
         }
 
         [Test]
@@ -88,11 +88,11 @@ namespace AngleSharp.Css.Tests.Declarations
              0px 24px 2px rgba(0,0,0,0.1),
              0px 34px 30px rgba(0,0,0,0.1)";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("text-shadow", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.AreEqual("0 3px rgba(178, 169, 143, 1), 0 14px 10px rgba(0, 0, 0, 0.15), 0 24px 2px rgba(0, 0, 0, 0.1), 0 34px 30px rgba(0, 0, 0, 0.1)", property.Value);
+            Assert.That(property.Name, Is.EqualTo("text-shadow"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.Value, Is.EqualTo("0 3px rgba(178, 169, 143, 1), 0 14px 10px rgba(0, 0, 0, 0.15), 0 24px 2px rgba(0, 0, 0, 0.1), 0 34px 30px rgba(0, 0, 0, 0.1)"));
         }
 
         [Test]
@@ -100,11 +100,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "text-shadow: 4px 3px 0px #fff, 9px 8px 0px rgba(0,0,0,0.15)";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("text-shadow", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.AreEqual("4px 3px rgba(255, 255, 255, 1), 9px 8px rgba(0, 0, 0, 0.15)", property.Value);
+            Assert.That(property.Name, Is.EqualTo("text-shadow"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.Value, Is.EqualTo("4px 3px rgba(255, 255, 255, 1), 9px 8px rgba(0, 0, 0, 0.15)"));
         }
 
         [Test]
@@ -112,11 +112,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "text-shadow: 2px 4px 3px rgba(0,0,0,0.3)";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("text-shadow", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.AreEqual("2px 4px 3px rgba(0, 0, 0, 0.3)", property.Value);
+            Assert.That(property.Name, Is.EqualTo("text-shadow"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.Value, Is.EqualTo("2px 4px 3px rgba(0, 0, 0, 0.3)"));
         }
 
         [Test]
@@ -124,11 +124,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "text-align:justify";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("text-align", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.AreEqual("justify", property.Value);
+            Assert.That(property.Name, Is.EqualTo("text-align"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.Value, Is.EqualTo("justify"));
         }
 
         [Test]
@@ -136,11 +136,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "text-indent:3em";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("text-indent", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.AreEqual("3em", property.Value);
+            Assert.That(property.Name, Is.EqualTo("text-indent"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.Value, Is.EqualTo("3em"));
         }
 
         [Test]
@@ -148,11 +148,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "text-indent:0";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("text-indent", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.AreEqual("0", property.Value);
+            Assert.That(property.Name, Is.EqualTo("text-indent"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.Value, Is.EqualTo("0"));
         }
 
         [Test]
@@ -160,11 +160,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "text-indent:10%";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("text-indent", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.AreEqual("10%", property.Value);
+            Assert.That(property.Name, Is.EqualTo("text-indent"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.Value, Is.EqualTo("10%"));
         }
 
         [Test]
@@ -172,9 +172,9 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "text-indent:none";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("text-indent", property.Name);
-            Assert.IsFalse(property.HasValue);
-            Assert.IsFalse(property.IsImportant);
+            Assert.That(property.Name, Is.EqualTo("text-indent"));
+            Assert.That(property.HasValue, Is.False);
+            Assert.That(property.IsImportant, Is.False);
         }
 
         [Test]
@@ -182,7 +182,7 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "text-decoration: line-pass";
             var property = ParseDeclaration(snippet);
-            Assert.IsFalse(property.HasValue);
+            Assert.That(property.HasValue, Is.False);
         }
 
         [Test]
@@ -190,11 +190,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "text-decoration: line-Through";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("text-decoration", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsFalse(property.IsImportant);
-            Assert.AreEqual("line-through", property.Value);
+            Assert.That(property.Name, Is.EqualTo("text-decoration"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.Value, Is.EqualTo("line-through"));
         }
 
         [Test]
@@ -207,8 +207,8 @@ namespace AngleSharp.Css.Tests.Declarations
 </html>";
             var document = source.ToHtmlDocument(Configuration.Default.WithCss());
             var styleDeclaration = document.Body.ComputeCurrentStyle();
-            Assert.AreEqual("dotted", styleDeclaration.GetTextDecorationStyle());
-            Assert.AreEqual("underline", styleDeclaration.GetTextDecorationLine());
+            Assert.That(styleDeclaration.GetTextDecorationStyle(), Is.EqualTo("dotted"));
+            Assert.That(styleDeclaration.GetTextDecorationLine(), Is.EqualTo("underline"));
         }
 
         [Test]
@@ -216,11 +216,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "text-decoration:  underline  overline";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("text-decoration", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsFalse(property.IsImportant);
-            Assert.AreEqual("underline overline", property.Value);
+            Assert.That(property.Name, Is.EqualTo("text-decoration"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.Value, Is.EqualTo("underline overline"));
         }
 
         [Test]
@@ -228,11 +228,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "text-decoration-color: #F00";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("text-decoration-color", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsFalse(property.IsImportant);
-            Assert.AreEqual("rgba(255, 0, 0, 1)", property.Value);
+            Assert.That(property.Name, Is.EqualTo("text-decoration-color"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.Value, Is.EqualTo("rgba(255, 0, 0, 1)"));
         }
 
         [Test]
@@ -240,11 +240,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "text-decoration-color: red";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("text-decoration-color", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsFalse(property.IsImportant);
-            Assert.AreEqual("rgba(255, 0, 0, 1)", property.Value);
+            Assert.That(property.Name, Is.EqualTo("text-decoration-color"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.Value, Is.EqualTo("rgba(255, 0, 0, 1)"));
         }
 
         [Test]
@@ -252,10 +252,10 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "text-decoration-line: 5";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("text-decoration-line", property.Name);
-            Assert.IsFalse(property.HasValue);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsFalse(property.IsImportant);
+            Assert.That(property.Name, Is.EqualTo("text-decoration-line"));
+            Assert.That(property.HasValue, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.IsImportant, Is.False);
         }
 
         [Test]
@@ -263,11 +263,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "text-decoration-line: none";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("text-decoration-line", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsFalse(property.IsImportant);
-            Assert.AreEqual("none", property.Value);
+            Assert.That(property.Name, Is.EqualTo("text-decoration-line"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.Value, Is.EqualTo("none"));
         }
 
         [Test]
@@ -275,11 +275,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "text-decoration-line: overline    underline line-through  ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("text-decoration-line", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsFalse(property.IsImportant);
-            Assert.AreEqual("overline underline line-through", property.Value);
+            Assert.That(property.Name, Is.EqualTo("text-decoration-line"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.Value, Is.EqualTo("overline underline line-through"));
         }
 
         [Test]
@@ -287,11 +287,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "text-decoration-style: WAVY ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("text-decoration-style", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsFalse(property.IsImportant);
-            Assert.AreEqual("wavy", property.Value);
+            Assert.That(property.Name, Is.EqualTo("text-decoration-style"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.Value, Is.EqualTo("wavy"));
         }
 
         [Test]
@@ -299,10 +299,10 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "text-decoration-style: wavy dotted";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("text-decoration-style", property.Name);
-            Assert.IsFalse(property.HasValue);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsFalse(property.IsImportant);
+            Assert.That(property.Name, Is.EqualTo("text-decoration-style"));
+            Assert.That(property.HasValue, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.IsImportant, Is.False);
         }
 
         [Test]
@@ -312,7 +312,7 @@ namespace AngleSharp.Css.Tests.Declarations
             var expected = ".centered { text-decoration: underline }";
             var result = ParseRule(snippet);
             var actual = result.CssText;
-            Assert.AreEqual(expected, actual);
+            Assert.That(actual, Is.EqualTo(expected));
 		}
 
 		[Test]
@@ -320,11 +320,11 @@ namespace AngleSharp.Css.Tests.Declarations
 		{
 			var snippet = "word-break : normal";
 			var property = ParseDeclaration(snippet);
-			Assert.AreEqual("word-break", property.Name);
-			Assert.IsTrue(property.HasValue);
-			Assert.IsFalse(property.IsInherited);
-			Assert.IsFalse(property.IsImportant);
-			Assert.AreEqual("normal", property.Value);
+			Assert.That(property.Name, Is.EqualTo("word-break"));
+			Assert.That(property.HasValue, Is.True);
+			Assert.That(property.IsInherited, Is.False);
+			Assert.That(property.IsImportant, Is.False);
+			Assert.That(property.Value, Is.EqualTo("normal"));
 		}
 
 		[Test]
@@ -332,11 +332,11 @@ namespace AngleSharp.Css.Tests.Declarations
 		{
 			var snippet = "word-break : break-all";
 			var property = ParseDeclaration(snippet);
-			Assert.AreEqual("word-break", property.Name);
-			Assert.IsTrue(property.HasValue);
-			Assert.IsFalse(property.IsInherited);
-			Assert.IsFalse(property.IsImportant);
-			Assert.AreEqual("break-all", property.Value);
+			Assert.That(property.Name, Is.EqualTo("word-break"));
+			Assert.That(property.HasValue, Is.True);
+			Assert.That(property.IsInherited, Is.False);
+			Assert.That(property.IsImportant, Is.False);
+			Assert.That(property.Value, Is.EqualTo("break-all"));
 		}
 
 		[Test]
@@ -344,11 +344,11 @@ namespace AngleSharp.Css.Tests.Declarations
 		{
 			var snippet = "word-break : keep-all";
 			var property = ParseDeclaration(snippet);
-			Assert.AreEqual("word-break", property.Name);
-			Assert.IsTrue(property.HasValue);
-			Assert.IsFalse(property.IsInherited);
-			Assert.IsFalse(property.IsImportant);
-			Assert.AreEqual("keep-all", property.Value);
+			Assert.That(property.Name, Is.EqualTo("word-break"));
+			Assert.That(property.HasValue, Is.True);
+			Assert.That(property.IsInherited, Is.False);
+			Assert.That(property.IsImportant, Is.False);
+			Assert.That(property.Value, Is.EqualTo("keep-all"));
 		}
 
 		[Test]
@@ -356,21 +356,21 @@ namespace AngleSharp.Css.Tests.Declarations
 		{
 			var snippet = "word-break : none";
 			var property = ParseDeclaration(snippet);
-			Assert.AreEqual("word-break", property.Name);
-			Assert.IsFalse(property.HasValue);
-			Assert.IsFalse(property.IsInherited);
-			Assert.IsFalse(property.IsImportant);
+			Assert.That(property.Name, Is.EqualTo("word-break"));
+			Assert.That(property.HasValue, Is.False);
+			Assert.That(property.IsInherited, Is.False);
+			Assert.That(property.IsImportant, Is.False);
 		}
 
 		public void CssTextAlignLastAutoLegal()
 		{
 			var snippet = "text-align-last: auto";
 			var property = ParseDeclaration(snippet);
-			Assert.AreEqual("text-align-last", property.Name);
-			Assert.IsFalse(property.IsInherited);
-			Assert.IsFalse(property.IsImportant);
-			Assert.IsTrue(property.HasValue);
-			Assert.AreEqual("auto", property.Value);
+			Assert.That(property.Name, Is.EqualTo("text-align-last"));
+			Assert.That(property.IsInherited, Is.False);
+			Assert.That(property.IsImportant, Is.False);
+			Assert.That(property.HasValue, Is.True);
+			Assert.That(property.Value, Is.EqualTo("auto"));
 		}
 
 		[Test]
@@ -378,11 +378,11 @@ namespace AngleSharp.Css.Tests.Declarations
 		{
 			var snippet = "text-align-last: start";
 			var property = ParseDeclaration(snippet);
-			Assert.AreEqual("text-align-last", property.Name);
-			Assert.IsFalse(property.IsInherited);
-			Assert.IsFalse(property.IsImportant);
-			Assert.IsTrue(property.HasValue);
-			Assert.AreEqual("start", property.Value);
+			Assert.That(property.Name, Is.EqualTo("text-align-last"));
+			Assert.That(property.IsInherited, Is.False);
+			Assert.That(property.IsImportant, Is.False);
+			Assert.That(property.HasValue, Is.True);
+			Assert.That(property.Value, Is.EqualTo("start"));
 		}
 
 		[Test]
@@ -390,11 +390,11 @@ namespace AngleSharp.Css.Tests.Declarations
 		{
 			var snippet = "text-align-last: end";
 			var property = ParseDeclaration(snippet);
-			Assert.AreEqual("text-align-last", property.Name);
-			Assert.IsFalse(property.IsInherited);
-			Assert.IsFalse(property.IsImportant);
-			Assert.IsTrue(property.HasValue);
-			Assert.AreEqual("end", property.Value);
+			Assert.That(property.Name, Is.EqualTo("text-align-last"));
+			Assert.That(property.IsInherited, Is.False);
+			Assert.That(property.IsImportant, Is.False);
+			Assert.That(property.HasValue, Is.True);
+			Assert.That(property.Value, Is.EqualTo("end"));
 		}
 
 		[Test]
@@ -402,11 +402,11 @@ namespace AngleSharp.Css.Tests.Declarations
 		{
 			var snippet = "text-align-last: right";
 			var property = ParseDeclaration(snippet);
-			Assert.AreEqual("text-align-last", property.Name);
-			Assert.IsFalse(property.IsInherited);
-			Assert.IsFalse(property.IsImportant);
-			Assert.IsTrue(property.HasValue);
-			Assert.AreEqual("right", property.Value);
+			Assert.That(property.Name, Is.EqualTo("text-align-last"));
+			Assert.That(property.IsInherited, Is.False);
+			Assert.That(property.IsImportant, Is.False);
+			Assert.That(property.HasValue, Is.True);
+			Assert.That(property.Value, Is.EqualTo("right"));
 		}
 
 		[Test]
@@ -414,11 +414,11 @@ namespace AngleSharp.Css.Tests.Declarations
 		{
 			var snippet = "text-align-last: left";
 			var property = ParseDeclaration(snippet);
-			Assert.AreEqual("text-align-last", property.Name);
-			Assert.IsFalse(property.IsInherited);
-			Assert.IsFalse(property.IsImportant);
-			Assert.IsTrue(property.HasValue);
-			Assert.AreEqual("left", property.Value);
+			Assert.That(property.Name, Is.EqualTo("text-align-last"));
+			Assert.That(property.IsInherited, Is.False);
+			Assert.That(property.IsImportant, Is.False);
+			Assert.That(property.HasValue, Is.True);
+			Assert.That(property.Value, Is.EqualTo("left"));
 		}
 
 		[Test]
@@ -426,11 +426,11 @@ namespace AngleSharp.Css.Tests.Declarations
 		{
 			var snippet = "text-align-last: center";
 			var property = ParseDeclaration(snippet);
-			Assert.AreEqual("text-align-last", property.Name);
-			Assert.IsFalse(property.IsInherited);
-			Assert.IsFalse(property.IsImportant);
-			Assert.IsTrue(property.HasValue);
-			Assert.AreEqual("center", property.Value);
+			Assert.That(property.Name, Is.EqualTo("text-align-last"));
+			Assert.That(property.IsInherited, Is.False);
+			Assert.That(property.IsImportant, Is.False);
+			Assert.That(property.HasValue, Is.True);
+			Assert.That(property.Value, Is.EqualTo("center"));
 		}
 
 		[Test]
@@ -438,11 +438,11 @@ namespace AngleSharp.Css.Tests.Declarations
 		{
 			var snippet = "text-align-last: justify";
 			var property = ParseDeclaration(snippet);
-			Assert.AreEqual("text-align-last", property.Name);
-			Assert.IsFalse(property.IsInherited);
-			Assert.IsFalse(property.IsImportant);
-			Assert.IsTrue(property.HasValue);
-			Assert.AreEqual("justify", property.Value);
+			Assert.That(property.Name, Is.EqualTo("text-align-last"));
+			Assert.That(property.IsInherited, Is.False);
+			Assert.That(property.IsImportant, Is.False);
+			Assert.That(property.HasValue, Is.True);
+			Assert.That(property.Value, Is.EqualTo("justify"));
 		}
 
 		[Test]
@@ -450,10 +450,10 @@ namespace AngleSharp.Css.Tests.Declarations
 		{
 			var snippet = "text-align-last: none";
 			var property = ParseDeclaration(snippet);
-			Assert.AreEqual("text-align-last", property.Name);
-			Assert.IsFalse(property.IsInherited);
-			Assert.IsFalse(property.IsImportant);
-			Assert.IsFalse(property.HasValue);
+			Assert.That(property.Name, Is.EqualTo("text-align-last"));
+			Assert.That(property.IsInherited, Is.False);
+			Assert.That(property.IsImportant, Is.False);
+			Assert.That(property.HasValue, Is.False);
 		}
 
 		[Test]
@@ -461,11 +461,11 @@ namespace AngleSharp.Css.Tests.Declarations
 		{
 			var snippet = "text-anchor: start";
 			var property = ParseDeclaration(snippet);
-			Assert.AreEqual("text-anchor", property.Name);
-			Assert.IsFalse(property.IsInherited);
-			Assert.IsFalse(property.IsImportant);
-			Assert.IsTrue(property.HasValue);
-			Assert.AreEqual("start", property.Value);
+			Assert.That(property.Name, Is.EqualTo("text-anchor"));
+			Assert.That(property.IsInherited, Is.False);
+			Assert.That(property.IsImportant, Is.False);
+			Assert.That(property.HasValue, Is.True);
+			Assert.That(property.Value, Is.EqualTo("start"));
 		}
 
 		[Test]
@@ -473,11 +473,11 @@ namespace AngleSharp.Css.Tests.Declarations
 		{
 			var snippet = "text-anchor: middle";
 			var property = ParseDeclaration(snippet);
-			Assert.AreEqual("text-anchor", property.Name);
-			Assert.IsFalse(property.IsInherited);
-			Assert.IsFalse(property.IsImportant);
-			Assert.IsTrue(property.HasValue);
-			Assert.AreEqual("middle", property.Value);
+			Assert.That(property.Name, Is.EqualTo("text-anchor"));
+			Assert.That(property.IsInherited, Is.False);
+			Assert.That(property.IsImportant, Is.False);
+			Assert.That(property.HasValue, Is.True);
+			Assert.That(property.Value, Is.EqualTo("middle"));
 		}
 
 		[Test]
@@ -485,11 +485,11 @@ namespace AngleSharp.Css.Tests.Declarations
 		{
 			var snippet = "text-anchor: end";
 			var property = ParseDeclaration(snippet);
-			Assert.AreEqual("text-anchor", property.Name);
-			Assert.IsFalse(property.IsInherited);
-			Assert.IsFalse(property.IsImportant);
-			Assert.IsTrue(property.HasValue);
-			Assert.AreEqual("end", property.Value);
+			Assert.That(property.Name, Is.EqualTo("text-anchor"));
+			Assert.That(property.IsInherited, Is.False);
+			Assert.That(property.IsImportant, Is.False);
+			Assert.That(property.HasValue, Is.True);
+			Assert.That(property.Value, Is.EqualTo("end"));
 		}
 
 		[Test]
@@ -497,10 +497,10 @@ namespace AngleSharp.Css.Tests.Declarations
 		{
 			var snippet = "text-anchor: none";
 			var property = ParseDeclaration(snippet);
-			Assert.AreEqual("text-anchor", property.Name);
-			Assert.IsFalse(property.IsInherited);
-			Assert.IsFalse(property.IsImportant);
-			Assert.IsFalse(property.HasValue);
+			Assert.That(property.Name, Is.EqualTo("text-anchor"));
+			Assert.That(property.IsInherited, Is.False);
+			Assert.That(property.IsImportant, Is.False);
+			Assert.That(property.HasValue, Is.False);
 		}
 
 		[Test]
@@ -508,11 +508,11 @@ namespace AngleSharp.Css.Tests.Declarations
 		{
 			var snippet = "text-justify: auto";
 			var property = ParseDeclaration(snippet);
-			Assert.AreEqual("text-justify", property.Name);
-			Assert.IsFalse(property.IsInherited);
-			Assert.IsFalse(property.IsImportant);
-			Assert.IsTrue(property.HasValue);
-			Assert.AreEqual("auto", property.Value);
+			Assert.That(property.Name, Is.EqualTo("text-justify"));
+			Assert.That(property.IsInherited, Is.False);
+			Assert.That(property.IsImportant, Is.False);
+			Assert.That(property.HasValue, Is.True);
+			Assert.That(property.Value, Is.EqualTo("auto"));
 		}
 
 		[Test]
@@ -520,11 +520,11 @@ namespace AngleSharp.Css.Tests.Declarations
 		{
 			var snippet = "text-justify: distribute";
 			var property = ParseDeclaration(snippet);
-			Assert.AreEqual("text-justify", property.Name);
-			Assert.IsFalse(property.IsInherited);
-			Assert.IsFalse(property.IsImportant);
-			Assert.IsTrue(property.HasValue);
-			Assert.AreEqual("distribute", property.Value);
+			Assert.That(property.Name, Is.EqualTo("text-justify"));
+			Assert.That(property.IsInherited, Is.False);
+			Assert.That(property.IsImportant, Is.False);
+			Assert.That(property.HasValue, Is.True);
+			Assert.That(property.Value, Is.EqualTo("distribute"));
 		}
 
 		[Test]
@@ -532,11 +532,11 @@ namespace AngleSharp.Css.Tests.Declarations
 		{
 			var snippet = "text-justify: distribute-all-lines";
 			var property = ParseDeclaration(snippet);
-			Assert.AreEqual("text-justify", property.Name);
-			Assert.IsFalse(property.IsInherited);
-			Assert.IsFalse(property.IsImportant);
-			Assert.IsTrue(property.HasValue);
-			Assert.AreEqual("distribute-all-lines", property.Value);
+			Assert.That(property.Name, Is.EqualTo("text-justify"));
+			Assert.That(property.IsInherited, Is.False);
+			Assert.That(property.IsImportant, Is.False);
+			Assert.That(property.HasValue, Is.True);
+			Assert.That(property.Value, Is.EqualTo("distribute-all-lines"));
 		}
 
 		[Test]
@@ -544,11 +544,11 @@ namespace AngleSharp.Css.Tests.Declarations
 		{
 			var snippet = "text-justify: distribute-center-last";
 			var property = ParseDeclaration(snippet);
-			Assert.AreEqual("text-justify", property.Name);
-			Assert.IsFalse(property.IsInherited);
-			Assert.IsFalse(property.IsImportant);
-			Assert.IsTrue(property.HasValue);
-			Assert.AreEqual("distribute-center-last", property.Value);
+			Assert.That(property.Name, Is.EqualTo("text-justify"));
+			Assert.That(property.IsInherited, Is.False);
+			Assert.That(property.IsImportant, Is.False);
+			Assert.That(property.HasValue, Is.True);
+			Assert.That(property.Value, Is.EqualTo("distribute-center-last"));
 		}
 
 		[Test]
@@ -556,11 +556,11 @@ namespace AngleSharp.Css.Tests.Declarations
 		{
 			var snippet = "text-justify: inter-cluster";
 			var property = ParseDeclaration(snippet);
-			Assert.AreEqual("text-justify", property.Name);
-			Assert.IsFalse(property.IsInherited);
-			Assert.IsFalse(property.IsImportant);
-			Assert.IsTrue(property.HasValue);
-			Assert.AreEqual("inter-cluster", property.Value);
+			Assert.That(property.Name, Is.EqualTo("text-justify"));
+			Assert.That(property.IsInherited, Is.False);
+			Assert.That(property.IsImportant, Is.False);
+			Assert.That(property.HasValue, Is.True);
+			Assert.That(property.Value, Is.EqualTo("inter-cluster"));
 		}
 
 		[Test]
@@ -568,11 +568,11 @@ namespace AngleSharp.Css.Tests.Declarations
 		{
 			var snippet = "text-justify: inter-ideograph";
 			var property = ParseDeclaration(snippet);
-			Assert.AreEqual("text-justify", property.Name);
-			Assert.IsFalse(property.IsInherited);
-			Assert.IsFalse(property.IsImportant);
-			Assert.IsTrue(property.HasValue);
-			Assert.AreEqual("inter-ideograph", property.Value);
+			Assert.That(property.Name, Is.EqualTo("text-justify"));
+			Assert.That(property.IsInherited, Is.False);
+			Assert.That(property.IsImportant, Is.False);
+			Assert.That(property.HasValue, Is.True);
+			Assert.That(property.Value, Is.EqualTo("inter-ideograph"));
 		}
 
 		[Test]
@@ -580,11 +580,11 @@ namespace AngleSharp.Css.Tests.Declarations
 		{
 			var snippet = "text-justify: inter-word";
 			var property = ParseDeclaration(snippet);
-			Assert.AreEqual("text-justify", property.Name);
-			Assert.IsFalse(property.IsInherited);
-			Assert.IsFalse(property.IsImportant);
-			Assert.IsTrue(property.HasValue);
-			Assert.AreEqual("inter-word", property.Value);
+			Assert.That(property.Name, Is.EqualTo("text-justify"));
+			Assert.That(property.IsInherited, Is.False);
+			Assert.That(property.IsImportant, Is.False);
+			Assert.That(property.HasValue, Is.True);
+			Assert.That(property.Value, Is.EqualTo("inter-word"));
 		}
 
 		[Test]
@@ -592,11 +592,11 @@ namespace AngleSharp.Css.Tests.Declarations
 		{
 			var snippet = "text-justify: kashida";
 			var property = ParseDeclaration(snippet);
-			Assert.AreEqual("text-justify", property.Name);
-			Assert.IsFalse(property.IsInherited);
-			Assert.IsFalse(property.IsImportant);
-			Assert.IsTrue(property.HasValue);
-			Assert.AreEqual("kashida", property.Value);
+			Assert.That(property.Name, Is.EqualTo("text-justify"));
+			Assert.That(property.IsInherited, Is.False);
+			Assert.That(property.IsImportant, Is.False);
+			Assert.That(property.HasValue, Is.True);
+			Assert.That(property.Value, Is.EqualTo("kashida"));
 		}
 
 		[Test]
@@ -604,11 +604,11 @@ namespace AngleSharp.Css.Tests.Declarations
 		{
 			var snippet = "text-justify: newspaper";
 			var property = ParseDeclaration(snippet);
-			Assert.AreEqual("text-justify", property.Name);
-			Assert.IsFalse(property.IsInherited);
-			Assert.IsFalse(property.IsImportant);
-			Assert.IsTrue(property.HasValue);
-			Assert.AreEqual("newspaper", property.Value);
+			Assert.That(property.Name, Is.EqualTo("text-justify"));
+			Assert.That(property.IsInherited, Is.False);
+			Assert.That(property.IsImportant, Is.False);
+			Assert.That(property.HasValue, Is.True);
+			Assert.That(property.Value, Is.EqualTo("newspaper"));
 		}
 
 		[Test]
@@ -616,10 +616,10 @@ namespace AngleSharp.Css.Tests.Declarations
 		{
 			var snippet = "text-justify: none";
 			var property = ParseDeclaration(snippet);
-			Assert.AreEqual("text-justify", property.Name);
-			Assert.IsFalse(property.IsInherited);
-			Assert.IsFalse(property.IsImportant);
-			Assert.IsFalse(property.HasValue);
+			Assert.That(property.Name, Is.EqualTo("text-justify"));
+			Assert.That(property.IsInherited, Is.False);
+			Assert.That(property.IsImportant, Is.False);
+			Assert.That(property.HasValue, Is.False);
 		}
 
 		[Test]
@@ -627,11 +627,11 @@ namespace AngleSharp.Css.Tests.Declarations
 		{
 			var snippet = "overflow-wrap: normal";
 			var property = ParseDeclaration(snippet);
-			Assert.AreEqual("overflow-wrap", property.Name);
-			Assert.IsFalse(property.IsInherited);
-			Assert.IsFalse(property.IsImportant);
-			Assert.IsTrue(property.HasValue);
-			Assert.AreEqual("normal", property.Value);
+			Assert.That(property.Name, Is.EqualTo("overflow-wrap"));
+			Assert.That(property.IsInherited, Is.False);
+			Assert.That(property.IsImportant, Is.False);
+			Assert.That(property.HasValue, Is.True);
+			Assert.That(property.Value, Is.EqualTo("normal"));
 		}
 
 		[Test]
@@ -639,11 +639,11 @@ namespace AngleSharp.Css.Tests.Declarations
 		{
 			var snippet = "word-wrap: normal";
 			var property = ParseDeclaration(snippet);
-			Assert.AreEqual("word-wrap", property.Name);
-			Assert.IsFalse(property.IsInherited);
-			Assert.IsFalse(property.IsImportant);
-			Assert.IsTrue(property.HasValue);
-			Assert.AreEqual("normal", property.Value);
+			Assert.That(property.Name, Is.EqualTo("word-wrap"));
+			Assert.That(property.IsInherited, Is.False);
+			Assert.That(property.IsImportant, Is.False);
+			Assert.That(property.HasValue, Is.True);
+			Assert.That(property.Value, Is.EqualTo("normal"));
 		}
 
 		[Test]
@@ -651,11 +651,11 @@ namespace AngleSharp.Css.Tests.Declarations
 		{
 			var snippet = "overflow-wrap: break-word";
 			var property = ParseDeclaration(snippet);
-			Assert.AreEqual("overflow-wrap", property.Name);
-			Assert.IsFalse(property.IsInherited);
-			Assert.IsFalse(property.IsImportant);
-			Assert.IsTrue(property.HasValue);
-			Assert.AreEqual("break-word", property.Value);
+			Assert.That(property.Name, Is.EqualTo("overflow-wrap"));
+			Assert.That(property.IsInherited, Is.False);
+			Assert.That(property.IsImportant, Is.False);
+			Assert.That(property.HasValue, Is.True);
+			Assert.That(property.Value, Is.EqualTo("break-word"));
 		}
 
 		[Test]
@@ -663,11 +663,11 @@ namespace AngleSharp.Css.Tests.Declarations
 		{
 			var snippet = "word-wrap: break-word";
 			var property = ParseDeclaration(snippet);
-			Assert.AreEqual("word-wrap", property.Name);
-			Assert.IsFalse(property.IsInherited);
-			Assert.IsFalse(property.IsImportant);
-			Assert.IsTrue(property.HasValue);
-			Assert.AreEqual("break-word", property.Value);
+			Assert.That(property.Name, Is.EqualTo("word-wrap"));
+			Assert.That(property.IsInherited, Is.False);
+			Assert.That(property.IsImportant, Is.False);
+			Assert.That(property.HasValue, Is.True);
+			Assert.That(property.Value, Is.EqualTo("break-word"));
 		}
 
 		[Test]
@@ -675,10 +675,10 @@ namespace AngleSharp.Css.Tests.Declarations
 		{
 			var snippet = "overflow-wrap: none";
 			var property = ParseDeclaration(snippet);
-			Assert.AreEqual("overflow-wrap", property.Name);
-			Assert.IsFalse(property.IsInherited);
-			Assert.IsFalse(property.IsImportant);
-			Assert.IsFalse(property.HasValue);
+			Assert.That(property.Name, Is.EqualTo("overflow-wrap"));
+			Assert.That(property.IsInherited, Is.False);
+			Assert.That(property.IsImportant, Is.False);
+			Assert.That(property.HasValue, Is.False);
 		}
 
 		[Test]
@@ -686,10 +686,10 @@ namespace AngleSharp.Css.Tests.Declarations
 		{
 			var snippet = "word-wrap: none";
 			var property = ParseDeclaration(snippet);
-			Assert.AreEqual("word-wrap", property.Name);
-			Assert.IsFalse(property.IsInherited);
-			Assert.IsFalse(property.IsImportant);
-			Assert.IsFalse(property.HasValue);
+			Assert.That(property.Name, Is.EqualTo("word-wrap"));
+			Assert.That(property.IsInherited, Is.False);
+			Assert.That(property.IsImportant, Is.False);
+			Assert.That(property.HasValue, Is.False);
         }
 
         [Test]
@@ -697,11 +697,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "text-align:start";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("text-align", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.AreEqual("start", property.Value);
+            Assert.That(property.Name, Is.EqualTo("text-align"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.Value, Is.EqualTo("start"));
         }
 
         [Test]
@@ -709,11 +709,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "text-align:justify-all";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("text-align", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.AreEqual("justify-all", property.Value);
+            Assert.That(property.Name, Is.EqualTo("text-align"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.Value, Is.EqualTo("justify-all"));
         }
 
         [Test]
@@ -721,8 +721,8 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "text-align:justify-none";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("text-align", property.Name);
-            Assert.IsFalse(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("text-align"));
+            Assert.That(property.HasValue, Is.False);
         }
     }
 }

--- a/src/AngleSharp.Css.Tests/Declarations/CssTextShadowProperty.cs
+++ b/src/AngleSharp.Css.Tests/Declarations/CssTextShadowProperty.cs
@@ -17,7 +17,7 @@ namespace AngleSharp.Css.Tests.Declarations
             var div = dom.QuerySelector("div");
             var style = div.GetStyle();
             var css = style.CssText;
-            Assert.AreEqual("text-shadow: 2px 2px 2px rgba(0, 0, 0, 1)", css);
+            Assert.That(css, Is.EqualTo("text-shadow: 2px 2px 2px rgba(0, 0, 0, 1)"));
         }
     }
 }

--- a/src/AngleSharp.Css.Tests/Declarations/CssTransformProperty.cs
+++ b/src/AngleSharp.Css.Tests/Declarations/CssTransformProperty.cs
@@ -1,4 +1,4 @@
-﻿namespace AngleSharp.Css.Tests.Declarations
+namespace AngleSharp.Css.Tests.Declarations
 {
     using NUnit.Framework;
     using static CssConstructionFunctions;
@@ -11,11 +11,11 @@
         {
             var snippet = "perspective:  NONE ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("perspective", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("none", property.Value);
+            Assert.That(property.Name, Is.EqualTo("perspective"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("none"));
         }
 
         [Test]
@@ -23,11 +23,11 @@
         {
             var snippet = "perspective:  20px  ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("perspective", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("20px", property.Value);
+            Assert.That(property.Name, Is.EqualTo("perspective"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("20px"));
         }
 
         [Test]
@@ -35,11 +35,11 @@
         {
             var snippet = "perspective:  3.5em  ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("perspective", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("3.5em", property.Value);
+            Assert.That(property.Name, Is.EqualTo("perspective"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("3.5em"));
         }
 
         [Test]
@@ -47,11 +47,11 @@
         {
             var snippet = "perspective:  0  ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("perspective", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("0", property.Value);
+            Assert.That(property.Name, Is.EqualTo("perspective"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("0"));
         }
 
         [Test]
@@ -59,10 +59,10 @@
         {
             var snippet = "perspective:  10%  ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("perspective", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsFalse(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("perspective"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.False);
         }
 
         [Test]
@@ -70,11 +70,11 @@
         {
             var snippet = "perspective-origin:  0  ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("perspective-origin", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("left", property.Value);
+            Assert.That(property.Name, Is.EqualTo("perspective-origin"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("left"));
         }
 
         [Test]
@@ -82,11 +82,11 @@
         {
             var snippet = "perspective-origin:  20px  ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("perspective-origin", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("20px", property.Value);
+            Assert.That(property.Name, Is.EqualTo("perspective-origin"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("20px"));
         }
 
         [Test]
@@ -94,11 +94,11 @@
         {
             var snippet = "perspective-origin:  left  ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("perspective-origin", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("left", property.Value);
+            Assert.That(property.Name, Is.EqualTo("perspective-origin"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("left"));
         }
 
         [Test]
@@ -106,11 +106,11 @@
         {
             var snippet = "perspective-origin:  15%  ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("perspective-origin", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("15%", property.Value);
+            Assert.That(property.Name, Is.EqualTo("perspective-origin"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("15%"));
         }
 
         [Test]
@@ -118,11 +118,11 @@
         {
             var snippet = "perspective-origin:  15% 25% ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("perspective-origin", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("15% 25%", property.Value);
+            Assert.That(property.Name, Is.EqualTo("perspective-origin"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("15% 25%"));
         }
 
         [Test]
@@ -130,11 +130,11 @@
         {
             var snippet = "perspective-origin:  left center ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("perspective-origin", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("left", property.Value);
+            Assert.That(property.Name, Is.EqualTo("perspective-origin"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("left"));
         }
 
         [Test]
@@ -142,11 +142,11 @@
         {
             var snippet = "perspective-origin:  right BOTTOM ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("perspective-origin", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("right bottom", property.Value);
+            Assert.That(property.Name, Is.EqualTo("perspective-origin"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("right bottom"));
         }
 
         [Test]
@@ -154,11 +154,11 @@
         {
             var snippet = "perspective-origin:  top center ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("perspective-origin", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("top", property.Value);
+            Assert.That(property.Name, Is.EqualTo("perspective-origin"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("top"));
         }
 
         [Test]
@@ -166,12 +166,12 @@
         {
             var snippet = "transform-style:  preserve-3d ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("transform-style", property.Name);
-            Assert.IsTrue(property.HasValue);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("preserve-3d", property.Value);
+            Assert.That(property.Name, Is.EqualTo("transform-style"));
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("preserve-3d"));
         }
 
         [Test]
@@ -179,10 +179,10 @@
         {
             var snippet = "transform-style:  none ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("transform-style", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsFalse(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("transform-style"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.False);
         }
 
         [Test]
@@ -190,11 +190,11 @@
         {
             var snippet = "transform-origin:  2px ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("transform-origin", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("2px", property.Value);
+            Assert.That(property.Name, Is.EqualTo("transform-origin"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("2px"));
         }
 
         [Test]
@@ -202,11 +202,11 @@
         {
             var snippet = "transform-origin:  bottom ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("transform-origin", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("bottom", property.Value);
+            Assert.That(property.Name, Is.EqualTo("transform-origin"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("bottom"));
         }
 
         [Test]
@@ -214,11 +214,11 @@
         {
             var snippet = "transform-origin:  3cm 2px";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("transform-origin", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("3cm 2px", property.Value);
+            Assert.That(property.Name, Is.EqualTo("transform-origin"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("3cm 2px"));
         }
 
         [Test]
@@ -226,11 +226,11 @@
         {
             var snippet = "transform-origin:  2px left";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("transform-origin", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("0 2px", property.Value);
+            Assert.That(property.Name, Is.EqualTo("transform-origin"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("0 2px"));
         }
 
         [Test]
@@ -238,11 +238,11 @@
         {
             var snippet = "transform-origin:  left 2px ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("transform-origin", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("0 2px", property.Value);
+            Assert.That(property.Name, Is.EqualTo("transform-origin"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("0 2px"));
         }
 
         [Test]
@@ -250,11 +250,11 @@
         {
             var snippet = "transform-origin:  right top ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("transform-origin", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("right top", property.Value);
+            Assert.That(property.Name, Is.EqualTo("transform-origin"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("right top"));
         }
 
         [Test]
@@ -262,11 +262,11 @@
         {
             var snippet = "transform-origin:  top  right ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("transform-origin", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("right top", property.Value);
+            Assert.That(property.Name, Is.EqualTo("transform-origin"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("right top"));
         }
 
         [Test]
@@ -274,11 +274,11 @@
         {
             var snippet = "transform-origin:  2px 30% 10px ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("transform-origin", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("2px 30% 10px", property.Value);
+            Assert.That(property.Name, Is.EqualTo("transform-origin"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("2px 30% 10px"));
         }
 
         [Test]
@@ -286,11 +286,11 @@
         {
             var snippet = "transform-origin:  2px left 10px ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("transform-origin", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("0 2px 10px", property.Value);
+            Assert.That(property.Name, Is.EqualTo("transform-origin"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("0 2px 10px"));
         }
 
         [Test]
@@ -298,11 +298,11 @@
         {
             var snippet = "transform-origin:  left 5px -3px ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("transform-origin", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("0 5px -3px", property.Value);
+            Assert.That(property.Name, Is.EqualTo("transform-origin"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("0 5px -3px"));
         }
 
         [Test]
@@ -310,11 +310,11 @@
         {
             var snippet = "transform-origin:  right bottom 2cm ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("transform-origin", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("right bottom 2cm", property.Value);
+            Assert.That(property.Name, Is.EqualTo("transform-origin"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("right bottom 2cm"));
         }
 
         [Test]
@@ -322,11 +322,11 @@
         {
             var snippet = "transform-origin:  bottom  right  2cm ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("transform-origin", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("right bottom 2cm", property.Value);
+            Assert.That(property.Name, Is.EqualTo("transform-origin"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("right bottom 2cm"));
         }
 
         [Test]
@@ -334,11 +334,11 @@
         {
             var snippet = "transform:  none ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("transform", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("none", property.Value);
+            Assert.That(property.Name, Is.EqualTo("transform"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("none"));
         }
 
         [Test]
@@ -346,11 +346,11 @@
         {
             var snippet = "transform:  matrix(1.0, 2.0, 3.0, 4.0, 5.0, 6.0) ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("transform", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("matrix(1, 2, 3, 4, 5, 6)", property.Value);
+            Assert.That(property.Name, Is.EqualTo("transform"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("matrix(1, 2, 3, 4, 5, 6)"));
         }
 
         [Test]
@@ -358,11 +358,11 @@
         {
             var snippet = "transform:  translate(12px, 50%) ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("transform", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("translate(12px, 50%)", property.Value);
+            Assert.That(property.Name, Is.EqualTo("transform"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("translate(12px, 50%)"));
         }
 
         [Test]
@@ -370,11 +370,11 @@
         {
             var snippet = "transform:  translateX(2em) ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("transform", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("translateX(2em)", property.Value);
+            Assert.That(property.Name, Is.EqualTo("transform"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("translateX(2em)"));
         }
 
         [Test]
@@ -382,11 +382,11 @@
         {
             var snippet = "transform:  translateY(3in) ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("transform", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("translateY(3in)", property.Value);
+            Assert.That(property.Name, Is.EqualTo("transform"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("translateY(3in)"));
         }
 
         [Test]
@@ -394,11 +394,11 @@
         {
             var snippet = "transform:  scale(2, 0.5) ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("transform", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("scale(2, 0.5)", property.Value);
+            Assert.That(property.Name, Is.EqualTo("transform"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("scale(2, 0.5)"));
         }
 
         [Test]
@@ -406,11 +406,11 @@
         {
             var snippet = "transform:  scaleX(0.1) ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("transform", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("scaleX(0.1)", property.Value);
+            Assert.That(property.Name, Is.EqualTo("transform"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("scaleX(0.1)"));
         }
 
         [Test]
@@ -418,11 +418,11 @@
         {
             var snippet = "transform:  scaleY(1.5) ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("transform", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("scaleY(1.5)", property.Value);
+            Assert.That(property.Name, Is.EqualTo("transform"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("scaleY(1.5)"));
         }
 
         [Test]
@@ -430,11 +430,11 @@
         {
             var snippet = "transform:  rotate(0.5turn) ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("transform", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("rotate(0.5turn)", property.Value);
+            Assert.That(property.Name, Is.EqualTo("transform"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("rotate(0.5turn)"));
         }
 
         [Test]
@@ -442,11 +442,11 @@
         {
             var snippet = "transform:  skewX(  30deg  ) ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("transform", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("skewX(30deg)", property.Value);
+            Assert.That(property.Name, Is.EqualTo("transform"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("skewX(30deg)"));
         }
 
         [Test]
@@ -454,11 +454,11 @@
         {
             var snippet = "transform:  skewY(  1.07rad  ) ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("transform", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("skewY(1.07rad)", property.Value);
+            Assert.That(property.Name, Is.EqualTo("transform"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("skewY(1.07rad)"));
         }
 
         [Test]
@@ -466,11 +466,11 @@
         {
             var snippet = "transform:  skew(20deg) ";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("transform", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("skew(20deg)", property.Value);
+            Assert.That(property.Name, Is.EqualTo("transform"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("skew(20deg)"));
         }
 
         [Test]
@@ -478,11 +478,11 @@
         {
             var snippet = "transform:  translate(50%, 50%) rotate(45deg) scale(1.5)";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("transform", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("translate(50%, 50%) rotate(45deg) scale(1.5)", property.Value);
+            Assert.That(property.Name, Is.EqualTo("transform"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("translate(50%, 50%) rotate(45deg) scale(1.5)"));
         }
 
         [Test]
@@ -490,10 +490,10 @@
         {
             var snippet = "transform:  matrix3d(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0)";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("transform", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("transform"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
         }
 
         [Test]
@@ -501,10 +501,10 @@
         {
             var snippet = "transform:  translate3d(12px, 50%, 3em)";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("transform", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("transform"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
         }
 
         [Test]
@@ -512,10 +512,10 @@
         {
             var snippet = "transform:  translateZ(2px)";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("transform", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("transform"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
         }
 
         [Test]
@@ -523,10 +523,10 @@
         {
             var snippet = "transform:  scale3d(2.5, 1.2, 0.3)";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("transform", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("transform"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
         }
 
         [Test]
@@ -534,10 +534,10 @@
         {
             var snippet = "transform:  scaleZ(0.3)";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("transform", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("transform"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
         }
 
         [Test]
@@ -545,10 +545,10 @@
         {
             var snippet = "transform:  rotate3d(1, 2.0, 3.0, 10deg)";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("transform", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("transform"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
         }
 
         [Test]
@@ -556,11 +556,11 @@
         {
             var snippet = "transform:  rotateX(10deg)";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("transform", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual(property.Value, "rotateX(10deg)");
+            Assert.That(property.Name, Is.EqualTo("transform"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That("rotateX(10deg)", Is.EqualTo(property.Value));
         }
 
         [Test]
@@ -568,11 +568,11 @@
         {
             var snippet = "transform:  rotateY(10deg)";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("transform", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual(property.Value, "rotateY(10deg)");
+            Assert.That(property.Name, Is.EqualTo("transform"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That("rotateY(10deg)", Is.EqualTo(property.Value));
         }
 
         [Test]
@@ -580,11 +580,11 @@
         {
             var snippet = "transform: rotateZ(10deg)";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("transform", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual(property.Value, "rotateZ(10deg)");
+            Assert.That(property.Name, Is.EqualTo("transform"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That("rotateZ(10deg)", Is.EqualTo(property.Value));
         }
 
         [Test]
@@ -592,10 +592,10 @@
         {
             var snippet = "transform: perspective(17px)";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("transform", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("transform"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
         }
     }
 }

--- a/src/AngleSharp.Css.Tests/Declarations/CssTransitionProperty.cs
+++ b/src/AngleSharp.Css.Tests/Declarations/CssTransitionProperty.cs
@@ -1,4 +1,4 @@
-﻿namespace AngleSharp.Css.Tests.Declarations
+namespace AngleSharp.Css.Tests.Declarations
 {
     using NUnit.Framework;
     using static CssConstructionFunctions;
@@ -11,11 +11,11 @@
         {
             var snippet = "transition-property : none";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("transition-property", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("none", property.Value);
+            Assert.That(property.Name, Is.EqualTo("transition-property"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("none"));
         }
 
         [Test]
@@ -23,11 +23,11 @@
         {
             var snippet = "transition-property : ALL";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("transition-property", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("all", property.Value);
+            Assert.That(property.Name, Is.EqualTo("transition-property"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("all"));
         }
 
         [Test]
@@ -35,11 +35,11 @@
         {
             var snippet = "transition-property : width   , height";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("transition-property", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("width, height", property.Value);
+            Assert.That(property.Name, Is.EqualTo("transition-property"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("width, height"));
         }
 
         [Test]
@@ -47,10 +47,10 @@
         {
             var snippet = "transition-property : -specific";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("transition-property", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsFalse(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("transition-property"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.False);
         }
 
         [Test]
@@ -58,10 +58,10 @@
         {
             var snippet = "transition-property : sliding-vertically";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("transition-property", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsFalse(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("transition-property"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.False);
         }
 
         [Test]
@@ -69,10 +69,10 @@
         {
             var snippet = "transition-property : test_05";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("transition-property", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsFalse(property.HasValue);
+            Assert.That(property.Name, Is.EqualTo("transition-property"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.False);
         }
 
         [Test]
@@ -80,11 +80,11 @@
         {
             var snippet = "transition-timing-function : ease";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("transition-timing-function", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("ease", property.Value);
+            Assert.That(property.Name, Is.EqualTo("transition-timing-function"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("ease"));
         }
 
         [Test]
@@ -92,11 +92,11 @@
         {
             var snippet = "transition-timing-function : ease-IN";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("transition-timing-function", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("ease-in", property.Value);
+            Assert.That(property.Name, Is.EqualTo("transition-timing-function"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("ease-in"));
         }
 
         [Test]
@@ -104,11 +104,11 @@
         {
             var snippet = "transition-timing-function : step-start";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("transition-timing-function", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("step-start", property.Value);
+            Assert.That(property.Name, Is.EqualTo("transition-timing-function"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("step-start"));
         }
 
         [Test]
@@ -116,11 +116,11 @@
         {
             var snippet = "transition-timing-function : step-start  , step-end";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("transition-timing-function", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("step-start, step-end", property.Value);
+            Assert.That(property.Name, Is.EqualTo("transition-timing-function"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("step-start, step-end"));
         }
 
         [Test]
@@ -128,11 +128,11 @@
         {
             var snippet = "transition-timing-function : step-start  , step-end,linear,ease-IN-OUT";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("transition-timing-function", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("step-start, step-end, linear, ease-in-out", property.Value);
+            Assert.That(property.Name, Is.EqualTo("transition-timing-function"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("step-start, step-end, linear, ease-in-out"));
         }
 
         [Test]
@@ -140,11 +140,11 @@
         {
             var snippet = "transition-timing-function : cubic-bezier(0, 1, 0.5, 1)";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("transition-timing-function", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("cubic-bezier(0, 1, 0.5, 1)", property.Value);
+            Assert.That(property.Name, Is.EqualTo("transition-timing-function"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("cubic-bezier(0, 1, 0.5, 1)"));
         }
 
         [Test]
@@ -152,11 +152,11 @@
         {
             var snippet = "transition-timing-function : steps(10, start)";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("transition-timing-function", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("steps(10, start)", property.Value);
+            Assert.That(property.Name, Is.EqualTo("transition-timing-function"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("steps(10, start)"));
         }
 
         [Test]
@@ -164,11 +164,11 @@
         {
             var snippet = "transition-timing-function : steps(25, end)";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("transition-timing-function", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("steps(25)", property.Value);
+            Assert.That(property.Name, Is.EqualTo("transition-timing-function"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("steps(25)"));
         }
 
         [Test]
@@ -176,11 +176,11 @@
         {
             var snippet = "transition-timing-function : steps(25), linear, cubic-bezier(0.25, 1, 0.5, 1)";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("transition-timing-function", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("steps(25), linear, cubic-bezier(0.25, 1, 0.5, 1)", property.Value);
+            Assert.That(property.Name, Is.EqualTo("transition-timing-function"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("steps(25), linear, cubic-bezier(0.25, 1, 0.5, 1)"));
         }
 
         [Test]
@@ -188,11 +188,11 @@
         {
             var snippet = "transition-duration : 6s";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("transition-duration", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("6s", property.Value);
+            Assert.That(property.Name, Is.EqualTo("transition-duration"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("6s"));
         }
 
         [Test]
@@ -200,11 +200,11 @@
         {
             var snippet = "transition-duration : 60ms";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("transition-duration", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("60ms", property.Value);
+            Assert.That(property.Name, Is.EqualTo("transition-duration"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("60ms"));
         }
 
         [Test]
@@ -212,11 +212,11 @@
         {
             var snippet = "transition-duration : 60ms, 1s, 2s";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("transition-duration", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("60ms, 1s, 2s", property.Value);
+            Assert.That(property.Name, Is.EqualTo("transition-duration"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("60ms, 1s, 2s"));
         }
 
         [Test]
@@ -224,11 +224,11 @@
         {
             var snippet = "transition-delay : 60ms";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("transition-delay", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("60ms", property.Value);
+            Assert.That(property.Name, Is.EqualTo("transition-delay"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("60ms"));
         }
 
         [Test]
@@ -236,11 +236,11 @@
         {
             var snippet = "transition-delay : 60ms, 1s, 2s";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("transition-delay", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("60ms, 1s, 2s", property.Value);
+            Assert.That(property.Name, Is.EqualTo("transition-delay"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("60ms, 1s, 2s"));
         }
 
         [Test]
@@ -248,11 +248,11 @@
         {
             var snippet = "transition : 60ms, 1s, 2s";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("transition", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("60ms, 1s, 2s", property.Value);
+            Assert.That(property.Name, Is.EqualTo("transition"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("60ms, 1s, 2s"));
         }
 
         [Test]
@@ -260,11 +260,11 @@
         {
             var snippet = "transition : steps(25), linear, cubic-bezier(0.25, 1, 0.5, 1)";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("transition", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("steps(25), linear, cubic-bezier(0.25, 1, 0.5, 1)", property.Value);
+            Assert.That(property.Name, Is.EqualTo("transition"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("steps(25), linear, cubic-bezier(0.25, 1, 0.5, 1)"));
         }
 
         [Test]
@@ -272,11 +272,11 @@
         {
             var snippet = "transition : width   , height";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("transition", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("width, height", property.Value);
+            Assert.That(property.Name, Is.EqualTo("transition"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("width, height"));
         }
 
         [Test]
@@ -284,11 +284,11 @@
         {
             var snippet = "transition : ease";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("transition", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("ease", property.Value);
+            Assert.That(property.Name, Is.EqualTo("transition"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("ease"));
         }
 
         [Test]
@@ -296,11 +296,11 @@
         {
             var snippet = "transition : all 1s ease";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("transition", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("all 1s ease", property.Value);
+            Assert.That(property.Name, Is.EqualTo("transition"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("all 1s ease"));
         }
 
         [Test]
@@ -308,11 +308,11 @@
         {
             var snippet = "transition : all 1s ease, height steps(5) 50ms";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("transition", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("all 1s ease, height 50ms steps(5)", property.Value);
+            Assert.That(property.Name, Is.EqualTo("transition"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("all 1s ease, height 50ms steps(5)"));
         }
 
         [Test]
@@ -320,11 +320,11 @@
         {
             var snippet = "transition : all 1s ease, height step-start 50ms,width,cubic-bezier(0.2,0.5 , 1  ,  1)";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("transition", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("all 1s ease, height 50ms step-start, width, cubic-bezier(0.2, 0.5, 1, 1)", property.Value);
+            Assert.That(property.Name, Is.EqualTo("transition"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("all 1s ease, height 50ms step-start, width, cubic-bezier(0.2, 0.5, 1, 1)"));
         }
     }
 }

--- a/src/AngleSharp.Css.Tests/Declarations/CssVariables.cs
+++ b/src/AngleSharp.Css.Tests/Declarations/CssVariables.cs
@@ -13,15 +13,15 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var source = @":root { --my-variable: black; }";
             var sheet = ParseStyleSheet(source);
-            Assert.AreEqual(1, sheet.Rules.Length);
+            Assert.That(sheet.Rules.Length, Is.EqualTo(1));
             var style = sheet.Rules[0] as ICssStyleRule;
             Assert.IsNotNull(style);
-            Assert.AreEqual(":root", style.SelectorText);
-            Assert.AreEqual(1, style.Style.Length);
+            Assert.That(style.SelectorText, Is.EqualTo(":root"));
+            Assert.That(style.Style.Length, Is.EqualTo(1));
             var propertyName = style.Style[0];
             var propertyValue = style.Style[propertyName];
-            Assert.AreEqual("--my-variable", propertyName);
-            Assert.AreEqual("black", propertyValue);
+            Assert.That(propertyName, Is.EqualTo("--my-variable"));
+            Assert.That(propertyValue, Is.EqualTo("black"));
         }
 
         [Test]
@@ -29,11 +29,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var source = @":root { --my-vari@able: black; }";
             var sheet = ParseStyleSheet(source);
-            Assert.AreEqual(1, sheet.Rules.Length);
+            Assert.That(sheet.Rules.Length, Is.EqualTo(1));
             var style = sheet.Rules[0] as ICssStyleRule;
             Assert.IsNotNull(style);
-            Assert.AreEqual(":root", style.SelectorText);
-            Assert.AreEqual(0, style.Style.Length);
+            Assert.That(style.SelectorText, Is.EqualTo(":root"));
+            Assert.That(style.Style.Length, Is.EqualTo(0));
         }
 
         [Test]
@@ -44,8 +44,8 @@ namespace AngleSharp.Css.Tests.Declarations
             Assert.IsNotNull(property);
             var variable = property.RawValue as CssReferenceValue;
             Assert.IsNotNull(variable);
-            Assert.AreEqual(1, variable.References.Length);
-            Assert.AreEqual("--foo", variable.References[0].VariableName);
+            Assert.That(variable.References.Length, Is.EqualTo(1));
+            Assert.That(variable.References[0].VariableName, Is.EqualTo("--foo"));
             Assert.IsNull(variable.References[0].DefaultValue);
         }
 
@@ -57,9 +57,9 @@ namespace AngleSharp.Css.Tests.Declarations
             Assert.IsNotNull(property);
             var variable = property.RawValue as CssReferenceValue;
             Assert.IsNotNull(variable);
-            Assert.AreEqual(1, variable.References.Length);
-            Assert.AreEqual("--my-bar", variable.References[0].VariableName);
-            Assert.AreEqual("24px", variable.References[0].DefaultValue.CssText);
+            Assert.That(variable.References.Length, Is.EqualTo(1));
+            Assert.That(variable.References[0].VariableName, Is.EqualTo("--my-bar"));
+            Assert.That(variable.References[0].DefaultValue.CssText, Is.EqualTo("24px"));
         }
 
         [Test]
@@ -70,9 +70,9 @@ namespace AngleSharp.Css.Tests.Declarations
             Assert.IsNotNull(property);
             var variable = property.RawValue as CssReferenceValue;
             Assert.IsNotNull(variable);
-            Assert.AreEqual(1, variable.References.Length);
-            Assert.AreEqual("--color", variable.References[0].VariableName);
-            Assert.AreEqual("red, blue", variable.References[0].DefaultValue.CssText);
+            Assert.That(variable.References.Length, Is.EqualTo(1));
+            Assert.That(variable.References[0].VariableName, Is.EqualTo("--color"));
+            Assert.That(variable.References[0].DefaultValue.CssText, Is.EqualTo("red, blue"));
         }
 
         [Test]
@@ -83,8 +83,8 @@ namespace AngleSharp.Css.Tests.Declarations
             Assert.IsNotNull(property);
             var variable = property.RawValue as CssReferenceValue;
             Assert.IsNotNull(variable);
-            Assert.AreEqual(1, variable.References.Length);
-            Assert.AreEqual("--foo", variable.References[0].VariableName);
+            Assert.That(variable.References.Length, Is.EqualTo(1));
+            Assert.That(variable.References[0].VariableName, Is.EqualTo("--foo"));
             Assert.IsNull(variable.References[0].DefaultValue);
         }
 
@@ -96,8 +96,8 @@ namespace AngleSharp.Css.Tests.Declarations
             Assert.IsNotNull(property);
             var variable = property.RawValue as CssReferenceValue;
             Assert.IsNotNull(variable);
-            Assert.AreEqual(1, variable.References.Length);
-            Assert.AreEqual("--primary-color", variable.References[0].VariableName);
+            Assert.That(variable.References.Length, Is.EqualTo(1));
+            Assert.That(variable.References[0].VariableName, Is.EqualTo("--primary-color"));
             Assert.IsNull(variable.References[0].DefaultValue);
         }
 
@@ -109,11 +109,11 @@ namespace AngleSharp.Css.Tests.Declarations
             Assert.IsNotNull(property);
             var variable = property.RawValue as CssReferenceValue;
             Assert.IsNotNull(variable);
-            Assert.AreEqual(2, variable.References.Length);
-            Assert.AreEqual("--width", variable.References[0].VariableName);
+            Assert.That(variable.References.Length, Is.EqualTo(2));
+            Assert.That(variable.References[0].VariableName, Is.EqualTo("--width"));
             Assert.IsNull(variable.References[0].DefaultValue);
-            Assert.AreEqual("--color", variable.References[1].VariableName);
-            Assert.AreEqual("black", variable.References[1].DefaultValue.CssText);
+            Assert.That(variable.References[1].VariableName, Is.EqualTo("--color"));
+            Assert.That(variable.References[1].DefaultValue.CssText, Is.EqualTo("black"));
         }
     }
 }

--- a/src/AngleSharp.Css.Tests/Declarations/CssWidthProperty.cs
+++ b/src/AngleSharp.Css.Tests/Declarations/CssWidthProperty.cs
@@ -11,11 +11,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "width: auto";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("width", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("auto", property.Value);
+            Assert.That(property.Name, Is.EqualTo("width"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("auto"));
         }
         
         [Test]
@@ -23,11 +23,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "width: fit-content";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("width", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("fit-content", property.Value);
+            Assert.That(property.Name, Is.EqualTo("width"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("fit-content"));
         }
 
         [Test]
@@ -35,11 +35,11 @@ namespace AngleSharp.Css.Tests.Declarations
         {
             var snippet = "width: 42px";
             var property = ParseDeclaration(snippet);
-            Assert.AreEqual("width", property.Name);
-            Assert.IsFalse(property.IsImportant);
-            Assert.IsFalse(property.IsInherited);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("42px", property.Value);
+            Assert.That(property.Name, Is.EqualTo("width"));
+            Assert.That(property.IsImportant, Is.False);
+            Assert.That(property.IsInherited, Is.False);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("42px"));
         }
     }
 }

--- a/src/AngleSharp.Css.Tests/Extensions/AnalysisWindow.cs
+++ b/src/AngleSharp.Css.Tests/Extensions/AnalysisWindow.cs
@@ -21,12 +21,12 @@ namespace AngleSharp.Css.Tests.Extensions
             var element = document.QuerySelector("span.bold");
             Assert.IsNotNull(element);
 
-            Assert.AreEqual("span", element.LocalName);
-            Assert.AreEqual("bold", element.ClassName);
+            Assert.That(element.LocalName, Is.EqualTo("span"));
+            Assert.That(element.ClassName, Is.EqualTo("bold"));
 
             var style = window.GetComputedStyle(element);
             Assert.IsNotNull(style);
-            Assert.AreEqual(2, style.Length);
+            Assert.That(style.Length, Is.EqualTo(2));
         }
 
         [Test]
@@ -60,13 +60,13 @@ namespace AngleSharp.Css.Tests.Extensions
             // checks for element with text bold text
             var element = document.QuerySelector("span.bold");
             Assert.IsNotNull(element);
-            Assert.AreEqual("span", element.LocalName);
-            Assert.AreEqual("bold", element.ClassName);
+            Assert.That(element.LocalName, Is.EqualTo("span"));
+            Assert.That(element.ClassName, Is.EqualTo("bold"));
 
             var computedStyle = window.GetComputedStyle(element);
-            Assert.AreEqual("rgba(255, 0, 0, 1)", computedStyle.GetColor());
-            Assert.AreEqual("bold", computedStyle.GetFontWeight());
-            Assert.AreEqual(3, computedStyle.Length);
+            Assert.That(computedStyle.GetColor(), Is.EqualTo("rgba(255, 0, 0, 1)"));
+            Assert.That(computedStyle.GetFontWeight(), Is.EqualTo("bold"));
+            Assert.That(computedStyle.Length, Is.EqualTo(3));
         }
 
         [Test]
@@ -100,11 +100,11 @@ namespace AngleSharp.Css.Tests.Extensions
             // checks for element with text prioOne
             var prioOne = document.QuerySelector("#prioOne");
             Assert.IsNotNull(prioOne);
-            Assert.AreEqual("div", prioOne.LocalName);
-            Assert.AreEqual("prioOne", prioOne.Id);
+            Assert.That(prioOne.LocalName, Is.EqualTo("div"));
+            Assert.That(prioOne.Id, Is.EqualTo("prioOne"));
 
             var computePrioOneStyle = window.GetComputedStyle(prioOne);
-            Assert.AreEqual("rgba(0, 0, 0, 1)", computePrioOneStyle.GetColor());
+            Assert.That(computePrioOneStyle.GetColor(), Is.EqualTo("rgba(0, 0, 0, 1)"));
         }
 
         [Test]
@@ -130,11 +130,11 @@ namespace AngleSharp.Css.Tests.Extensions
             // checks for element with text bold text
             var element = document.QuerySelector("p > span");
             Assert.IsNotNull(element);
-            Assert.AreEqual("span", element.LocalName);
+            Assert.That(element.LocalName, Is.EqualTo("span"));
 
             var computedStyle = window.GetComputedStyle(element);
-            Assert.AreEqual("rgba(255, 0, 0, 1)", computedStyle.GetColor());
-            Assert.AreEqual(1, computedStyle.Length);
+            Assert.That(computedStyle.GetColor(), Is.EqualTo("rgba(255, 0, 0, 1)"));
+            Assert.That(computedStyle.Length, Is.EqualTo(1));
         }
 
         [Test]
@@ -165,20 +165,20 @@ em { font-style: italic !important; }
             var element = document.QuerySelector("#text");
             Assert.IsNotNull(element);
 
-            Assert.AreEqual("em", element.LocalName);
-            Assert.AreEqual("red", element.ClassName);
+            Assert.That(element.LocalName, Is.EqualTo("em"));
+            Assert.That(element.ClassName, Is.EqualTo("red"));
             Assert.IsNotNull(element.GetAttribute("style"));
-            Assert.AreEqual("text", element.TextContent);
+            Assert.That(element.TextContent, Is.EqualTo("text"));
 
             var style = window.GetComputedStyle(element);
             Assert.IsNotNull(style);
-            Assert.AreEqual(8, style.Length);
+            Assert.That(style.Length, Is.EqualTo(8));
 
-            Assert.AreEqual("0", style.GetMargin());
-            Assert.AreEqual("rgba(255, 0, 0, 1)", style.GetColor());
-            Assert.AreEqual("bold", style.GetFontWeight());
-            Assert.AreEqual("italic", style.GetFontStyle());
-            Assert.AreEqual("20px", style.GetFontSize());
+            Assert.That(style.GetMargin(), Is.EqualTo("0"));
+            Assert.That(style.GetColor(), Is.EqualTo("rgba(255, 0, 0, 1)"));
+            Assert.That(style.GetFontWeight(), Is.EqualTo("bold"));
+            Assert.That(style.GetFontStyle(), Is.EqualTo("italic"));
+            Assert.That(style.GetFontSize(), Is.EqualTo("20px"));
         }
 
         [Test]
@@ -193,12 +193,12 @@ em { font-style: italic !important; }
             var element = document.QuerySelector("span.bold");
             Assert.IsNotNull(element);
 
-            Assert.AreEqual("span", element.LocalName);
-            Assert.AreEqual("bold", element.ClassName);
+            Assert.That(element.LocalName, Is.EqualTo("span"));
+            Assert.That(element.ClassName, Is.EqualTo("bold"));
 
             var style = window.GetComputedStyle(element, ":after");
             Assert.IsNotNull(style);
-            Assert.AreEqual(2, style.Length);
+            Assert.That(style.Length, Is.EqualTo(2));
         }
 
         [Test]
@@ -213,12 +213,12 @@ em { font-style: italic !important; }
             var element = document.QuerySelector("span.bold");
             Assert.IsNotNull(element);
 
-            Assert.AreEqual("span", element.LocalName);
-            Assert.AreEqual("bold", element.ClassName);
+            Assert.That(element.LocalName, Is.EqualTo("span"));
+            Assert.That(element.ClassName, Is.EqualTo("bold"));
 
             var style = window.GetComputedStyle(element, "::after");
             Assert.IsNotNull(style);
-            Assert.AreEqual(2, style.Length);
+            Assert.That(style.Length, Is.EqualTo(2));
         }
 
         [Test]
@@ -233,16 +233,16 @@ em { font-style: italic !important; }
             var element = document.QuerySelector("span.bold");
             Assert.IsNotNull(element);
 
-            Assert.AreEqual("span", element.LocalName);
-            Assert.AreEqual("bold", element.ClassName);
+            Assert.That(element.LocalName, Is.EqualTo("span"));
+            Assert.That(element.ClassName, Is.EqualTo("bold"));
 
             var styleNormal = window.GetComputedStyle(element);
             Assert.IsNotNull(styleNormal);
-            Assert.AreEqual(2, styleNormal.Length);
+            Assert.That(styleNormal.Length, Is.EqualTo(2));
 
             var stylePseudo = window.GetComputedStyle(element, ":before");
             Assert.IsNotNull(stylePseudo);
-            Assert.AreEqual(3, stylePseudo.Length);
+            Assert.That(stylePseudo.Length, Is.EqualTo(3));
         }
 
         [Test]
@@ -259,7 +259,7 @@ em { font-style: italic !important; }
 
             var styleNormal = window.GetComputedStyle(element);
             Assert.IsNotNull(styleNormal);
-            Assert.AreEqual("uppercase", styleNormal.GetTextTransform());
+            Assert.That(styleNormal.GetTextTransform(), Is.EqualTo("uppercase"));
         }
 
         [Test]
@@ -276,7 +276,7 @@ em { font-style: italic !important; }
 
             var styleNormal = window.GetComputedStyle(element);
             Assert.IsNotNull(styleNormal);
-            Assert.AreEqual("uppercase", styleNormal.GetTextTransform());
+            Assert.That(styleNormal.GetTextTransform(), Is.EqualTo("uppercase"));
         }
 
         [Test]
@@ -288,7 +288,7 @@ em { font-style: italic !important; }
             var element = document.QuerySelector("span");
             var styleNormal = element.ComputeStyle();
             Assert.IsNotNull(styleNormal);
-            Assert.AreEqual("uppercase", styleNormal.GetTextTransform());
+            Assert.That(styleNormal.GetTextTransform(), Is.EqualTo("uppercase"));
         }
 
         [Test]
@@ -308,7 +308,7 @@ em { font-style: italic !important; }
             var document = await sheet.Context.OpenAsync(res => res.Content(@"<h3 id='target'>Test</h3>"));
             var sc = new StyleCollection(new[] { sheet }, new DefaultRenderDevice());
             var style = sc.ComputeCascadedStyle(document.QuerySelector("h3"));
-            Assert.AreEqual("rgba(0, 0, 255, 1)", style.GetColor());
+            Assert.That(style.GetColor(), Is.EqualTo("rgba(0, 0, 255, 1)"));
         }
 
         [Test]
@@ -318,7 +318,7 @@ em { font-style: italic !important; }
             var document = await sheet.Context.OpenAsync(res => res.Content(@"<p>This is <span>only</span> a test.</p>"));
             var sc = new StyleCollection(new[] { sheet }, new DefaultRenderDevice());
             var style = sc.ComputeDeclarations(document.QuerySelector("span"));
-            Assert.AreEqual("24px", style.GetFontSize());
+            Assert.That(style.GetFontSize(), Is.EqualTo("24px"));
         }
 
         [Test]
@@ -335,7 +335,7 @@ em { font-style: italic !important; }
             var document = await sheet.Context.OpenAsync(res => res.Content(@"<p>This is a test</p>"));
             var sc = new StyleCollection(new[] { sheet }, new DefaultRenderDevice());
             var style = sc.ComputeDeclarations(document.QuerySelector("p"));
-            Assert.AreEqual("rgba(255, 255, 255, 1)", style.GetColor());
+            Assert.That(style.GetColor(), Is.EqualTo("rgba(255, 255, 255, 1)"));
         }
 
         [Test]
@@ -352,7 +352,7 @@ em { font-style: italic !important; }
             var document = await sheet.Context.OpenAsync(res => res.Content(@"<p>This is a test</p>"));
             var sc = new StyleCollection(new[] { sheet }, new DefaultRenderDevice());
             var style = sc.ComputeDeclarations(document.QuerySelector("p"));
-            Assert.AreEqual("rgba(255, 255, 255, 1)", style.GetColor());
+            Assert.That(style.GetColor(), Is.EqualTo("rgba(255, 255, 255, 1)"));
         }
 
         [Test]
@@ -367,7 +367,7 @@ em { font-style: italic !important; }
             var document = await sheet.Context.OpenAsync(res => res.Content(@"<p>This is a test</p>"));
             var sc = new StyleCollection(new[] { sheet }, new DefaultRenderDevice());
             var style = sc.ComputeDeclarations(document.QuerySelector("p"));
-            Assert.AreEqual("rgba(0, 128, 0, 1)", style.GetColor());
+            Assert.That(style.GetColor(), Is.EqualTo("rgba(0, 128, 0, 1)"));
         }
 
         [Test]
@@ -384,7 +384,7 @@ em { font-style: italic !important; }
             var document = await sheet.Context.OpenAsync(res => res.Content(@"<p>This is a test</p>"));
             var sc = new StyleCollection(new[] { sheet }, new DefaultRenderDevice());
             var style = sc.ComputeDeclarations(document.QuerySelector("p"));
-            Assert.AreEqual("rgba(0, 128, 0, 1)", style.GetColor());
+            Assert.That(style.GetColor(), Is.EqualTo("rgba(0, 128, 0, 1)"));
         }
 
         [Test]
@@ -406,7 +406,7 @@ em { font-style: italic !important; }
             var document = await sheet.Context.OpenAsync(res => res.Content(@"<p>This is a test</p>"));
             var sc = new StyleCollection(new[] { sheet }, new DefaultRenderDevice());
             var style = sc.ComputeDeclarations(document.QuerySelector("p"));
-            Assert.AreEqual("rgba(0, 128, 0, 1)", style.GetColor());
+            Assert.That(style.GetColor(), Is.EqualTo("rgba(0, 128, 0, 1)"));
         }
     }
 }

--- a/src/AngleSharp.Css.Tests/Extensions/ApiExtension.cs
+++ b/src/AngleSharp.Css.Tests/Extensions/ApiExtension.cs
@@ -1,4 +1,4 @@
-﻿namespace AngleSharp.Css.Tests.Extensions
+namespace AngleSharp.Css.Tests.Extensions
 {
     using AngleSharp.Dom;
     using NUnit.Framework;
@@ -13,7 +13,7 @@
         {
             var document = ParseDocument("");
             var elements = document.QuerySelectorAll("li").Css(new { });
-            Assert.AreEqual(0, elements.Count());
+            Assert.That(elements.Count(), Is.EqualTo(0));
         }
 
         [Test]
@@ -21,7 +21,7 @@
         {
             var document = ParseDocument("");
             var elements = document.QuerySelectorAll("li").Css("color", "red");
-            Assert.AreEqual(0, elements.Count());
+            Assert.That(elements.Count(), Is.EqualTo(0));
         }
     }
 }

--- a/src/AngleSharp.Css.Tests/Extensions/AsyncParsing.cs
+++ b/src/AngleSharp.Css.Tests/Extensions/AsyncParsing.cs
@@ -1,4 +1,4 @@
-﻿namespace AngleSharp.Css.Tests.Extensions
+namespace AngleSharp.Css.Tests.Extensions
 {
     using AngleSharp.Css.Parser;
     using AngleSharp.Css.Tests.Mocks;
@@ -19,11 +19,11 @@
 
             using (var task = parser.ParseStyleSheetAsync(source))
             {
-                Assert.IsFalse(task.IsCompleted);
+                Assert.That(task.IsCompleted, Is.False);
                 var result = await task;
 
-                Assert.IsTrue(task.IsCompleted);
-                Assert.AreEqual(4, result.Rules.Length);
+                Assert.That(task.IsCompleted, Is.True);
+                Assert.That(result.Rules.Length, Is.EqualTo(4));
             }
         }
 
@@ -36,11 +36,11 @@
 
             using (var task = parser.ParseStyleSheetAsync(source))
             {
-                Assert.IsTrue(task.IsCompleted);
+                Assert.That(task.IsCompleted, Is.True);
                 var result = await task;
 
-                Assert.AreEqual(result, result);
-                Assert.AreEqual(4, result.Rules.Length);
+                Assert.That(result, Is.EqualTo(result));
+                Assert.That(result.Rules.Length, Is.EqualTo(4));
             }
         }
     }

--- a/src/AngleSharp.Css.Tests/Extensions/Elements.cs
+++ b/src/AngleSharp.Css.Tests/Extensions/Elements.cs
@@ -19,9 +19,9 @@ namespace AngleSharp.Css.Tests.Extensions
             var divs = document.QuerySelectorAll("div");
             divs.SetStyle(style => style.SetBackground("red"));
 
-            Assert.AreEqual("rgba(255, 0, 0, 1)", divs.Skip(0).First().GetStyle().GetBackground());
-            Assert.AreEqual("rgba(255, 0, 0, 1)", divs.Skip(1).First().GetStyle().GetBackground());
-            Assert.AreEqual("rgba(255, 0, 0, 1)", divs.Skip(2).First().GetStyle().GetBackground());
+            Assert.That(divs.Skip(0).First().GetStyle().GetBackground(), Is.EqualTo("rgba(255, 0, 0, 1)"));
+            Assert.That(divs.Skip(1).First().GetStyle().GetBackground(), Is.EqualTo("rgba(255, 0, 0, 1)"));
+            Assert.That(divs.Skip(2).First().GetStyle().GetBackground(), Is.EqualTo("rgba(255, 0, 0, 1)"));
         }
 
         [Test]
@@ -45,8 +45,8 @@ namespace AngleSharp.Css.Tests.Extensions
             var tree = document.DefaultView.Render();
             var node = tree.Find(document.QuerySelector("div"));
             await node.DownloadResources();
-            Assert.AreEqual(1, urls.Count);
-            Assert.AreEqual("https://avatars1.githubusercontent.com/u/10828168?s=200&v=4", urls[0].Href);
+            Assert.That(urls.Count, Is.EqualTo(1));
+            Assert.That(urls[0].Href, Is.EqualTo("https://avatars1.githubusercontent.com/u/10828168?s=200&v=4"));
         }
     }
 }

--- a/src/AngleSharp.Css.Tests/Extensions/InnerText.cs
+++ b/src/AngleSharp.Css.Tests/Extensions/InnerText.cs
@@ -20,8 +20,8 @@ namespace AngleSharp.Css.Tests.Extensions
 
             doc.Body.SetInnerText(fixture);
 
-            Assert.AreEqual(expectedInnerText, doc.Body.GetInnerText());
-            Assert.AreEqual(expectedHtml, doc.Body.InnerHtml);
+            Assert.That(doc.Body.GetInnerText(), Is.EqualTo(expectedInnerText));
+            Assert.That(doc.Body.InnerHtml, Is.EqualTo(expectedHtml));
         }
 
         // text & spaces
@@ -82,7 +82,7 @@ namespace AngleSharp.Css.Tests.Extensions
             var config = Configuration.Default.With(defaultSheet).WithCss();
             var doc = fixture.ToHtmlDocument(config);
 
-            Assert.AreEqual(expected, doc.Body.GetInnerText());
+            Assert.That(doc.Body.GetInnerText(), Is.EqualTo(expected));
         }
 
         [Test]
@@ -92,7 +92,7 @@ namespace AngleSharp.Css.Tests.Extensions
             var document = ("<div><div>Div with <span>a span</span> in it.</div></div>").ToHtmlDocument(config);
             var element = document.QuerySelector("div");
 
-            Assert.AreEqual("Div with a span in it.", element.GetInnerText());
+            Assert.That(element.GetInnerText(), Is.EqualTo("Div with a span in it."));
         }
     }
 }

--- a/src/AngleSharp.Css.Tests/Extensions/Nesting.cs
+++ b/src/AngleSharp.Css.Tests/Extensions/Nesting.cs
@@ -22,7 +22,7 @@ namespace AngleSharp.Css.Tests.Extensions
             var element = document.QuerySelector(".bar");
             var style = window.GetComputedStyle(element);
 
-            Assert.AreEqual("22.4px", style.GetFontSize());
+            Assert.That(style.GetFontSize(), Is.EqualTo("22.4px"));
         }
 
         [Test]
@@ -40,7 +40,7 @@ namespace AngleSharp.Css.Tests.Extensions
             var styleCollection = window.GetStyleCollection();
             var style = styleCollection.GetDeclarations(element);
 
-            Assert.AreEqual("1.4rem", style.GetFontSize());
+            Assert.That(style.GetFontSize(), Is.EqualTo("1.4rem"));
         }
 
         [Test]
@@ -57,7 +57,7 @@ namespace AngleSharp.Css.Tests.Extensions
             var element = document.QuerySelector(".bar");
             var style = window.GetComputedStyle(element);
 
-            Assert.AreEqual("22.4px", style.GetFontSize());
+            Assert.That(style.GetFontSize(), Is.EqualTo("22.4px"));
         }
 
         [Test]
@@ -78,7 +78,7 @@ namespace AngleSharp.Css.Tests.Extensions
             var element = document.QuerySelector(".bar");
             var style = window.GetComputedStyle(element);
 
-            Assert.AreEqual("22.4px", style.GetFontSize());
+            Assert.That(style.GetFontSize(), Is.EqualTo("22.4px"));
         }
 
         [Test]
@@ -95,7 +95,7 @@ namespace AngleSharp.Css.Tests.Extensions
             var element = document.QuerySelector(".bar");
             var style = window.GetComputedStyle(element);
 
-            Assert.AreEqual("rgba(0, 128, 0, 1)", style.GetColor());
+            Assert.That(style.GetColor(), Is.EqualTo("rgba(0, 128, 0, 1)"));
         }
 
         [Test]
@@ -112,7 +112,7 @@ namespace AngleSharp.Css.Tests.Extensions
             var element = document.QuerySelector("li");
             var style = window.GetComputedStyle(element);
 
-            Assert.AreEqual("rgba(0, 128, 0, 1)", style.GetColor());
+            Assert.That(style.GetColor(), Is.EqualTo("rgba(0, 128, 0, 1)"));
         }
     }
 }

--- a/src/AngleSharp.Css.Tests/Functions/CssColorFunction.cs
+++ b/src/AngleSharp.Css.Tests/Functions/CssColorFunction.cs
@@ -17,7 +17,7 @@ namespace AngleSharp.Css.Tests.Functions
             var p = dom.QuerySelector("p");
             var s = p.GetStyle();
             var color = s.GetColor();
-            Assert.AreEqual("rgba(0, 17, 0, 1)", color);
+            Assert.That(color, Is.EqualTo("rgba(0, 17, 0, 1)"));
         }
 
         [Test]
@@ -28,7 +28,7 @@ namespace AngleSharp.Css.Tests.Functions
             var p = dom.QuerySelector("p");
             var s = p.GetStyle();
             var color = s.GetColor();
-            Assert.AreEqual("rgba(255, 122, 127, 0.8)", color);
+            Assert.That(color, Is.EqualTo("rgba(255, 122, 127, 0.8)"));
         }
 
         [Test]
@@ -39,7 +39,7 @@ namespace AngleSharp.Css.Tests.Functions
             var p = dom.QuerySelector("p");
             var s = p.GetStyle();
             var color = s.GetColor();
-            Assert.AreEqual("rgba(255, 26, 128, 0.7)", color);
+            Assert.That(color, Is.EqualTo("rgba(255, 26, 128, 0.7)"));
         }
 
         [Test]
@@ -50,7 +50,7 @@ namespace AngleSharp.Css.Tests.Functions
             var p = dom.QuerySelector("p");
             var s = p.GetStyle();
             var color = s.GetColor();
-            Assert.AreEqual("rgba(255, 0, 128, 0.35)", color);
+            Assert.That(color, Is.EqualTo("rgba(255, 0, 128, 0.35)"));
         }
 
         [Test]
@@ -61,7 +61,7 @@ namespace AngleSharp.Css.Tests.Functions
             var p = dom.QuerySelector("p");
             var s = p.GetStyle();
             var color = s.GetColor();
-            Assert.AreEqual("rgba(125, 35, 40, 1)", color);
+            Assert.That(color, Is.EqualTo("rgba(125, 35, 40, 1)"));
         }
 
         [Test]
@@ -72,7 +72,7 @@ namespace AngleSharp.Css.Tests.Functions
             var p = dom.QuerySelector("p");
             var s = p.GetStyle();
             var color = s.GetColor();
-            Assert.AreEqual("rgba(198, 93, 7, 1)", color);
+            Assert.That(color, Is.EqualTo("rgba(198, 93, 7, 1)"));
         }
 
         [Test]
@@ -83,7 +83,7 @@ namespace AngleSharp.Css.Tests.Functions
             var p = dom.QuerySelector("p");
             var s = p.GetStyle();
             var color = s.GetColor();
-            Assert.AreEqual("rgba(198, 93, 7, 0.5)", color);
+            Assert.That(color, Is.EqualTo("rgba(198, 93, 7, 0.5)"));
         }
 
         [Test]
@@ -94,7 +94,7 @@ namespace AngleSharp.Css.Tests.Functions
             var p = dom.QuerySelector("p");
             var s = p.GetStyle();
             var color = s.GetColor();
-            Assert.AreEqual("rgba(125, 35, 40, 1)", color);
+            Assert.That(color, Is.EqualTo("rgba(125, 35, 40, 1)"));
         }
 
         [Test]
@@ -105,7 +105,7 @@ namespace AngleSharp.Css.Tests.Functions
             var p = dom.QuerySelector("p");
             var s = p.GetStyle();
             var color = s.GetColor();
-            Assert.AreEqual("rgba(198, 93, 7, 1)", color);
+            Assert.That(color, Is.EqualTo("rgba(198, 93, 7, 1)"));
         }
 
         [Test]
@@ -116,7 +116,7 @@ namespace AngleSharp.Css.Tests.Functions
             var p = dom.QuerySelector("p");
             var s = p.GetStyle();
             var color = s.GetColor();
-            Assert.AreEqual("rgba(198, 93, 7, 0.5)", color);
+            Assert.That(color, Is.EqualTo("rgba(198, 93, 7, 0.5)"));
         }
 
         [Test]
@@ -127,7 +127,7 @@ namespace AngleSharp.Css.Tests.Functions
             var p = dom.QuerySelector("p");
             var s = p.GetStyle();
             var color = s.GetColor();
-            Assert.AreEqual("rgba(125, 35, 40, 1)", color);
+            Assert.That(color, Is.EqualTo("rgba(125, 35, 40, 1)"));
         }
 
         [Test]
@@ -138,7 +138,7 @@ namespace AngleSharp.Css.Tests.Functions
             var p = dom.QuerySelector("p");
             var s = p.GetStyle();
             var color = s.GetColor();
-            Assert.AreEqual("rgba(198, 93, 6, 1)", color);
+            Assert.That(color, Is.EqualTo("rgba(198, 93, 6, 1)"));
         }
 
         [Test]
@@ -149,7 +149,7 @@ namespace AngleSharp.Css.Tests.Functions
             var p = dom.QuerySelector("p");
             var s = p.GetStyle();
             var color = s.GetColor();
-            Assert.AreEqual("rgba(198, 93, 6, 0.5)", color);
+            Assert.That(color, Is.EqualTo("rgba(198, 93, 6, 0.5)"));
         }
 
         [Test]
@@ -160,7 +160,7 @@ namespace AngleSharp.Css.Tests.Functions
             var p = dom.QuerySelector("p");
             var s = p.GetStyle();
             var color = s.GetColor();
-            Assert.AreEqual("rgba(125, 35, 40, 1)", color);
+            Assert.That(color, Is.EqualTo("rgba(125, 35, 40, 1)"));
         }
 
         [Test]
@@ -171,7 +171,7 @@ namespace AngleSharp.Css.Tests.Functions
             var p = dom.QuerySelector("p");
             var s = p.GetStyle();
             var color = s.GetColor();
-            Assert.AreEqual("rgba(198, 93, 6, 1)", color);
+            Assert.That(color, Is.EqualTo("rgba(198, 93, 6, 1)"));
         }
 
         [Test]
@@ -182,7 +182,7 @@ namespace AngleSharp.Css.Tests.Functions
             var p = dom.QuerySelector("p");
             var s = p.GetStyle();
             var color = s.GetColor();
-            Assert.AreEqual("rgba(198, 93, 6, 0.5)", color);
+            Assert.That(color, Is.EqualTo("rgba(198, 93, 6, 0.5)"));
         }
     }
 }

--- a/src/AngleSharp.Css.Tests/Functions/CssDocumentFunction.cs
+++ b/src/AngleSharp.Css.Tests/Functions/CssDocumentFunction.cs
@@ -1,4 +1,4 @@
-﻿namespace AngleSharp.Css.Tests.Functions
+namespace AngleSharp.Css.Tests.Functions
 {
     using AngleSharp.Css.Dom;
     using AngleSharp.Dom;
@@ -15,13 +15,13 @@
             var snippet = "@document url(http://www.w3.org/) { }";
             var rule = ParseRule(snippet) as ICssDocumentRule;
             Assert.IsNotNull(rule);
-            Assert.AreEqual(CssRuleType.Document, rule.Type);
-            Assert.AreEqual(1, rule.Conditions.Count());
+            Assert.That(rule.Type, Is.EqualTo(CssRuleType.Document));
+            Assert.That(rule.Conditions.Count(), Is.EqualTo(1));
             var condition = rule.Conditions.First();
-            Assert.AreEqual("url", condition.Name);
-            Assert.AreEqual("http://www.w3.org/", condition.Data);
-            Assert.IsFalse(condition.Matches(Url.Create("https://www.w3.org/")));
-            Assert.IsTrue(condition.Matches(Url.Create("http://www.w3.org")));
+            Assert.That(condition.Name, Is.EqualTo("url"));
+            Assert.That(condition.Data, Is.EqualTo("http://www.w3.org/"));
+            Assert.That(condition.Matches(Url.Create("https://www.w3.org/")), Is.False);
+            Assert.That(condition.Matches(Url.Create("http://www.w3.org")), Is.True);
         }
 
         [Test]
@@ -30,13 +30,13 @@
             var snippet = "@document url-prefix('http://www.w3.org/Style/') { }";
             var rule = ParseRule(snippet) as ICssDocumentRule;
             Assert.IsNotNull(rule);
-            Assert.AreEqual(CssRuleType.Document, rule.Type);
-            Assert.AreEqual(1, rule.Conditions.Count());
+            Assert.That(rule.Type, Is.EqualTo(CssRuleType.Document));
+            Assert.That(rule.Conditions.Count(), Is.EqualTo(1));
             var condition = rule.Conditions.First();
-            Assert.AreEqual("url-prefix", condition.Name);
-            Assert.AreEqual("http://www.w3.org/Style/", condition.Data);
-            Assert.IsFalse(condition.Matches(Url.Create("https://www.w3.org/Style/")));
-            Assert.IsTrue(condition.Matches(Url.Create("http://www.w3.org/Style/foo/bar")));
+            Assert.That(condition.Name, Is.EqualTo("url-prefix"));
+            Assert.That(condition.Data, Is.EqualTo("http://www.w3.org/Style/"));
+            Assert.That(condition.Matches(Url.Create("https://www.w3.org/Style/")), Is.False);
+            Assert.That(condition.Matches(Url.Create("http://www.w3.org/Style/foo/bar")), Is.True);
         }
 
         [Test]
@@ -45,15 +45,15 @@
             var snippet = "@document domain('mozilla.org') { }";
             var rule = ParseRule(snippet) as ICssDocumentRule;
             Assert.IsNotNull(rule);
-            Assert.AreEqual(CssRuleType.Document, rule.Type);
-            Assert.AreEqual(1, rule.Conditions.Count());
+            Assert.That(rule.Type, Is.EqualTo(CssRuleType.Document));
+            Assert.That(rule.Conditions.Count(), Is.EqualTo(1));
             var condition = rule.Conditions.First();
-            Assert.AreEqual("domain", condition.Name);
-            Assert.AreEqual("mozilla.org", condition.Data);
-            Assert.IsFalse(condition.Matches(Url.Create("https://www.w3.org/")));
-            Assert.IsTrue(condition.Matches(Url.Create("http://mozilla.org")));
-            Assert.IsTrue(condition.Matches(Url.Create("http://www.mozilla.org")));
-            Assert.IsTrue(condition.Matches(Url.Create("http://foo.mozilla.org")));
+            Assert.That(condition.Name, Is.EqualTo("domain"));
+            Assert.That(condition.Data, Is.EqualTo("mozilla.org"));
+            Assert.That(condition.Matches(Url.Create("https://www.w3.org/")), Is.False);
+            Assert.That(condition.Matches(Url.Create("http://mozilla.org")), Is.True);
+            Assert.That(condition.Matches(Url.Create("http://www.mozilla.org")), Is.True);
+            Assert.That(condition.Matches(Url.Create("http://foo.mozilla.org")), Is.True);
         }
 
         [Test]
@@ -62,13 +62,13 @@
             var snippet = "@document regexp(\"https:.*\") { }";
             var rule = ParseRule(snippet) as ICssDocumentRule;
             Assert.IsNotNull(rule);
-            Assert.AreEqual(CssRuleType.Document, rule.Type);
-            Assert.AreEqual(1, rule.Conditions.Count());
+            Assert.That(rule.Type, Is.EqualTo(CssRuleType.Document));
+            Assert.That(rule.Conditions.Count(), Is.EqualTo(1));
             var condition = rule.Conditions.First();
-            Assert.AreEqual("regexp", condition.Name);
-            Assert.AreEqual("https:.*", condition.Data);
-            Assert.IsFalse(condition.Matches(Url.Create("http://www.w3.org")));
-            Assert.IsTrue(condition.Matches(Url.Create("https://www.w3.org/")));
+            Assert.That(condition.Name, Is.EqualTo("regexp"));
+            Assert.That(condition.Data, Is.EqualTo("https:.*"));
+            Assert.That(condition.Matches(Url.Create("http://www.w3.org")), Is.False);
+            Assert.That(condition.Matches(Url.Create("https://www.w3.org/")), Is.True);
         }
 
         [Test]
@@ -77,13 +77,13 @@
             var snippet = "@document url(http://www.w3.org/), url-prefix('http://www.w3.org/Style/'), domain('mozilla.org'), regexp(\"https:.*\") { }";
             var rule = ParseRule(snippet) as CssDocumentRule;
             Assert.IsNotNull(rule);
-            Assert.AreEqual(CssRuleType.Document, rule.Type);
-            Assert.AreEqual(4, rule.Conditions.Count());
-            Assert.IsTrue(rule.IsValid(Url.Create("https://www.w3.org/")));
-            Assert.IsTrue(rule.IsValid(Url.Create("http://www.w3.org/")));
-            Assert.IsTrue(rule.IsValid(Url.Create("http://www.w3.org/Style/bar")));
-            Assert.IsTrue(rule.IsValid(Url.Create("https://test.mozilla.org/foo")));
-            Assert.IsFalse(rule.IsValid(Url.Create("http://localhost")));
+            Assert.That(rule.Type, Is.EqualTo(CssRuleType.Document));
+            Assert.That(rule.Conditions.Count(), Is.EqualTo(4));
+            Assert.That(rule.IsValid(Url.Create("https://www.w3.org/")), Is.True);
+            Assert.That(rule.IsValid(Url.Create("http://www.w3.org/")), Is.True);
+            Assert.That(rule.IsValid(Url.Create("http://www.w3.org/Style/bar")), Is.True);
+            Assert.That(rule.IsValid(Url.Create("https://test.mozilla.org/foo")), Is.True);
+            Assert.That(rule.IsValid(Url.Create("http://localhost")), Is.False);
         }
     }
 }

--- a/src/AngleSharp.Css.Tests/Functions/CssHelpers.cs
+++ b/src/AngleSharp.Css.Tests/Functions/CssHelpers.cs
@@ -1,4 +1,4 @@
-﻿namespace AngleSharp.Css.Tests.Functions
+namespace AngleSharp.Css.Tests.Functions
 {
     using AngleSharp.Css.Dom;
     using NUnit.Framework;
@@ -11,7 +11,7 @@
         {
             var str = "";
             var escaped = CssHelpers.Escape(str);
-            Assert.AreEqual("", escaped);
+            Assert.That(escaped, Is.EqualTo(""));
         }
 
         [Test]
@@ -19,7 +19,7 @@
         {
             var str = "abc";
             var escaped = CssHelpers.Escape(str);
-            Assert.AreEqual("abc", escaped);
+            Assert.That(escaped, Is.EqualTo("abc"));
         }
 
         [Test]
@@ -27,7 +27,7 @@
         {
             var str = "-";
             var escaped = CssHelpers.Escape(str);
-            Assert.AreEqual("\\-", escaped);
+            Assert.That(escaped, Is.EqualTo("\\-"));
         }
 
         [Test]
@@ -35,7 +35,7 @@
         {
             var str = "-bc";
             var escaped = CssHelpers.Escape(str);
-            Assert.AreEqual("-bc", escaped);
+            Assert.That(escaped, Is.EqualTo("-bc"));
         }
 
         [Test]
@@ -43,7 +43,7 @@
         {
             var str = "123";
             var escaped = CssHelpers.Escape(str);
-            Assert.AreEqual("\\31 23", escaped);
+            Assert.That(escaped, Is.EqualTo("\\31 23"));
         }
 
         [Test]
@@ -51,7 +51,7 @@
         {
             var str = "1.23";
             var escaped = CssHelpers.Escape(str);
-            Assert.AreEqual("\\31 \\.23", escaped);
+            Assert.That(escaped, Is.EqualTo("\\31 \\.23"));
         }
 
         [Test]
@@ -59,7 +59,7 @@
         {
             var str = "\0";
             var escaped = CssHelpers.Escape(str);
-            Assert.AreEqual("\ufffd", escaped);
+            Assert.That(escaped, Is.EqualTo("\ufffd"));
         }
 
         [Test]
@@ -67,7 +67,7 @@
         {
             var str = "0";
             var escaped = CssHelpers.Escape(str);
-            Assert.AreEqual(@"\30 ", escaped);
+            Assert.That(escaped, Is.EqualTo(@"\30 "));
         }
 
         [Test]
@@ -75,7 +75,7 @@
         {
             var str = "--a";
             var escaped = CssHelpers.Escape(str);
-            Assert.AreEqual("--a", escaped);
+            Assert.That(escaped, Is.EqualTo("--a"));
         }
 
         [Test]
@@ -83,7 +83,7 @@
         {
             var str = "()[]{}";
             var escaped = CssHelpers.Escape(str);
-            Assert.AreEqual(@"\(\)\[\]\{\}", escaped);
+            Assert.That(escaped, Is.EqualTo(@"\(\)\[\]\{\}"));
         }
 
         [Test]
@@ -91,7 +91,7 @@
         {
             var str = ".foo#bar";
             var escaped = CssHelpers.Escape(str);
-            Assert.AreEqual(@"\.foo\#bar", escaped);
+            Assert.That(escaped, Is.EqualTo(@"\.foo\#bar"));
         }
     }
 }

--- a/src/AngleSharp.Css.Tests/Library/ComputedStyle.cs
+++ b/src/AngleSharp.Css.Tests/Library/ComputedStyle.cs
@@ -23,7 +23,7 @@ namespace AngleSharp.Css.Tests.Library
             var span = document.QuerySelector("span");
             var fontSize = span.ComputeCurrentStyle().GetProperty("font-size");
 
-            Assert.AreEqual("24px", fontSize.Value);
+            Assert.That(fontSize.Value, Is.EqualTo("24px"));
         }
     }
 }

--- a/src/AngleSharp.Css.Tests/Library/ExtractInfos.cs
+++ b/src/AngleSharp.Css.Tests/Library/ExtractInfos.cs
@@ -25,7 +25,7 @@ namespace AngleSharp.Css.Tests.Library
             var fontFace = sheet.Rules[0] as ICssFontFaceRule;
             var src = fontFace.GetProperty("src").RawValue;
             var url = ((src as ICssMultipleValue)[0] as ICssMultipleValue)[0] as CssUrlValue;
-            Assert.AreEqual("https://example.org/some-font.ttf", url.Path);
+            Assert.That(url.Path, Is.EqualTo("https://example.org/some-font.ttf"));
         }
     }
 }

--- a/src/AngleSharp.Css.Tests/Library/StringRepresentation.cs
+++ b/src/AngleSharp.Css.Tests/Library/StringRepresentation.cs
@@ -25,7 +25,7 @@ namespace AngleSharp.Css.Tests.Library
             using (var stringWriter = new StringWriter())
             {
                 document.ToCss(stringWriter, new PrettyStyleFormatter());
-                Assert.AreEqual("@media (min-width: 800px) { \n\t.ad_column {\n\t\twidth: 728px;\n\t\theight: 90px;\n\t}\n}", stringWriter.ToString());
+                Assert.That(stringWriter.ToString(), Is.EqualTo("@media (min-width: 800px) { \n\t.ad_column {\n\t\twidth: 728px;\n\t\theight: 90px;\n\t}\n}"));
             }
         }
 
@@ -36,7 +36,7 @@ namespace AngleSharp.Css.Tests.Library
             CssColorValue.UseHex = true;
             var text = color.CssText;
             CssColorValue.UseHex = false;
-            Assert.AreEqual("#410C30", text);
+            Assert.That(text, Is.EqualTo("#410C30"));
         }
 
         [Test]
@@ -46,7 +46,7 @@ namespace AngleSharp.Css.Tests.Library
             CssColorValue.UseHex = true;
             var text = color.CssText;
             CssColorValue.UseHex = false;
-            Assert.AreEqual("#410C300A", text);
+            Assert.That(text, Is.EqualTo("#410C300A"));
         }
 
         [Test]
@@ -56,7 +56,7 @@ namespace AngleSharp.Css.Tests.Library
             var dom = ParseDocument(html);
             var styleSheet = dom.StyleSheets[0] as ICssStyleSheet;
             var css = styleSheet.ToCss();
-            Assert.AreEqual("#x div { padding: inherit }", css);
+            Assert.That(css, Is.EqualTo("#x div { padding: inherit }"));
         }
 
         [Test]
@@ -66,7 +66,7 @@ namespace AngleSharp.Css.Tests.Library
             var dom = ParseDocument(html);
             var styleSheet = dom.StyleSheets[0] as ICssStyleSheet;
             var css = styleSheet.ToCss();
-            Assert.AreEqual("#x div { margin: inherit }", css);
+            Assert.That(css, Is.EqualTo("#x div { margin: inherit }"));
         }
 
         [Test]
@@ -76,7 +76,7 @@ namespace AngleSharp.Css.Tests.Library
             var dom = ParseDocument(html);
             var styleSheet = dom.StyleSheets[0] as ICssStyleSheet;
             var css = styleSheet.ToCss();
-            Assert.AreEqual("#x div { border: inherit }", css);
+            Assert.That(css, Is.EqualTo("#x div { border: inherit }"));
         }
 
         [Test]
@@ -86,7 +86,7 @@ namespace AngleSharp.Css.Tests.Library
             var dom = ParseDocument(html);
             var styleSheet = dom.StyleSheets[0] as ICssStyleSheet;
             var css = styleSheet.ToCss();
-            Assert.AreEqual("div { background: conic-gradient(rgba(255, 0, 0, 1), rgba(255, 255, 0, 1), rgba(0, 128, 0, 1)) }", css);
+            Assert.That(css, Is.EqualTo("div { background: conic-gradient(rgba(255, 0, 0, 1), rgba(255, 255, 0, 1), rgba(0, 128, 0, 1)) }"));
         }
 
         [Test]
@@ -97,7 +97,7 @@ namespace AngleSharp.Css.Tests.Library
 
             var generatedCss = styleSheet.ToCss();
 
-            Assert.AreEqual(css, generatedCss);
+            Assert.That(generatedCss, Is.EqualTo(css));
         }
 
         [Test]
@@ -108,7 +108,7 @@ namespace AngleSharp.Css.Tests.Library
 
             var generatedCss = styleSheet.ToCss();
 
-            Assert.AreEqual(css, generatedCss);
+            Assert.That(generatedCss, Is.EqualTo(css));
         }
 
         [Test]
@@ -125,7 +125,7 @@ namespace AngleSharp.Css.Tests.Library
             var style = div.GetStyle();
             var css = style.ToCss();
 
-            Assert.AreEqual("background-image: var(--urlSpellingErrorV2,url(\"https://www.example.com/))", css);
+            Assert.That(css, Is.EqualTo("background-image: var(--urlSpellingErrorV2,url(\"https://www.example.com/))"));
         }
 
         [Test]
@@ -142,7 +142,7 @@ namespace AngleSharp.Css.Tests.Library
             var style = div.GetStyle();
             var css = style.ToCss();
 
-            Assert.AreEqual("color: rgba(255, 0, 0, 1)", css);
+            Assert.That(css, Is.EqualTo("color: rgba(255, 0, 0, 1)"));
         }
 
         [Test]
@@ -154,7 +154,7 @@ namespace AngleSharp.Css.Tests.Library
             var style = div.GetStyle();
             var css = style.ToCss();
 
-            Assert.AreEqual("border-width: 1px", css);
+            Assert.That(css, Is.EqualTo("border-width: 1px"));
         }
 
         [Test]
@@ -175,8 +175,8 @@ namespace AngleSharp.Css.Tests.Library
             var context = BrowsingContext.New(config);
             var document = await context.OpenAsync((res) => res.Content(html));
             var link = document.QuerySelector<IHtmlLinkElement>("link");
-            Assert.AreEqual("", link.Sheet.Media.MediaText);
-            Assert.IsTrue(link.Sheet.Media.Validate(new DefaultRenderDevice()));
+            Assert.That(link.Sheet.Media.MediaText, Is.EqualTo(""));
+            Assert.That(link.Sheet.Media.Validate(new DefaultRenderDevice()), Is.True);
         }
 
         [Test]
@@ -214,7 +214,7 @@ namespace AngleSharp.Css.Tests.Library
             var label = tree.Find(document.QuerySelector("label"));
             var minWidth = window.GetComputedStyle(label.Ref as IHtmlElement).GetMinWidth();
 
-            Assert.AreEqual("50px", minWidth);
+            Assert.That(minWidth, Is.EqualTo("50px"));
         }
     }
 }

--- a/src/AngleSharp.Css.Tests/Parsing/CssTokenization.cs
+++ b/src/AngleSharp.Css.Tests/Parsing/CssTokenization.cs
@@ -14,7 +14,7 @@ namespace AngleSharp.Css.Tests.Parsing
             var teststring = "h1 { background: blue; }";
             var tokenizer = new CssTokenizer(new TextSource(teststring));
             var token = tokenizer.Get();
-            Assert.AreEqual(CssTokenType.Ident, token.Type);
+            Assert.That(token.Type, Is.EqualTo(CssTokenType.Ident));
         }
 
         [Test]
@@ -23,7 +23,7 @@ namespace AngleSharp.Css.Tests.Parsing
             var teststring = "@media { background: blue; }";
             var tokenizer = new CssTokenizer(new TextSource(teststring));
             var token = tokenizer.Get();
-            Assert.AreEqual(CssTokenType.AtKeyword, token.Type);
+            Assert.That(token.Type, Is.EqualTo(CssTokenType.AtKeyword));
         }
 
         [Test]
@@ -33,7 +33,7 @@ namespace AngleSharp.Css.Tests.Parsing
             var teststring = "url(" + url + ")";
             var tokenizer = new CssTokenizer(new TextSource(teststring));
             var token = tokenizer.Get();
-            Assert.AreEqual(url, token.Data);
+            Assert.That(token.Data, Is.EqualTo(url));
         }
 
         [Test]
@@ -43,7 +43,7 @@ namespace AngleSharp.Css.Tests.Parsing
             var teststring = "url(\"" + url + "\")";
             var tokenizer = new CssTokenizer(new TextSource(teststring));
             var token = tokenizer.Get();
-            Assert.AreEqual(url, token.Data);
+            Assert.That(token.Data, Is.EqualTo(url));
         }
 
         [Test]
@@ -53,7 +53,7 @@ namespace AngleSharp.Css.Tests.Parsing
             var teststring = "url('" + url + "')";
             var tokenizer = new CssTokenizer(new TextSource(teststring));
             var token = tokenizer.Get();
-            Assert.AreEqual(url, token.Data);
+            Assert.That(token.Data, Is.EqualTo(url));
         }
 
         [Test]
@@ -62,7 +62,7 @@ namespace AngleSharp.Css.Tests.Parsing
             var teststring = "\r";
             var tokenizer = new CssTokenizer(new TextSource(teststring));
             var token = tokenizer.Get();
-            Assert.AreEqual("\n", token.Data);
+            Assert.That(token.Data, Is.EqualTo("\n"));
         }
 
         [Test]
@@ -71,7 +71,7 @@ namespace AngleSharp.Css.Tests.Parsing
             var teststring = "\r\n";
             var tokenizer = new CssTokenizer(new TextSource(teststring));
             var token = tokenizer.Get();
-            Assert.AreEqual("\n", token.Data);
+            Assert.That(token.Data, Is.EqualTo("\n"));
         }
 
         [Test]
@@ -80,7 +80,7 @@ namespace AngleSharp.Css.Tests.Parsing
             var teststring = "\n";
             var tokenizer = new CssTokenizer(new TextSource(teststring));
             var token = tokenizer.Get();
-            Assert.AreEqual("\n", token.Data);
+            Assert.That(token.Data, Is.EqualTo("\n"));
         }
     }
 }

--- a/src/AngleSharp.Css.Tests/Parsing/LargeValues.cs
+++ b/src/AngleSharp.Css.Tests/Parsing/LargeValues.cs
@@ -15,9 +15,9 @@ namespace AngleSharp.Css.Tests.Parsing
     z-index: 9999999999999
 }";
             var sheet = ParseStyleSheet(source);
-            Assert.AreEqual(1, sheet.Rules.Length);
+            Assert.That(sheet.Rules.Length, Is.EqualTo(1));
             var style = sheet.Rules[0] as ICssStyleRule;
-            Assert.AreEqual("2147483647", style.Style.GetZIndex());
+            Assert.That(style.Style.GetZIndex(), Is.EqualTo("2147483647"));
         }
 
         [Test]
@@ -27,9 +27,9 @@ namespace AngleSharp.Css.Tests.Parsing
     z-index: -9999999999999
 }";
             var sheet = ParseStyleSheet(source);
-            Assert.AreEqual(1, sheet.Rules.Length);
+            Assert.That(sheet.Rules.Length, Is.EqualTo(1));
             var style = sheet.Rules[0] as ICssStyleRule;
-            Assert.AreEqual("-2147483648", style.Style.GetZIndex());
+            Assert.That(style.Style.GetZIndex(), Is.EqualTo("-2147483648"));
         }
 
         [Test]

--- a/src/AngleSharp.Css.Tests/Parsing/PseudoElements.cs
+++ b/src/AngleSharp.Css.Tests/Parsing/PseudoElements.cs
@@ -27,7 +27,7 @@ namespace AngleSharp.Css.Tests.Parsing
             var stylesheet = document.StyleSheets.OfType<ICssStyleSheet>().First();
             var rule = stylesheet.Rules.OfType<ICssStyleRule>().First();
             var selectorText = rule.SelectorText;
-            Assert.AreEqual("p::-webkit-scrollbar-thumb", selectorText);
+            Assert.That(selectorText, Is.EqualTo("p::-webkit-scrollbar-thumb"));
         }
     }
 }

--- a/src/AngleSharp.Css.Tests/Parsing/StyleSheet.cs
+++ b/src/AngleSharp.Css.Tests/Parsing/StyleSheet.cs
@@ -157,8 +157,8 @@ namespace AngleSharp.Css.Tests.Parsing
             var css = "a\r\n{\r\nheight: 100vh;\r\n}";
             var parser = new CssParser();
             var ss = parser.ParseStyleSheet(css);
-            Assert.AreEqual(1, ss.Rules.Length);
-            Assert.AreEqual("a", ((AngleSharp.Css.Dom.ICssStyleRule)ss.Rules[0]).SelectorText);
+            Assert.That(ss.Rules.Length, Is.EqualTo(1));
+            Assert.That(((AngleSharp.Css.Dom.ICssStyleRule)ss.Rules[0]).SelectorText, Is.EqualTo("a"));
         }
     }
 }

--- a/src/AngleSharp.Css.Tests/Rules/CssCounterStyleRule.cs
+++ b/src/AngleSharp.Css.Tests/Rules/CssCounterStyleRule.cs
@@ -12,7 +12,7 @@ namespace AngleSharp.Css.Tests.Rules
         {
             var source = "@counter-style thumbs {\n                  system: cyclic;\n                  symbols: \"\"\\1F44D\"\";\n                  suffix: \"\" \"\";\n                }";
             var rule = ParseCounterStyleRule(source);
-            Assert.AreEqual("thumbs", rule.StyleName);
+            Assert.That(rule.StyleName, Is.EqualTo("thumbs"));
         }
     }
 }

--- a/src/AngleSharp.Css.Tests/Rules/CssFontFeatureValuesRule.cs
+++ b/src/AngleSharp.Css.Tests/Rules/CssFontFeatureValuesRule.cs
@@ -12,7 +12,7 @@ namespace AngleSharp.Css.Tests.Rules
         {
             var source = "@font-feature-values Font One {\n                    @styleset {\n                    nice-style: 12;\n                    }\n                }";
             var rule = ParseFontFeatureValuesRule(source);
-            Assert.AreEqual("Font One", rule.FamilyName);
+            Assert.That(rule.FamilyName, Is.EqualTo("Font One"));
         }
     }
 }

--- a/src/AngleSharp.Css.Tests/Rules/CssImportRule.cs
+++ b/src/AngleSharp.Css.Tests/Rules/CssImportRule.cs
@@ -1,4 +1,4 @@
-﻿namespace AngleSharp.Css.Tests.Rules
+namespace AngleSharp.Css.Tests.Rules
 {
     using AngleSharp.Dom;
     using NUnit.Framework;
@@ -12,8 +12,8 @@
         {
             var source = "@import url(button.css);";
             var rule = ParseImportRule(source);
-            Assert.AreEqual("button.css", rule.Href);
-            Assert.AreEqual("", rule.Media.MediaText);
+            Assert.That(rule.Href, Is.EqualTo("button.css"));
+            Assert.That(rule.Media.MediaText, Is.EqualTo(""));
         }
 
         [Test]
@@ -21,8 +21,8 @@
         {
             var source = "@import url(\"button.css\");";
             var rule = ParseImportRule(source);
-            Assert.AreEqual("button.css", rule.Href);
-            Assert.AreEqual("", rule.Media.MediaText);
+            Assert.That(rule.Href, Is.EqualTo("button.css"));
+            Assert.That(rule.Media.MediaText, Is.EqualTo(""));
         }
 
         [Test]
@@ -30,8 +30,8 @@
         {
             var source = "@import url('button.css');";
             var rule = ParseImportRule(source);
-            Assert.AreEqual("button.css", rule.Href);
-            Assert.AreEqual("", rule.Media.MediaText);
+            Assert.That(rule.Href, Is.EqualTo("button.css"));
+            Assert.That(rule.Media.MediaText, Is.EqualTo(""));
         }
 
         [Test]
@@ -39,8 +39,8 @@
         {
             var source = "@import \"button.css\";";
             var rule = ParseImportRule(source);
-            Assert.AreEqual("button.css", rule.Href);
-            Assert.AreEqual("", rule.Media.MediaText);
+            Assert.That(rule.Href, Is.EqualTo("button.css"));
+            Assert.That(rule.Media.MediaText, Is.EqualTo(""));
         }
 
         [Test]
@@ -48,8 +48,8 @@
         {
             var source = "@import 'button.css';";
             var rule = ParseImportRule(source);
-            Assert.AreEqual("button.css", rule.Href);
-            Assert.AreEqual("", rule.Media.MediaText);
+            Assert.That(rule.Href, Is.EqualTo("button.css"));
+            Assert.That(rule.Media.MediaText, Is.EqualTo(""));
         }
 
         [Test]
@@ -58,9 +58,9 @@
             var media = "all";
             var source = "@import url(size/medium.css) " + media + ";";
             var rule = ParseImportRule(source);
-            Assert.AreEqual("size/medium.css", rule.Href);
-            Assert.AreEqual(media, rule.Media.MediaText);
-            Assert.AreEqual(1, rule.Media.Length);
+            Assert.That(rule.Href, Is.EqualTo("size/medium.css"));
+            Assert.That(rule.Media.MediaText, Is.EqualTo(media));
+            Assert.That(rule.Media.Length, Is.EqualTo(1));
         }
 
         [Test]
@@ -69,9 +69,9 @@
             var media = "screen and (color), projection and (min-color: 256)";
             var source = "@import url(old.css) " + media + ";";
             var rule = ParseImportRule(source);
-            Assert.AreEqual("old.css", rule.Href);
-            Assert.AreEqual(media, rule.Media.MediaText);
-            Assert.AreEqual(2, rule.Media.Length);
+            Assert.That(rule.Href, Is.EqualTo("old.css"));
+            Assert.That(rule.Media.MediaText, Is.EqualTo(media));
+            Assert.That(rule.Media.Length, Is.EqualTo(2));
         }
     }
 }

--- a/src/AngleSharp.Css.Tests/Rules/CssKeyframeRule.cs
+++ b/src/AngleSharp.Css.Tests/Rules/CssKeyframeRule.cs
@@ -14,10 +14,10 @@ namespace AngleSharp.Css.Tests.Rules
     margin-left: 0px;
   }");
             Assert.IsNotNull(rule);
-            Assert.AreEqual("0%", rule.KeyText);
-            Assert.AreEqual(1, rule.Key.Stops.Count());
-            Assert.AreEqual(1, rule.Style.Length);
-            Assert.AreEqual("margin-left", rule.Style.First().Name);
+            Assert.That(rule.KeyText, Is.EqualTo("0%"));
+            Assert.That(rule.Key.Stops.Count(), Is.EqualTo(1));
+            Assert.That(rule.Style.Length, Is.EqualTo(1));
+            Assert.That(rule.Style.First().Name, Is.EqualTo("margin-left"));
         }
 
         [Test]
@@ -28,11 +28,11 @@ namespace AngleSharp.Css.Tests.Rules
     opacity: 1;
   }");
             Assert.IsNotNull(rule);
-            Assert.AreEqual("50%", rule.KeyText);
-            Assert.AreEqual(1, rule.Key.Stops.Count());
-            Assert.AreEqual(2, rule.Style.Length);
-            Assert.AreEqual("margin-left", rule.Style.Skip(0).First().Name);
-            Assert.AreEqual("opacity", rule.Style.Skip(1).First().Name);
+            Assert.That(rule.KeyText, Is.EqualTo("50%"));
+            Assert.That(rule.Key.Stops.Count(), Is.EqualTo(1));
+            Assert.That(rule.Style.Length, Is.EqualTo(2));
+            Assert.That(rule.Style.Skip(0).First().Name, Is.EqualTo("margin-left"));
+            Assert.That(rule.Style.Skip(1).First().Name, Is.EqualTo("opacity"));
         }
 
         [Test]
@@ -42,10 +42,10 @@ namespace AngleSharp.Css.Tests.Rules
     margin-left: 200px;
   }");
             Assert.IsNotNull(rule);
-            Assert.AreEqual("100%", rule.KeyText);
-            Assert.AreEqual(1, rule.Key.Stops.Count());
-            Assert.AreEqual(1, rule.Style.Length);
-            Assert.AreEqual("margin-left", rule.Style.First().Name);
+            Assert.That(rule.KeyText, Is.EqualTo("100%"));
+            Assert.That(rule.Key.Stops.Count(), Is.EqualTo(1));
+            Assert.That(rule.Style.Length, Is.EqualTo(1));
+            Assert.That(rule.Style.First().Name, Is.EqualTo("margin-left"));
         }
 
         [Test]
@@ -57,12 +57,12 @@ namespace AngleSharp.Css.Tests.Rules
     color: red
   }");
             Assert.IsNotNull(rule);
-            Assert.AreEqual("0%, 100%, 25%, 50%, 75%", rule.KeyText);
-            Assert.AreEqual(5, rule.Key.Stops.Count());
-            Assert.AreEqual(3, rule.Style.Length);
-            Assert.AreEqual("padding-top", rule.Style.Skip(0).First().Name);
-            Assert.AreEqual("padding-left", rule.Style.Skip(1).First().Name);
-            Assert.AreEqual("color", rule.Style.Skip(2).First().Name);
+            Assert.That(rule.KeyText, Is.EqualTo("0%, 100%, 25%, 50%, 75%"));
+            Assert.That(rule.Key.Stops.Count(), Is.EqualTo(5));
+            Assert.That(rule.Style.Length, Is.EqualTo(3));
+            Assert.That(rule.Style.Skip(0).First().Name, Is.EqualTo("padding-top"));
+            Assert.That(rule.Style.Skip(1).First().Name, Is.EqualTo("padding-left"));
+            Assert.That(rule.Style.Skip(2).First().Name, Is.EqualTo("color"));
         }
 
         [Test]
@@ -70,9 +70,9 @@ namespace AngleSharp.Css.Tests.Rules
         {
             var rule = ParseKeyframeRule(@"  0% { }");
             Assert.IsNotNull(rule);
-            Assert.AreEqual("0%", rule.KeyText);
-            Assert.AreEqual(1, rule.Key.Stops.Count());
-            Assert.AreEqual(0, rule.Style.Length);
+            Assert.That(rule.KeyText, Is.EqualTo("0%"));
+            Assert.That(rule.Key.Stops.Count(), Is.EqualTo(1));
+            Assert.That(rule.Style.Length, Is.EqualTo(0));
         }
 
         [Test]
@@ -80,9 +80,9 @@ namespace AngleSharp.Css.Tests.Rules
         {
             var rule = ParseKeyframeRule(@"  0.52%,   50.0%,92.82% { }");
             Assert.IsNotNull(rule);
-            Assert.AreEqual("0.52%, 50%, 92.82%", rule.KeyText);
-            Assert.AreEqual(3, rule.Key.Stops.Count());
-            Assert.AreEqual(0, rule.Style.Length);
+            Assert.That(rule.KeyText, Is.EqualTo("0.52%, 50%, 92.82%"));
+            Assert.That(rule.Key.Stops.Count(), Is.EqualTo(3));
+            Assert.That(rule.Style.Length, Is.EqualTo(0));
         }
     }
 }

--- a/src/AngleSharp.Css.Tests/Rules/CssMediaFeatures.cs
+++ b/src/AngleSharp.Css.Tests/Rules/CssMediaFeatures.cs
@@ -34,8 +34,8 @@ namespace AngleSharp.Css.Tests.Rules
             var validate = CreateValidator(FeatureNames.Width, "100px");
             var valid = validate(new DefaultRenderDevice { ViewPortWidth = 100, ViewPortHeight = 0 });
             var invalid = validate(new DefaultRenderDevice { ViewPortWidth = 0, ViewPortHeight = 0 });
-            Assert.IsTrue(valid);
-            Assert.IsFalse(invalid);
+            Assert.That(valid, Is.True);
+            Assert.That(invalid, Is.False);
         }
 
         [Test]
@@ -44,8 +44,8 @@ namespace AngleSharp.Css.Tests.Rules
             var validate = CreateValidator(FeatureNames.MaxHeight, "100px");
             var valid = validate(new DefaultRenderDevice { ViewPortWidth = 0, ViewPortHeight = 99 });
             var invalid = validate(new DefaultRenderDevice { ViewPortWidth = 0, ViewPortHeight = 101 });
-            Assert.IsTrue(valid);
-            Assert.IsFalse(invalid);
+            Assert.That(valid, Is.True);
+            Assert.That(invalid, Is.False);
         }
 
         [Test]
@@ -54,8 +54,8 @@ namespace AngleSharp.Css.Tests.Rules
             var validate = CreateValidator(FeatureNames.MinDeviceWidth, "100px");
             var valid = validate(new DefaultRenderDevice { DeviceWidth = 100, DeviceHeight = 0 });
             var invalid = validate(new DefaultRenderDevice { DeviceWidth = 99, DeviceHeight = 0 });
-            Assert.IsTrue(valid);
-            Assert.IsFalse(invalid);
+            Assert.That(valid, Is.True);
+            Assert.That(invalid, Is.False);
         }
 
         [Test]
@@ -64,8 +64,8 @@ namespace AngleSharp.Css.Tests.Rules
             var validate = CreateValidator(FeatureNames.AspectRatio, "1/1");
             var valid = validate(new DefaultRenderDevice { ViewPortWidth = 100, ViewPortHeight = 100 });
             var invalid = validate(new DefaultRenderDevice { ViewPortWidth = 16, ViewPortHeight = 9 });
-            Assert.IsTrue(valid);
-            Assert.IsFalse(invalid);
+            Assert.That(valid, Is.True);
+            Assert.That(invalid, Is.False);
         }
     }
 }

--- a/src/AngleSharp.Css.Tests/Rules/CssMediaList.cs
+++ b/src/AngleSharp.Css.Tests/Rules/CssMediaList.cs
@@ -15,13 +15,13 @@ namespace AngleSharp.Css.Tests.Rules
     h1 { color: green }
 }";
             var sheet = ParseStyleSheet(source);
-            Assert.AreEqual(1, sheet.Rules.Length);
+            Assert.That(sheet.Rules.Length, Is.EqualTo(1));
             Assert.IsInstanceOf<CssMediaRule>(sheet.Rules[0]);
             var media = (CssMediaRule)sheet.Rules[0];
-            Assert.AreEqual("screen", media.Media.MediaText);
+            Assert.That(media.Media.MediaText, Is.EqualTo("screen"));
             var list = media.Media;
-            Assert.AreEqual(1, list.Length);
-            Assert.AreEqual(1, media.Rules.Length);
+            Assert.That(list.Length, Is.EqualTo(1));
+            Assert.That(media.Rules.Length, Is.EqualTo(1));
         }
 
         [Test]
@@ -31,11 +31,11 @@ namespace AngleSharp.Css.Tests.Rules
     h1 { color: green }
 }";
             var sheet = ParseStyleSheet(source);
-            Assert.AreEqual(1, sheet.Rules.Length);
-            Assert.AreEqual(CssRuleType.Media, sheet.Rules[0].Type);
+            Assert.That(sheet.Rules.Length, Is.EqualTo(1));
+            Assert.That(sheet.Rules[0].Type, Is.EqualTo(CssRuleType.Media));
             var media = sheet.Rules[0] as ICssMediaRule;
-            Assert.AreEqual("not all", media.ConditionText);
-            Assert.AreEqual(1, media.Rules.Length);
+            Assert.That(media.ConditionText, Is.EqualTo("not all"));
+            Assert.That(media.Rules.Length, Is.EqualTo(1));
         }
 
         [Test]
@@ -43,12 +43,12 @@ namespace AngleSharp.Css.Tests.Rules
         {
             var source = @"@media screen; h1 { color: green }";
             var sheet = ParseStyleSheet(source);
-            Assert.AreEqual(1, sheet.Rules.Length);
+            Assert.That(sheet.Rules.Length, Is.EqualTo(1));
             Assert.IsInstanceOf<ICssStyleRule>(sheet.Rules[0]);
             var h1 = (ICssStyleRule)sheet.Rules[0];
-            Assert.AreEqual("h1", h1.SelectorText);
+            Assert.That(h1.SelectorText, Is.EqualTo("h1"));
             var style = h1.Style;
-            Assert.AreEqual("rgba(0, 128, 0, 1)", style.GetColor());
+            Assert.That(style.GetColor(), Is.EqualTo("rgba(0, 128, 0, 1)"));
         }
 
         [Test]
@@ -58,13 +58,13 @@ namespace AngleSharp.Css.Tests.Rules
     h1 { color: green }
 }";
             var sheet = ParseStyleSheet(source);
-            Assert.AreEqual(1, sheet.Rules.Length);
+            Assert.That(sheet.Rules.Length, Is.EqualTo(1));
             Assert.IsInstanceOf<CssMediaRule>(sheet.Rules[0]);
             var media = (CssMediaRule)sheet.Rules[0];
-            Assert.AreEqual("screen, tv", media.Media.MediaText);
+            Assert.That(media.Media.MediaText, Is.EqualTo("screen, tv"));
             var list = media.Media;
-            Assert.AreEqual(2, list.Length);
-            Assert.AreEqual(1, media.Rules.Length);
+            Assert.That(list.Length, Is.EqualTo(2));
+            Assert.That(media.Rules.Length, Is.EqualTo(1));
         }
 
         [Test]
@@ -74,13 +74,13 @@ namespace AngleSharp.Css.Tests.Rules
     h1 { color: green }
 }";
             var sheet = ParseStyleSheet(source);
-            Assert.AreEqual(1, sheet.Rules.Length);
+            Assert.That(sheet.Rules.Length, Is.EqualTo(1));
             Assert.IsInstanceOf<CssMediaRule>(sheet.Rules[0]);
             var media = (CssMediaRule)sheet.Rules[0];
-            Assert.AreEqual("screen, tv", media.Media.MediaText);
+            Assert.That(media.Media.MediaText, Is.EqualTo("screen, tv"));
             var list = media.Media;
-            Assert.AreEqual(2, list.Length);
-            Assert.AreEqual(1, media.Rules.Length);
+            Assert.That(list.Length, Is.EqualTo(2));
+            Assert.That(media.Rules.Length, Is.EqualTo(1));
         }
 
         [Test]
@@ -90,13 +90,13 @@ namespace AngleSharp.Css.Tests.Rules
     h1 { color: green }
 }";
             var sheet = ParseStyleSheet(source);
-            Assert.AreEqual(1, sheet.Rules.Length);
+            Assert.That(sheet.Rules.Length, Is.EqualTo(1));
             Assert.IsInstanceOf<CssMediaRule>(sheet.Rules[0]);
             var media = (CssMediaRule)sheet.Rules[0];
-            Assert.AreEqual("only screen, tv", media.Media.MediaText);
+            Assert.That(media.Media.MediaText, Is.EqualTo("only screen, tv"));
             var list = media.Media;
-            Assert.AreEqual(2, list.Length);
-            Assert.AreEqual(1, media.Rules.Length);
+            Assert.That(list.Length, Is.EqualTo(2));
+            Assert.That(media.Rules.Length, Is.EqualTo(1));
         }
 
         [Test]
@@ -106,13 +106,13 @@ namespace AngleSharp.Css.Tests.Rules
     h1 { color: green }
 }";
             var sheet = ParseStyleSheet(source);
-            Assert.AreEqual(1, sheet.Rules.Length);
+            Assert.That(sheet.Rules.Length, Is.EqualTo(1));
             Assert.IsInstanceOf<CssMediaRule>(sheet.Rules[0]);
             var media = (CssMediaRule)sheet.Rules[0];
-            Assert.AreEqual("not screen, tv", media.Media.MediaText);
+            Assert.That(media.Media.MediaText, Is.EqualTo("not screen, tv"));
             var list = media.Media;
-            Assert.AreEqual(2, list.Length);
-            Assert.AreEqual(1, media.Rules.Length);
+            Assert.That(list.Length, Is.EqualTo(2));
+            Assert.That(media.Rules.Length, Is.EqualTo(1));
         }
 
         [Test]
@@ -122,13 +122,13 @@ namespace AngleSharp.Css.Tests.Rules
     h1 { color: green }
 }";
             var sheet = ParseStyleSheet(source);
-            Assert.AreEqual(1, sheet.Rules.Length);
+            Assert.That(sheet.Rules.Length, Is.EqualTo(1));
             Assert.IsInstanceOf<CssMediaRule>(sheet.Rules[0]);
             var media = (CssMediaRule)sheet.Rules[0];
-            Assert.AreEqual("(min-width: 30px)", media.Media.MediaText);
+            Assert.That(media.Media.MediaText, Is.EqualTo("(min-width: 30px)"));
             var list = media.Media;
-            Assert.AreEqual(1, list.Length);
-            Assert.AreEqual(1, media.Rules.Length);
+            Assert.That(list.Length, Is.EqualTo(1));
+            Assert.That(media.Rules.Length, Is.EqualTo(1));
         }
 
         [Test]
@@ -138,13 +138,13 @@ namespace AngleSharp.Css.Tests.Rules
     h1 { color: green }
 }";
             var sheet = ParseStyleSheet(source);
-            Assert.AreEqual(1, sheet.Rules.Length);
+            Assert.That(sheet.Rules.Length, Is.EqualTo(1));
             Assert.IsInstanceOf<CssMediaRule>(sheet.Rules[0]);
             var media = (CssMediaRule)sheet.Rules[0];
-            Assert.AreEqual("not all", media.Media.MediaText);
+            Assert.That(media.Media.MediaText, Is.EqualTo("not all"));
             var list = media.Media;
-            Assert.AreEqual(1, list.Length);
-            Assert.AreEqual(1, media.Rules.Length);
+            Assert.That(list.Length, Is.EqualTo(1));
+            Assert.That(media.Rules.Length, Is.EqualTo(1));
         }
 
         [Test]
@@ -154,13 +154,13 @@ namespace AngleSharp.Css.Tests.Rules
     h1 { color: green }
 }";
             var sheet = ParseStyleSheet(source);
-            Assert.AreEqual(1, sheet.Rules.Length);
+            Assert.That(sheet.Rules.Length, Is.EqualTo(1));
             Assert.IsInstanceOf<CssMediaRule>(sheet.Rules[0]);
             var media = (CssMediaRule)sheet.Rules[0];
-            Assert.AreEqual("only screen and (width: 640px)", media.Media.MediaText);
+            Assert.That(media.Media.MediaText, Is.EqualTo("only screen and (width: 640px)"));
             var list = media.Media;
-            Assert.AreEqual(1, list.Length);
-            Assert.AreEqual(1, media.Rules.Length);
+            Assert.That(list.Length, Is.EqualTo(1));
+            Assert.That(media.Rules.Length, Is.EqualTo(1));
         }
 
         [Test]
@@ -170,13 +170,13 @@ namespace AngleSharp.Css.Tests.Rules
     h1 { color: green }
 }";
             var sheet = ParseStyleSheet(source);
-            Assert.AreEqual(1, sheet.Rules.Length);
+            Assert.That(sheet.Rules.Length, Is.EqualTo(1));
             Assert.IsInstanceOf<CssMediaRule>(sheet.Rules[0]);
             var media = (CssMediaRule)sheet.Rules[0];
-            Assert.AreEqual("not (device-width: 640px)", media.Media.MediaText);
+            Assert.That(media.Media.MediaText, Is.EqualTo("not (device-width: 640px)"));
             var list = media.Media;
-            Assert.AreEqual(1, list.Length);
-            Assert.AreEqual(1, media.Rules.Length);
+            Assert.That(list.Length, Is.EqualTo(1));
+            Assert.That(media.Rules.Length, Is.EqualTo(1));
         }
 
         [Test]
@@ -186,11 +186,11 @@ namespace AngleSharp.Css.Tests.Rules
     h1 { color: red }
 }";
             var sheet = ParseStyleSheet(source);
-            Assert.AreEqual(1, sheet.Rules.Length);
-            Assert.AreEqual(CssRuleType.Media, sheet.Rules[0].Type);
+            Assert.That(sheet.Rules.Length, Is.EqualTo(1));
+            Assert.That(sheet.Rules[0].Type, Is.EqualTo(CssRuleType.Media));
             var media = sheet.Rules[0] as ICssMediaRule;
-            Assert.AreEqual("not all", media.ConditionText);
-            Assert.AreEqual(1, media.Rules.Length);
+            Assert.That(media.ConditionText, Is.EqualTo("not all"));
+            Assert.That(media.Rules.Length, Is.EqualTo(1));
         }
 
         [Test]
@@ -200,11 +200,11 @@ namespace AngleSharp.Css.Tests.Rules
     h1 { color: red }
 }";
             var sheet = ParseStyleSheet(source);
-            Assert.AreEqual(1, sheet.Rules.Length);
-            Assert.AreEqual(CssRuleType.Media, sheet.Rules[0].Type);
+            Assert.That(sheet.Rules.Length, Is.EqualTo(1));
+            Assert.That(sheet.Rules[0].Type, Is.EqualTo(CssRuleType.Media));
             var media = sheet.Rules[0] as ICssMediaRule;
-            Assert.AreEqual("", media.ConditionText);
-            Assert.AreEqual(1, media.Rules.Length);
+            Assert.That(media.ConditionText, Is.EqualTo(""));
+            Assert.That(media.Rules.Length, Is.EqualTo(1));
         }
 
         [Test]
@@ -214,11 +214,11 @@ namespace AngleSharp.Css.Tests.Rules
     h1 { color: red }
 }";
             var sheet = ParseStyleSheet(source);
-            Assert.AreEqual(1, sheet.Rules.Length);
-            Assert.AreEqual(CssRuleType.Media, sheet.Rules[0].Type);
+            Assert.That(sheet.Rules.Length, Is.EqualTo(1));
+            Assert.That(sheet.Rules[0].Type, Is.EqualTo(CssRuleType.Media));
             var media = sheet.Rules[0] as ICssMediaRule;
-            Assert.AreEqual("not all", media.ConditionText);
-            Assert.AreEqual(1, media.Rules.Length);
+            Assert.That(media.ConditionText, Is.EqualTo("not all"));
+            Assert.That(media.Rules.Length, Is.EqualTo(1));
         }
 
         [Test]
@@ -228,11 +228,11 @@ namespace AngleSharp.Css.Tests.Rules
     h1 { color: red }
 }";
             var sheet = ParseStyleSheet(source);
-            Assert.AreEqual(1, sheet.Rules.Length);
-            Assert.AreEqual(CssRuleType.Media, sheet.Rules[0].Type);
+            Assert.That(sheet.Rules.Length, Is.EqualTo(1));
+            Assert.That(sheet.Rules[0].Type, Is.EqualTo(CssRuleType.Media));
             var media = sheet.Rules[0] as ICssMediaRule;
-            Assert.AreEqual("not all", media.ConditionText);
-            Assert.AreEqual(1, media.Rules.Length);
+            Assert.That(media.ConditionText, Is.EqualTo("not all"));
+            Assert.That(media.Rules.Length, Is.EqualTo(1));
         }
 
         [Test]
@@ -243,11 +243,11 @@ namespace AngleSharp.Css.Tests.Rules
 }";
 
             var sheet = ParseStyleSheet(source);
-            Assert.AreEqual(1, sheet.Rules.Length);
-            Assert.AreEqual(CssRuleType.Media, sheet.Rules[0].Type);
+            Assert.That(sheet.Rules.Length, Is.EqualTo(1));
+            Assert.That(sheet.Rules[0].Type, Is.EqualTo(CssRuleType.Media));
             var media = sheet.Rules[0] as ICssMediaRule;
-            Assert.AreEqual("not all", media.ConditionText);
-            Assert.AreEqual(1, media.Rules.Length);
+            Assert.That(media.ConditionText, Is.EqualTo("not all"));
+            Assert.That(media.Rules.Length, Is.EqualTo(1));
         }
 
         [Test]
@@ -258,12 +258,12 @@ namespace AngleSharp.Css.Tests.Rules
 }
 h1 { color: green }";
             var sheet = ParseStyleSheet(source);
-            Assert.AreEqual(2, sheet.Rules.Length);
-            Assert.AreEqual(CssRuleType.Media, sheet.Rules[0].Type);
+            Assert.That(sheet.Rules.Length, Is.EqualTo(2));
+            Assert.That(sheet.Rules[0].Type, Is.EqualTo(CssRuleType.Media));
             Assert.IsInstanceOf<ICssStyleRule>(sheet.Rules[1]);
             var style = (ICssStyleRule)sheet.Rules[1];
-            Assert.AreEqual("rgba(0, 128, 0, 1)", style.Style.GetColor());
-            Assert.AreEqual("h1", style.SelectorText);
+            Assert.That(style.Style.GetColor(), Is.EqualTo("rgba(0, 128, 0, 1)"));
+            Assert.That(style.SelectorText, Is.EqualTo("h1"));
         }
 
         [Test]
@@ -273,11 +273,11 @@ h1 { color: green }";
     h1 { color: red }
 }";
             var sheet = ParseStyleSheet(source);
-            Assert.AreEqual(1, sheet.Rules.Length);
-            Assert.AreEqual(CssRuleType.Media, sheet.Rules[0].Type);
+            Assert.That(sheet.Rules.Length, Is.EqualTo(1));
+            Assert.That(sheet.Rules[0].Type, Is.EqualTo(CssRuleType.Media));
             var media = sheet.Rules[0] as ICssMediaRule;
-            Assert.AreEqual("not all", media.ConditionText);
-            Assert.AreEqual(1, media.Rules.Length);
+            Assert.That(media.ConditionText, Is.EqualTo("not all"));
+            Assert.That(media.Rules.Length, Is.EqualTo(1));
         }
 
         [Test]
@@ -287,11 +287,11 @@ h1 { color: green }";
     h1 { color: red }
 }";
             var sheet = ParseStyleSheet(source);
-            Assert.AreEqual(1, sheet.Rules.Length);
-            Assert.AreEqual(CssRuleType.Media, sheet.Rules[0].Type);
+            Assert.That(sheet.Rules.Length, Is.EqualTo(1));
+            Assert.That(sheet.Rules[0].Type, Is.EqualTo(CssRuleType.Media));
             var media = sheet.Rules[0] as ICssMediaRule;
-            Assert.AreEqual("not all", media.ConditionText);
-            Assert.AreEqual(1, media.Rules.Length);
+            Assert.That(media.ConditionText, Is.EqualTo("not all"));
+            Assert.That(media.Rules.Length, Is.EqualTo(1));
         }
 
         [Test]
@@ -301,13 +301,13 @@ h1 { color: green }";
     h1 { color: green }
 }";
             var sheet = ParseStyleSheet(source);
-            Assert.AreEqual(1, sheet.Rules.Length);
+            Assert.That(sheet.Rules.Length, Is.EqualTo(1));
             Assert.IsInstanceOf<CssMediaRule>(sheet.Rules[0]);
             var media = (CssMediaRule)sheet.Rules[0];
-            Assert.AreEqual("all and (max-width: 30px)", media.Media.MediaText);
+            Assert.That(media.Media.MediaText, Is.EqualTo("all and (max-width: 30px)"));
             var list = media.Media;
-            Assert.AreEqual(1, list.Length);
-            Assert.AreEqual(1, media.Rules.Length);
+            Assert.That(list.Length, Is.EqualTo(1));
+            Assert.That(media.Rules.Length, Is.EqualTo(1));
         }
 
         [Test]
@@ -317,13 +317,13 @@ h1 { color: green }";
     h1 { color: green }
 }";
             var sheet = ParseStyleSheet(source);
-            Assert.AreEqual(1, sheet.Rules.Length);
+            Assert.That(sheet.Rules.Length, Is.EqualTo(1));
             Assert.IsInstanceOf<CssMediaRule>(sheet.Rules[0]);
             var media = (CssMediaRule)sheet.Rules[0];
-            Assert.AreEqual("(aspect-ratio: 16/9)", media.Media.MediaText);
+            Assert.That(media.Media.MediaText, Is.EqualTo("(aspect-ratio: 16/9)"));
             var list = media.Media;
-            Assert.AreEqual(1, list.Length);
-            Assert.AreEqual(1, media.Rules.Length);
+            Assert.That(list.Length, Is.EqualTo(1));
+            Assert.That(media.Rules.Length, Is.EqualTo(1));
         }
 
         [Test]
@@ -333,13 +333,13 @@ h1 { color: green }";
     h1 { color: green }
 }";
             var sheet = ParseStyleSheet(source);
-            Assert.AreEqual(1, sheet.Rules.Length);
+            Assert.That(sheet.Rules.Length, Is.EqualTo(1));
             Assert.IsInstanceOf<CssMediaRule>(sheet.Rules[0]);
             var media = (CssMediaRule)sheet.Rules[0];
-            Assert.AreEqual("print and (max-width: 30px) and (min-device-width: 100px)", media.Media.MediaText);
+            Assert.That(media.Media.MediaText, Is.EqualTo("print and (max-width: 30px) and (min-device-width: 100px)"));
             var list = media.Media;
-            Assert.AreEqual(1, list.Length);
-            Assert.AreEqual(1, media.Rules.Length);
+            Assert.That(list.Length, Is.EqualTo(1));
+            Assert.That(media.Rules.Length, Is.EqualTo(1));
         }
 
         [Test]
@@ -349,13 +349,13 @@ h1 { color: green }";
     h1 { color: green }
 }";
             var sheet = ParseStyleSheet(source);
-            Assert.AreEqual(1, sheet.Rules.Length);
+            Assert.That(sheet.Rules.Length, Is.EqualTo(1));
             Assert.IsInstanceOf<CssMediaRule>(sheet.Rules[0]);
             var media = (CssMediaRule)sheet.Rules[0];
-            Assert.AreEqual("all and (min-width: 0) and (min-device-width: 100px), screen", media.Media.MediaText);
+            Assert.That(media.Media.MediaText, Is.EqualTo("all and (min-width: 0) and (min-device-width: 100px), screen"));
             var list = media.Media;
-            Assert.AreEqual(2, list.Length);
-            Assert.AreEqual(1, media.Rules.Length);
+            Assert.That(list.Length, Is.EqualTo(2));
+            Assert.That(media.Rules.Length, Is.EqualTo(1));
         }
 
         [Test]
@@ -365,13 +365,13 @@ h1 { color: green }";
     h1 { color: green }
 }";
             var sheet = ParseStyleSheet(source);
-            Assert.AreEqual(1, sheet.Rules.Length);
+            Assert.That(sheet.Rules.Length, Is.EqualTo(1));
             Assert.IsInstanceOf<CssMediaRule>(sheet.Rules[0]);
             var media = (CssMediaRule)sheet.Rules[0];
-            Assert.AreEqual("(resolution: 72dpi)", media.Media.MediaText);
+            Assert.That(media.Media.MediaText, Is.EqualTo("(resolution: 72dpi)"));
             var list = media.Media;
-            Assert.AreEqual(1, list.Length);
-            Assert.AreEqual(1, media.Rules.Length);
+            Assert.That(list.Length, Is.EqualTo(1));
+            Assert.That(media.Rules.Length, Is.EqualTo(1));
         }
 
         [Test]
@@ -381,13 +381,13 @@ h1 { color: green }";
     h1 { color: green }
 }";
             var sheet = ParseStyleSheet(source);
-            Assert.AreEqual(1, sheet.Rules.Length);
+            Assert.That(sheet.Rules.Length, Is.EqualTo(1));
             Assert.IsInstanceOf<CssMediaRule>(sheet.Rules[0]);
             var media = (CssMediaRule)sheet.Rules[0];
-            Assert.AreEqual("(min-resolution: 72dpi) and (max-resolution: 140dpi)", media.Media.MediaText);
+            Assert.That(media.Media.MediaText, Is.EqualTo("(min-resolution: 72dpi) and (max-resolution: 140dpi)"));
             var list = media.Media;
-            Assert.AreEqual(1, list.Length);
-            Assert.AreEqual(1, media.Rules.Length);
+            Assert.That(list.Length, Is.EqualTo(1));
+            Assert.That(media.Rules.Length, Is.EqualTo(1));
         }
 
         [Test]
@@ -396,7 +396,7 @@ h1 { color: green }";
             var media = new [] { "handheld", "screen", "only screen and (max-device-width: 480px)" };
             var context = BrowsingContext.New(Configuration.Default.WithCss());
 		    var list = new MediaList(context);
-            Assert.AreEqual(0, list.Length);
+            Assert.That(list.Length, Is.EqualTo(0));
 
 		    list.Add(media[0]);
 		    list.Add(media[1]);
@@ -404,10 +404,10 @@ h1 { color: green }";
 
 		    list.Remove(media[1]);
 
-            Assert.AreEqual(2, list.Length);
-            Assert.AreEqual(media[0], list[0]);
-            Assert.AreEqual(media[2], list[1]);
-            Assert.AreEqual(String.Concat(media[0], ", ", media[2]), list.MediaText);
+            Assert.That(list.Length, Is.EqualTo(2));
+            Assert.That(list[0], Is.EqualTo(media[0]));
+            Assert.That(list[1], Is.EqualTo(media[2]));
+            Assert.That(list.MediaText, Is.EqualTo(String.Concat(media[0], ", ", media[2])));
         }
 
         [Test]
@@ -417,13 +417,13 @@ h1 { color: green }";
     h1 { color: green }
 }";
             var sheet = ParseStyleSheet(source);
-            Assert.AreEqual(1, sheet.Rules.Length);
+            Assert.That(sheet.Rules.Length, Is.EqualTo(1));
             Assert.IsInstanceOf<CssMediaRule>(sheet.Rules[0]);
             var media = (CssMediaRule)sheet.Rules[0];
-            Assert.AreEqual("not all, speech", media.Media.MediaText);
+            Assert.That(media.Media.MediaText, Is.EqualTo("not all, speech"));
             var list = media.Media;
-            Assert.AreEqual(2, list.Length);
-            Assert.AreEqual(1, media.Rules.Length);
+            Assert.That(list.Length, Is.EqualTo(2));
+            Assert.That(media.Rules.Length, Is.EqualTo(1));
         }
 
         [Test]
@@ -433,13 +433,13 @@ h1 { color: green }";
     h1 { color: green }
 }";
             var sheet = ParseStyleSheet(source);
-            Assert.AreEqual(1, sheet.Rules.Length);
+            Assert.That(sheet.Rules.Length, Is.EqualTo(1));
             Assert.IsInstanceOf<CssMediaRule>(sheet.Rules[0]);
             var media = (CssMediaRule)sheet.Rules[0];
-            Assert.AreEqual("not all, speech", media.Media.MediaText);
+            Assert.That(media.Media.MediaText, Is.EqualTo("not all, speech"));
             var list = media.Media;
-            Assert.AreEqual(2, list.Length);
-            Assert.AreEqual(1, media.Rules.Length);
+            Assert.That(list.Length, Is.EqualTo(2));
+            Assert.That(media.Rules.Length, Is.EqualTo(1));
         }
 
         [Test]
@@ -449,13 +449,13 @@ h1 { color: green }";
     h1 { color: green }
 }";
             var sheet = ParseStyleSheet(source);
-            Assert.AreEqual(1, sheet.Rules.Length);
+            Assert.That(sheet.Rules.Length, Is.EqualTo(1));
             Assert.IsInstanceOf<CssMediaRule>(sheet.Rules[0]);
             var media = (CssMediaRule)sheet.Rules[0];
-            Assert.AreEqual("not all", media.Media.MediaText);
+            Assert.That(media.Media.MediaText, Is.EqualTo("not all"));
             var list = media.Media;
-            Assert.AreEqual(1, list.Length);
-            Assert.AreEqual(1, media.Rules.Length);
+            Assert.That(list.Length, Is.EqualTo(1));
+            Assert.That(media.Rules.Length, Is.EqualTo(1));
         }
     }
 }

--- a/src/AngleSharp.Css.Tests/Rules/CssPageRule.cs
+++ b/src/AngleSharp.Css.Tests/Rules/CssPageRule.cs
@@ -15,7 +15,7 @@ namespace AngleSharp.Css.Tests.Rules
             var styleSheet = document.StyleSheets.OfType<ICssStyleSheet>().First();
             var css = styleSheet.ToCss();
 
-            Assert.AreEqual("@page { margin-top: 25mm; margin-right: 25mm }", css);
+            Assert.That(css, Is.EqualTo("@page { margin-top: 25mm; margin-right: 25mm }"));
         }
 
         [Test]
@@ -26,7 +26,7 @@ namespace AngleSharp.Css.Tests.Rules
             var styleSheet = document.StyleSheets.OfType<ICssStyleSheet>().First();
             var css = styleSheet.ToCss();
 
-            Assert.AreEqual("@page { margin: 25mm }", css);
+            Assert.That(css, Is.EqualTo("@page { margin: 25mm }"));
         }
     }
 }

--- a/src/AngleSharp.Css.Tests/Rules/CssSupports.cs
+++ b/src/AngleSharp.Css.Tests/Rules/CssSupports.cs
@@ -13,11 +13,11 @@ namespace AngleSharp.Css.Tests.Rules
             var source = @"@supports () { }";
             var sheet = ParseStyleSheet(source);
             var device = new DefaultRenderDevice();
-            Assert.AreEqual(1, sheet.Rules.Length);
+            Assert.That(sheet.Rules.Length, Is.EqualTo(1));
             Assert.IsInstanceOf<CssSupportsRule>(sheet.Rules[0]);
             var supports = sheet.Rules[0] as CssSupportsRule;
-            Assert.AreEqual("()", supports.ConditionText);
-            Assert.IsTrue(supports.Condition.Check(device));
+            Assert.That(supports.ConditionText, Is.EqualTo("()"));
+            Assert.That(supports.Condition.Check(device), Is.True);
         }
 
         [Test]
@@ -26,11 +26,11 @@ namespace AngleSharp.Css.Tests.Rules
             var source = @"@supports (background-color: red) { }";
             var sheet = ParseStyleSheet(source);
             var device = new DefaultRenderDevice();
-            Assert.AreEqual(1, sheet.Rules.Length);
+            Assert.That(sheet.Rules.Length, Is.EqualTo(1));
             Assert.IsInstanceOf<CssSupportsRule>(sheet.Rules[0]);
             var supports = sheet.Rules[0] as CssSupportsRule;
-            Assert.AreEqual("(background-color: red)", supports.ConditionText);
-            Assert.IsTrue(supports.Condition.Check(device));
+            Assert.That(supports.ConditionText, Is.EqualTo("(background-color: red)"));
+            Assert.That(supports.Condition.Check(device), Is.True);
         }
 
         [Test]
@@ -39,11 +39,11 @@ namespace AngleSharp.Css.Tests.Rules
             var source = @"@supports ((background-color: red) and (color: blue)) { }";
             var sheet = ParseStyleSheet(source);
             var device = new DefaultRenderDevice();
-            Assert.AreEqual(1, sheet.Rules.Length);
+            Assert.That(sheet.Rules.Length, Is.EqualTo(1));
             Assert.IsInstanceOf<CssSupportsRule>(sheet.Rules[0]);
             var supports = sheet.Rules[0] as CssSupportsRule;
-            Assert.AreEqual("((background-color: red) and (color: blue))", supports.ConditionText);
-            Assert.IsTrue(supports.Condition.Check(device));
+            Assert.That(supports.ConditionText, Is.EqualTo("((background-color: red) and (color: blue))"));
+            Assert.That(supports.Condition.Check(device), Is.True);
         }
 
         [Test]
@@ -52,11 +52,11 @@ namespace AngleSharp.Css.Tests.Rules
             var source = @"@supports (not (background-transparency: half)) { }";
             var sheet = ParseStyleSheet(source);
             var device = new DefaultRenderDevice();
-            Assert.AreEqual(1, sheet.Rules.Length);
+            Assert.That(sheet.Rules.Length, Is.EqualTo(1));
             Assert.IsInstanceOf<CssSupportsRule>(sheet.Rules[0]);
             var supports = sheet.Rules[0] as CssSupportsRule;
-            Assert.AreEqual("(not (background-transparency: half))", supports.ConditionText);
-            Assert.IsTrue(supports.Condition.Check(device));
+            Assert.That(supports.ConditionText, Is.EqualTo("(not (background-transparency: half))"));
+            Assert.That(supports.Condition.Check(device), Is.True);
         }
 
         [Test]
@@ -65,11 +65,11 @@ namespace AngleSharp.Css.Tests.Rules
             var source = @"@supports ((background-transparency: zero)) { }";
             var sheet = ParseStyleSheet(source);
             var device = new DefaultRenderDevice();
-            Assert.AreEqual(1, sheet.Rules.Length);
+            Assert.That(sheet.Rules.Length, Is.EqualTo(1));
             Assert.IsInstanceOf<CssSupportsRule>(sheet.Rules[0]);
             var supports = sheet.Rules[0] as CssSupportsRule;
-            Assert.AreEqual("((background-transparency: zero))", supports.ConditionText);
-            Assert.IsFalse(supports.Condition.Check(device));
+            Assert.That(supports.ConditionText, Is.EqualTo("((background-transparency: zero))"));
+            Assert.That(supports.Condition.Check(device), Is.False);
         }
 
         [Test]
@@ -78,11 +78,11 @@ namespace AngleSharp.Css.Tests.Rules
             var source = @"@supports (background: red !important) { }";
             var sheet = ParseStyleSheet(source);
             var device = new DefaultRenderDevice();
-            Assert.AreEqual(1, sheet.Rules.Length);
+            Assert.That(sheet.Rules.Length, Is.EqualTo(1));
             Assert.IsInstanceOf<CssSupportsRule>(sheet.Rules[0]);
             var supports = sheet.Rules[0] as CssSupportsRule;
-            Assert.AreEqual("(background: red !important)", supports.ConditionText);
-            Assert.IsTrue(supports.Condition.Check(device));
+            Assert.That(supports.ConditionText, Is.EqualTo("(background: red !important)"));
+            Assert.That(supports.Condition.Check(device), Is.True);
         }
 
         [Test]
@@ -91,11 +91,11 @@ namespace AngleSharp.Css.Tests.Rules
             var source = @"@supports ((padding-TOP :  0) or (padding-left : 0)) { }";
             var sheet = ParseStyleSheet(source);
             var device = new DefaultRenderDevice();
-            Assert.AreEqual(1, sheet.Rules.Length);
+            Assert.That(sheet.Rules.Length, Is.EqualTo(1));
             Assert.IsInstanceOf<CssSupportsRule>(sheet.Rules[0]);
             var supports = sheet.Rules[0] as CssSupportsRule;
-            Assert.AreEqual("((padding-TOP: 0) or (padding-left: 0))", supports.ConditionText);
-            Assert.IsTrue(supports.Condition.Check(device));
+            Assert.That(supports.ConditionText, Is.EqualTo("((padding-TOP: 0) or (padding-left: 0))"));
+            Assert.That(supports.Condition.Check(device), Is.True);
         }
 
         [Test]
@@ -104,11 +104,11 @@ namespace AngleSharp.Css.Tests.Rules
             var source = @"@supports (((padding-top: 0)  or  (padding-left: 0))  and  ((padding-bottom:  0)  or  (padding-right: 0))) { }";
             var sheet = ParseStyleSheet(source);
             var device = new DefaultRenderDevice();
-            Assert.AreEqual(1, sheet.Rules.Length);
+            Assert.That(sheet.Rules.Length, Is.EqualTo(1));
             Assert.IsInstanceOf<CssSupportsRule>(sheet.Rules[0]);
             var supports = sheet.Rules[0] as CssSupportsRule;
-            Assert.AreEqual("(((padding-top: 0) or (padding-left: 0)) and ((padding-bottom: 0) or (padding-right: 0)))", supports.ConditionText);
-            Assert.IsTrue(supports.Condition.Check(device));
+            Assert.That(supports.ConditionText, Is.EqualTo("(((padding-top: 0) or (padding-left: 0)) and ((padding-bottom: 0) or (padding-right: 0)))"));
+            Assert.That(supports.Condition.Check(device), Is.True);
         }
 
         [Test]
@@ -117,11 +117,11 @@ namespace AngleSharp.Css.Tests.Rules
             var source = @"@supports (display: flex !important) { }";
             var sheet = ParseStyleSheet(source);
             var device = new DefaultRenderDevice();
-            Assert.AreEqual(1, sheet.Rules.Length);
+            Assert.That(sheet.Rules.Length, Is.EqualTo(1));
             Assert.IsInstanceOf<CssSupportsRule>(sheet.Rules[0]);
             var supports = sheet.Rules[0] as CssSupportsRule;
-            Assert.AreEqual("(display: flex !important)", supports.ConditionText);
-            Assert.IsTrue(supports.Condition.Check(device));
+            Assert.That(supports.ConditionText, Is.EqualTo("(display: flex !important)"));
+            Assert.That(supports.Condition.Check(device), Is.True);
         }
 
         [Test]
@@ -129,7 +129,7 @@ namespace AngleSharp.Css.Tests.Rules
         {
             var source = @"@supports display: flex { }";
             var sheet = ParseStyleSheet(source);
-            Assert.AreEqual(0, sheet.Rules.Length);
+            Assert.That(sheet.Rules.Length, Is.EqualTo(0));
         }
 
         [Test]
@@ -138,11 +138,11 @@ namespace AngleSharp.Css.Tests.Rules
             var source = @"@supports ((display: flex)) { }";
             var sheet = ParseStyleSheet(source);
             var device = new DefaultRenderDevice();
-            Assert.AreEqual(1, sheet.Rules.Length);
+            Assert.That(sheet.Rules.Length, Is.EqualTo(1));
             Assert.IsInstanceOf<CssSupportsRule>(sheet.Rules[0]);
             var supports = sheet.Rules[0] as CssSupportsRule;
-            Assert.AreEqual("((display: flex))", supports.ConditionText);
-            Assert.IsTrue(supports.Condition.Check(device));
+            Assert.That(supports.ConditionText, Is.EqualTo("((display: flex))"));
+            Assert.That(supports.Condition.Check(device), Is.True);
         }
 
         [Test]
@@ -153,11 +153,11 @@ namespace AngleSharp.Css.Tests.Rules
           (transform: rotate(10deg)) { }";
             var sheet = ParseStyleSheet(source);
             var device = new DefaultRenderDevice();
-            Assert.AreEqual(1, sheet.Rules.Length);
+            Assert.That(sheet.Rules.Length, Is.EqualTo(1));
             Assert.IsInstanceOf<CssSupportsRule>(sheet.Rules[0]);
             var supports = sheet.Rules[0] as CssSupportsRule;
-            Assert.AreEqual("((transition-property: color) or (animation-name: foo)) and (transform: rotate(10deg))", supports.ConditionText);
-            Assert.IsTrue(supports.Condition.Check(device));
+            Assert.That(supports.ConditionText, Is.EqualTo("((transition-property: color) or (animation-name: foo)) and (transform: rotate(10deg))"));
+            Assert.That(supports.Condition.Check(device), Is.True);
         }
 
         [Test]
@@ -168,11 +168,11 @@ namespace AngleSharp.Css.Tests.Rules
           (transform: rotate(10deg))) { }";
             var sheet = ParseStyleSheet(source);
             var device = new DefaultRenderDevice();
-            Assert.AreEqual(1, sheet.Rules.Length);
+            Assert.That(sheet.Rules.Length, Is.EqualTo(1));
             Assert.IsInstanceOf<CssSupportsRule>(sheet.Rules[0]);
             var supports = sheet.Rules[0] as CssSupportsRule;
-            Assert.AreEqual("(transition-property: color) or ((animation-name: foo) and (transform: rotate(10deg)))", supports.ConditionText);
-            Assert.IsTrue(supports.Condition.Check(device));
+            Assert.That(supports.ConditionText, Is.EqualTo("(transition-property: color) or ((animation-name: foo) and (transform: rotate(10deg)))"));
+            Assert.That(supports.Condition.Check(device), Is.True);
         }
 
         [Test]
@@ -184,11 +184,11 @@ namespace AngleSharp.Css.Tests.Rules
           ( -o-box-shadow: 0 0 2px black ) { }";
             var sheet = ParseStyleSheet(source);
             var device = new DefaultRenderDevice();
-            Assert.AreEqual(1, sheet.Rules.Length);
+            Assert.That(sheet.Rules.Length, Is.EqualTo(1));
             Assert.IsInstanceOf<CssSupportsRule>(sheet.Rules[0]);
             var supports = sheet.Rules[0] as CssSupportsRule;
-            Assert.AreEqual("(box-shadow: 0 0 2px black) or (-moz-box-shadow: 0 0 2px black) or (-webkit-box-shadow: 0 0 2px black) or (-o-box-shadow: 0 0 2px black)", supports.ConditionText);
-            Assert.IsTrue(supports.Condition.Check(device));
+            Assert.That(supports.ConditionText, Is.EqualTo("(box-shadow: 0 0 2px black) or (-moz-box-shadow: 0 0 2px black) or (-webkit-box-shadow: 0 0 2px black) or (-o-box-shadow: 0 0 2px black)"));
+            Assert.That(supports.Condition.Check(device), Is.True);
         }
 
         [Test]
@@ -201,12 +201,12 @@ namespace AngleSharp.Css.Tests.Rules
 }";
             var sheet = ParseStyleSheet(source);
             var device = new DefaultRenderDevice();
-            Assert.AreEqual(1, sheet.Rules.Length);
+            Assert.That(sheet.Rules.Length, Is.EqualTo(1));
             Assert.IsInstanceOf<CssSupportsRule>(sheet.Rules[0]);
             var supports = sheet.Rules[0] as CssSupportsRule;
-            Assert.AreEqual(3, supports.Rules.Length);
-            Assert.AreEqual("not (display: flex)", supports.ConditionText);
-            Assert.IsFalse(supports.Condition.Check(device));
+            Assert.That(supports.Rules.Length, Is.EqualTo(3));
+            Assert.That(supports.ConditionText, Is.EqualTo("not (display: flex)"));
+            Assert.That(supports.Condition.Check(device), Is.False);
         }
     }
 }

--- a/src/AngleSharp.Css.Tests/Rules/FontFace.cs
+++ b/src/AngleSharp.Css.Tests/Rules/FontFace.cs
@@ -1,4 +1,4 @@
-﻿namespace AngleSharp.Css.Tests.Rules
+namespace AngleSharp.Css.Tests.Rules
 {
     using AngleSharp.Css.Dom;
     using NUnit.Framework;
@@ -13,17 +13,17 @@
             var src = "@font-face{font-family:'Open Sans';src:url(fonts/OpenSans-Light.eot);src:local('Open Sans Light'),local('OpenSans-Light'),url(fonts/OpenSans-Light.ttf) format('truetype'),url(fonts/OpenSans-Light.woff) format('woff');font-style:normal}";
             var sheet = ParseStyleSheet(src);
             Assert.IsNotNull(sheet);
-            Assert.AreEqual(1, sheet.Rules.Length);
+            Assert.That(sheet.Rules.Length, Is.EqualTo(1));
             Assert.IsInstanceOf<CssFontFaceRule>(sheet.Rules[0]);
             var fontface = (ICssFontFaceRule)sheet.Rules[0];
-            Assert.AreEqual("\"Open Sans\"", fontface.Family);
-            Assert.AreEqual("", fontface.Features);
-            Assert.AreEqual("", fontface.Range);
+            Assert.That(fontface.Family, Is.EqualTo("\"Open Sans\""));
+            Assert.That(fontface.Features, Is.EqualTo(""));
+            Assert.That(fontface.Range, Is.EqualTo(""));
             Assert.AreNotEqual("", fontface.Source);
-            Assert.AreEqual("", fontface.Stretch);
-            Assert.AreEqual("normal", fontface.Style);
-            Assert.AreEqual("", fontface.Variant);
-            Assert.AreEqual("", fontface.Weight);
+            Assert.That(fontface.Stretch, Is.EqualTo(""));
+            Assert.That(fontface.Style, Is.EqualTo("normal"));
+            Assert.That(fontface.Variant, Is.EqualTo(""));
+            Assert.That(fontface.Weight, Is.EqualTo(""));
         }
 
         [Test]
@@ -32,17 +32,17 @@
             var src = "@font-face{font-family:'Open Sans';font-style:normal}";
             var sheet = ParseStyleSheet(src);
             Assert.IsNotNull(sheet);
-            Assert.AreEqual(1, sheet.Rules.Length);
+            Assert.That(sheet.Rules.Length, Is.EqualTo(1));
             Assert.IsInstanceOf<CssFontFaceRule>(sheet.Rules[0]);
             var fontface = (ICssFontFaceRule)sheet.Rules[0];
-            Assert.AreEqual("\"Open Sans\"", fontface.Family);
-            Assert.AreEqual("", fontface.Features);
-            Assert.AreEqual("", fontface.Range);
-            Assert.AreEqual("", fontface.Source);
-            Assert.AreEqual("", fontface.Stretch);
-            Assert.AreEqual("normal", fontface.Style);
-            Assert.AreEqual("", fontface.Variant);
-            Assert.AreEqual("", fontface.Weight);
+            Assert.That(fontface.Family, Is.EqualTo("\"Open Sans\""));
+            Assert.That(fontface.Features, Is.EqualTo(""));
+            Assert.That(fontface.Range, Is.EqualTo(""));
+            Assert.That(fontface.Source, Is.EqualTo(""));
+            Assert.That(fontface.Stretch, Is.EqualTo(""));
+            Assert.That(fontface.Style, Is.EqualTo("normal"));
+            Assert.That(fontface.Variant, Is.EqualTo(""));
+            Assert.That(fontface.Weight, Is.EqualTo(""));
         }
     }
 }

--- a/src/AngleSharp.Css.Tests/Styling/BasicStyling.cs
+++ b/src/AngleSharp.Css.Tests/Styling/BasicStyling.cs
@@ -46,11 +46,11 @@ namespace AngleSharp.Css.Tests.Styling
             var document = await CreateDocumentWithOptions(source);
             var link = document.QuerySelector<IHtmlLinkElement>("link");
 
-            Assert.AreEqual(2, document.StyleSheets.Length);
-            Assert.AreEqual(2, document.StyleSheetSets.Length);
-            Assert.IsTrue(link.IsPreferred());
-            Assert.IsFalse(link.IsAlternate());
-            Assert.IsFalse(link.IsPersistent());
+            Assert.That(document.StyleSheets.Length, Is.EqualTo(2));
+            Assert.That(document.StyleSheetSets.Length, Is.EqualTo(2));
+            Assert.That(link.IsPreferred(), Is.True);
+            Assert.That(link.IsAlternate(), Is.False);
+            Assert.That(link.IsPersistent(), Is.False);
         }
 
         [Test]
@@ -66,11 +66,11 @@ namespace AngleSharp.Css.Tests.Styling
             var document = await CreateDocumentWithOptions(source);
             var link = document.QuerySelector<IHtmlLinkElement>("link");
 
-            Assert.AreEqual(2, document.StyleSheets.Length);
-            Assert.AreEqual(1, document.StyleSheetSets.Length);
-            Assert.IsFalse(link.IsPreferred());
-            Assert.IsFalse(link.IsAlternate());
-            Assert.IsTrue(link.IsPersistent());
+            Assert.That(document.StyleSheets.Length, Is.EqualTo(2));
+            Assert.That(document.StyleSheetSets.Length, Is.EqualTo(1));
+            Assert.That(link.IsPreferred(), Is.False);
+            Assert.That(link.IsAlternate(), Is.False);
+            Assert.That(link.IsPersistent(), Is.True);
         }
 
         [Test]
@@ -86,11 +86,11 @@ namespace AngleSharp.Css.Tests.Styling
             var document = await CreateDocumentWithOptions(source);
             var link = document.QuerySelector<IHtmlLinkElement>("link");
 
-            Assert.AreEqual(2, document.StyleSheets.Length);
-            Assert.AreEqual(2, document.StyleSheetSets.Length);
-            Assert.IsFalse(link.IsPreferred());
-            Assert.IsTrue(link.IsAlternate());
-            Assert.IsFalse(link.IsPersistent());
+            Assert.That(document.StyleSheets.Length, Is.EqualTo(2));
+            Assert.That(document.StyleSheetSets.Length, Is.EqualTo(2));
+            Assert.That(link.IsPreferred(), Is.False);
+            Assert.That(link.IsAlternate(), Is.True);
+            Assert.That(link.IsPersistent(), Is.False);
         }
 
         [Test]
@@ -99,19 +99,19 @@ namespace AngleSharp.Css.Tests.Styling
             var source = "<!doctype html><head><style>p > span { color: blue; } span.bold { font-weight: bold; }</style></head><body><div><p><span class='bold'>Bold text";
             var document = await CreateDocumentWithOptions(source);
             var element = document.QuerySelector("span.bold");
-            Assert.AreEqual("span", element.LocalName);
-            Assert.AreEqual("bold", element.ClassName);
+            Assert.That(element.LocalName, Is.EqualTo("span"));
+            Assert.That(element.ClassName, Is.EqualTo("bold"));
             var style = element.ComputeCurrentStyle();
             Assert.IsNotNull(style);
-            Assert.AreEqual(2, style.Length);
+            Assert.That(style.Length, Is.EqualTo(2));
         }
 
         [Test]
         public void CssStyleDeclarationEmpty()
         {
             var css = ParseDeclarations(String.Empty);
-            Assert.AreEqual("", css.CssText);
-            Assert.AreEqual(0, css.Length);
+            Assert.That(css.CssText, Is.EqualTo(""));
+            Assert.That(css.Length, Is.EqualTo(0));
         }
 
         [Test]
@@ -119,8 +119,8 @@ namespace AngleSharp.Css.Tests.Styling
         {
             var css = ParseDeclarations(String.Empty);
             css.CssText = "background-color: rgb(255, 0, 0); color: rgb(0, 0, 0)";
-            Assert.AreEqual("background-color: rgba(255, 0, 0, 1); color: rgba(0, 0, 0, 1)", css.CssText);
-            Assert.AreEqual(2, css.Length);
+            Assert.That(css.CssText, Is.EqualTo("background-color: rgba(255, 0, 0, 1); color: rgba(0, 0, 0, 1)"));
+            Assert.That(css.Length, Is.EqualTo(2));
         }
 
         [Test]
@@ -129,8 +129,8 @@ namespace AngleSharp.Css.Tests.Styling
             var document = ParseDocument(String.Empty);
             var element = document.CreateElement<IHtmlSpanElement>();
             element.SetAttribute("style", "background-color: rgb(255, 0, 0); color: rgb(0, 0, 0)");
-            Assert.AreEqual("background-color: rgba(255, 0, 0, 1); color: rgba(0, 0, 0, 1)", element.GetStyle().CssText);
-            Assert.AreEqual(2, element.GetStyle().Length);
+            Assert.That(element.GetStyle().CssText, Is.EqualTo("background-color: rgba(255, 0, 0, 1); color: rgba(0, 0, 0, 1)"));
+            Assert.That(element.GetStyle().Length, Is.EqualTo(2));
         }
 
         [Test]
@@ -139,10 +139,10 @@ namespace AngleSharp.Css.Tests.Styling
             var document = ParseDocument(String.Empty);
             var element = document.CreateElement<IHtmlSpanElement>();
             element.SetAttribute("style", String.Empty);
-            Assert.AreEqual(String.Empty, element.GetStyle().CssText);
+            Assert.That(element.GetStyle().CssText, Is.EqualTo(String.Empty));
             element.SetAttribute("style", "background-color: rgb(255, 0, 0); color: rgb(0, 0, 0)");
-            Assert.AreEqual("background-color: rgba(255, 0, 0, 1); color: rgba(0, 0, 0, 1)", element.GetStyle().CssText);
-            Assert.AreEqual(2, element.GetStyle().Length);
+            Assert.That(element.GetStyle().CssText, Is.EqualTo("background-color: rgba(255, 0, 0, 1); color: rgba(0, 0, 0, 1)"));
+            Assert.That(element.GetStyle().Length, Is.EqualTo(2));
         }
 
         [Test]
@@ -151,8 +151,8 @@ namespace AngleSharp.Css.Tests.Styling
             var document = ParseDocument(String.Empty);
             var element = document.CreateElement<IHtmlSpanElement>();
             element.SetStyle("background-color: rgb(255, 0, 0); color: rgb(0, 0, 0)");
-            Assert.AreEqual("background-color: rgb(255, 0, 0); color: rgb(0, 0, 0)", element.GetAttribute("style"));
-            Assert.AreEqual(2, element.GetStyle().Length);
+            Assert.That(element.GetAttribute("style"), Is.EqualTo("background-color: rgb(255, 0, 0); color: rgb(0, 0, 0)"));
+            Assert.That(element.GetStyle().Length, Is.EqualTo(2));
         }
 
         [Test]
@@ -160,7 +160,7 @@ namespace AngleSharp.Css.Tests.Styling
         {
             var sheet = ParseStyleSheet("h1 /* this is a comment */ { color: red; /*another comment*/ }");
             var result = sheet.ToCss(new MinifyStyleFormatter());
-            Assert.AreEqual("h1{color:rgba(255, 0, 0, 1)}", result);
+            Assert.That(result, Is.EqualTo("h1{color:rgba(255, 0, 0, 1)}"));
         }
 
         [Test]
@@ -168,7 +168,7 @@ namespace AngleSharp.Css.Tests.Styling
         {
             var sheet = ParseStyleSheet("h1 {  }");
             var result = sheet.ToCss(new MinifyStyleFormatter());
-            Assert.AreEqual("", result);
+            Assert.That(result, Is.EqualTo(""));
         }
 
         [Test]
@@ -176,7 +176,7 @@ namespace AngleSharp.Css.Tests.Styling
         {
             var sheet = ParseStyleSheet("h1 {  } h2 { font-size:0;  }");
             var result = sheet.ToCss(new MinifyStyleFormatter());
-            Assert.AreEqual("h2{font-size:0}", result);
+            Assert.That(result, Is.EqualTo("h2{font-size:0}"));
         }
 
         [Test]
@@ -184,7 +184,7 @@ namespace AngleSharp.Css.Tests.Styling
         {
             var sheet = ParseStyleSheet("@media screen { h1 {  } }");
             var result = sheet.ToCss(new MinifyStyleFormatter());
-            Assert.AreEqual("", result);
+            Assert.That(result, Is.EqualTo(""));
         }
 
         [Test]
@@ -192,7 +192,7 @@ namespace AngleSharp.Css.Tests.Styling
         {
             var sheet = ParseStyleSheet("@media screen { h1 {  } h2 { top:0} }");
             var result = sheet.ToCss(new MinifyStyleFormatter());
-            Assert.AreEqual("@media screen{h2{top:0}}", result);
+            Assert.That(result, Is.EqualTo("@media screen{h2{top:0}}"));
         }
 
         [Test]
@@ -200,7 +200,7 @@ namespace AngleSharp.Css.Tests.Styling
         {
             var sheet = ParseStyleSheet("@media screen { @media screen{h1{}}div{border-top  :  none} }");
             var result = sheet.ToCss(new MinifyStyleFormatter());
-            Assert.AreEqual("@media screen{div{border-top:none}}", result);
+            Assert.That(result, Is.EqualTo("@media screen{div{border-top:none}}"));
         }
 
         [Test]
@@ -208,7 +208,7 @@ namespace AngleSharp.Css.Tests.Styling
         {
             var sheet = ParseStyleSheet("h1 { top:0   ; left:   2px;  border: none;  } h2 { border: 1px solid red;} h3{}");
             var result = sheet.ToCss(new MinifyStyleFormatter());
-            Assert.AreEqual("h1{top:0;left:2px;border:none}h2{border:1px solid rgba(255, 0, 0, 1)}", result);
+            Assert.That(result, Is.EqualTo("h1{top:0;left:2px;border:none}h2{border:1px solid rgba(255, 0, 0, 1)}"));
         }
 
         [Test]
@@ -216,7 +216,7 @@ namespace AngleSharp.Css.Tests.Styling
         {
             var sheet = ParseStyleSheet("a { grid-area: aa / aa / aa / aa }");
             var result = sheet.ToCss(new MinifyStyleFormatter());
-            Assert.AreEqual("a{grid-area:aa}", result);
+            Assert.That(result, Is.EqualTo("a{grid-area:aa}"));
         }
     }
 }

--- a/src/AngleSharp.Css.Tests/Styling/Configuration.cs
+++ b/src/AngleSharp.Css.Tests/Styling/Configuration.cs
@@ -34,7 +34,7 @@ namespace AngleSharp.Css.Tests.Styling
             Assert.IsNotNull(service.Default);
             var sheet = service.Default;
             Assert.IsNotNull(sheet);
-            Assert.AreEqual(49, sheet.Rules.Length);
+            Assert.That(sheet.Rules.Length, Is.EqualTo(49));
         }
     }
 }

--- a/src/AngleSharp.Css.Tests/Styling/ContextLoading.cs
+++ b/src/AngleSharp.Css.Tests/Styling/ContextLoading.cs
@@ -23,10 +23,10 @@ namespace AngleSharp.Css.Tests.Styling
             var context = BrowsingContext.New(config);
             var document = await context.OpenAsync(m => m.Content(memory).Address(url));
             var links = document.QuerySelectorAll("link");
-            Assert.AreEqual(1, links.Length);
+            Assert.That(links.Length, Is.EqualTo(1));
             var link = links[0] as IHtmlLinkElement;
             Assert.NotNull(link);
-            Assert.AreEqual("http://localhost/beispiel.css", link.Href);
+            Assert.That(link.Href, Is.EqualTo("http://localhost/beispiel.css"));
         }
 
         [Test]
@@ -53,7 +53,7 @@ namespace AngleSharp.Css.Tests.Styling
 
             var config = Configuration.Default.WithPageRequester(enableResourceLoading: true).WithCss();
             var document = await BrowsingContext.New(config).OpenAsync(m => m.Content(html));
-            Assert.AreEqual(1, document.StyleSheets.Length);
+            Assert.That(document.StyleSheets.Length, Is.EqualTo(1));
         }
 
         [Test]
@@ -76,20 +76,20 @@ namespace AngleSharp.Css.Tests.Styling
             var document = await BrowsingContext.New(config).OpenAsync(res => res.Content(content).Address("http://localhost"));
             var downloads = document.GetDownloads().ToArray();
 
-            Assert.AreEqual(6, downloads.Length);
+            Assert.That(downloads.Length, Is.EqualTo(6));
 
             foreach (var download in downloads)
             {
-                Assert.IsTrue(download.IsCompleted);
+                Assert.That(download.IsCompleted, Is.True);
                 Assert.IsNotNull(download.Source);
             }
 
-            Assert.AreEqual(document.QuerySelectorAll("link").Skip(0).First(), downloads[0].Source);
-            Assert.AreEqual(document.QuerySelectorAll("link").Skip(1).First(), downloads[1].Source);
-            Assert.AreEqual(document.QuerySelectorAll("link").Skip(2).First(), downloads[2].Source);
-            Assert.AreEqual(document.QuerySelector("img"), downloads[3].Source);
-            Assert.AreEqual(document.QuerySelector("iframe"), downloads[4].Source);
-            Assert.AreEqual(document.QuerySelectorAll("script").Skip(1).First(), downloads[5].Source);
+            Assert.That(downloads[0].Source, Is.EqualTo(document.QuerySelectorAll("link").Skip(0).First()));
+            Assert.That(downloads[1].Source, Is.EqualTo(document.QuerySelectorAll("link").Skip(1).First()));
+            Assert.That(downloads[2].Source, Is.EqualTo(document.QuerySelectorAll("link").Skip(2).First()));
+            Assert.That(downloads[3].Source, Is.EqualTo(document.QuerySelector("img")));
+            Assert.That(downloads[4].Source, Is.EqualTo(document.QuerySelector("iframe")));
+            Assert.That(downloads[5].Source, Is.EqualTo(document.QuerySelectorAll("script").Skip(1).First()));
         }
     }
 }

--- a/src/AngleSharp.Css.Tests/Styling/CssCases.cs
+++ b/src/AngleSharp.Css.Tests/Styling/CssCases.cs
@@ -24,7 +24,7 @@ namespace AngleSharp.Css.Tests.Styling
         public void StyleSheetAtNamespace()
 		{
 			var sheet = ParseSheet(@"@namespace svg ""http://www.w3.org/2000/svg"";");
-			Assert.AreEqual(1, sheet.Rules.Length);
+			Assert.That(sheet.Rules.Length, Is.EqualTo(1));
 		}
 
 		[Test]
@@ -33,10 +33,10 @@ namespace AngleSharp.Css.Tests.Styling
 			var sheet = ParseSheet(@"@charset
     ""UTF-8""
     ;");
-			Assert.AreEqual(1, sheet.Rules.Length);
+			Assert.That(sheet.Rules.Length, Is.EqualTo(1));
 
 			foreach (var rule in sheet.Rules)
-				Assert.AreEqual(@"UTF-8", ((ICssCharsetRule)rule).CharacterSet);
+				Assert.That(((ICssCharsetRule)rule).CharacterSet, Is.EqualTo(@"UTF-8"));
 		}
 
 		[Test]
@@ -45,9 +45,9 @@ namespace AngleSharp.Css.Tests.Styling
 			var sheet = ParseSheet(@"@charset ""UTF-8"";       /* Set the encoding of the style sheet to Unicode UTF-8 */
 @charset 'iso-8859-15'; /* Set the encoding of the style sheet to Latin-9 (Western European languages, with euro sign) */
 ");
-			Assert.AreEqual(2, sheet.Rules.Length);
-            Assert.AreEqual(@"UTF-8", ((ICssCharsetRule)sheet.Rules[0]).CharacterSet);
-            Assert.AreEqual(@"iso-8859-15", ((ICssCharsetRule)sheet.Rules[1]).CharacterSet);
+			Assert.That(sheet.Rules.Length, Is.EqualTo(2));
+            Assert.That(((ICssCharsetRule)sheet.Rules[0]).CharacterSet, Is.EqualTo(@"UTF-8"));
+            Assert.That(((ICssCharsetRule)sheet.Rules[1]).CharacterSet, Is.EqualTo(@"iso-8859-15"));
 		}
 
 		[Test]
@@ -57,13 +57,13 @@ namespace AngleSharp.Css.Tests.Styling
     margin  : auto;
     padding : 0;
 }");
-			Assert.AreEqual(1, sheet.Rules.Length);
+			Assert.That(sheet.Rules.Length, Is.EqualTo(1));
 
 			foreach (var rule in sheet.Rules)
 			{
-				Assert.AreEqual(@"a", ((ICssStyleRule)rule).SelectorText);
-				Assert.AreEqual(@"auto", ((ICssStyleRule)rule).Style["margin"]);
-				Assert.AreEqual(@"0", ((ICssStyleRule)rule).Style["padding"]);
+				Assert.That(((ICssStyleRule)rule).SelectorText, Is.EqualTo(@"a"));
+				Assert.That(((ICssStyleRule)rule).Style["margin"], Is.EqualTo(@"auto"));
+				Assert.That(((ICssStyleRule)rule).Style["padding"], Is.EqualTo(@"0"));
 			}
 		}
 
@@ -109,22 +109,22 @@ namespace AngleSharp.Css.Tests.Styling
 #foo[qux=' , '] {
   foobar: 345;
 }");
-			Assert.AreEqual(5, sheet.Rules.Length);
+			Assert.That(sheet.Rules.Length, Is.EqualTo(5));
 
-            Assert.AreEqual(@".foo[bar=""baz,quz""]", ((ICssStyleRule)sheet.Rules[0]).SelectorText);
-            Assert.AreEqual(@"123", ((ICssStyleRule)sheet.Rules[0]).Style["foobar"]);
+            Assert.That(((ICssStyleRule)sheet.Rules[0]).SelectorText, Is.EqualTo(@".foo[bar=""baz,quz""]"));
+            Assert.That(((ICssStyleRule)sheet.Rules[0]).Style["foobar"], Is.EqualTo(@"123"));
 
-            Assert.AreEqual(@".bar, #bar[baz=""qux,foo""], #qux", ((ICssStyleRule)sheet.Rules[1]).SelectorText);
-            Assert.AreEqual(@"456", ((ICssStyleRule)sheet.Rules[1]).Style["foobar"]);
+            Assert.That(((ICssStyleRule)sheet.Rules[1]).SelectorText, Is.EqualTo(@".bar, #bar[baz=""qux,foo""], #qux"));
+            Assert.That(((ICssStyleRule)sheet.Rules[1]).Style["foobar"], Is.EqualTo(@"456"));
 
-            Assert.AreEqual(@".baz[qux="",foo""], .baz[qux=""foo,""], .baz[qux=""foo,bar,baz""], .baz[qux="",foo,bar,baz,""], .baz[qux="" , foo , bar , baz , ""]", ((ICssStyleRule)sheet.Rules[2]).SelectorText);
-            Assert.AreEqual(@"789", ((ICssStyleRule)sheet.Rules[2]).Style["foobar"]);
+            Assert.That(((ICssStyleRule)sheet.Rules[2]).SelectorText, Is.EqualTo(@".baz[qux="",foo""], .baz[qux=""foo,""], .baz[qux=""foo,bar,baz""], .baz[qux="",foo,bar,baz,""], .baz[qux="" , foo , bar , baz , ""]"));
+            Assert.That(((ICssStyleRule)sheet.Rules[2]).Style["foobar"], Is.EqualTo(@"789"));
 
-            Assert.AreEqual(@".qux[foo=""bar,baz""], .qux[bar=""baz,foo""], #qux[foo=""foobar""], #qux[foo="",bar,baz, ""]", ((ICssStyleRule)sheet.Rules[3]).SelectorText);
-            Assert.AreEqual(@"012", ((ICssStyleRule)sheet.Rules[3]).Style["foobar"]);
+            Assert.That(((ICssStyleRule)sheet.Rules[3]).SelectorText, Is.EqualTo(@".qux[foo=""bar,baz""], .qux[bar=""baz,foo""], #qux[foo=""foobar""], #qux[foo="",bar,baz, ""]"));
+            Assert.That(((ICssStyleRule)sheet.Rules[3]).Style["foobar"], Is.EqualTo(@"012"));
 
-            Assert.AreEqual(@"#foo[foo=""""], #foo[bar="" ""], #foo[bar="",""], #foo[bar="", ""], #foo[bar="" ,""], #foo[bar="" , ""], #foo[baz=""""], #foo[qux="" ""], #foo[qux="",""], #foo[qux="", ""], #foo[qux="" ,""], #foo[qux="" , ""]", ((ICssStyleRule)sheet.Rules[4]).SelectorText);
-            Assert.AreEqual(@"345", ((ICssStyleRule)sheet.Rules[4]).Style["foobar"]);
+            Assert.That(((ICssStyleRule)sheet.Rules[4]).SelectorText, Is.EqualTo(@"#foo[foo=""""], #foo[bar="" ""], #foo[bar="",""], #foo[bar="", ""], #foo[bar="" ,""], #foo[bar="" , ""], #foo[baz=""""], #foo[qux="" ""], #foo[qux="",""], #foo[qux="", ""], #foo[qux="" ,""], #foo[qux="" , ""]"));
+            Assert.That(((ICssStyleRule)sheet.Rules[4]).Style["foobar"], Is.EqualTo(@"345"));
 		}
 
 		[Test]
@@ -142,13 +142,13 @@ namespace AngleSharp.Css.Tests.Styling
 .foo:matches(,.bar , .baz) {
   anotherprop: anothervalue;
 }");
-            Assert.AreEqual(2, sheet.Rules.Length);
+            Assert.That(sheet.Rules.Length, Is.EqualTo(2));
 
-            Assert.AreEqual(@".foo:matches(.bar, .baz), .foo:matches(.bar, .baz), .foo:matches(.bar, .baz), .foo:matches(.bar, .baz)", ((ICssStyleRule)sheet.Rules[0]).SelectorText);
-            Assert.AreEqual(@"value", ((ICssStyleRule)sheet.Rules[0]).Style["prop"]);
+            Assert.That(((ICssStyleRule)sheet.Rules[0]).SelectorText, Is.EqualTo(@".foo:matches(.bar, .baz), .foo:matches(.bar, .baz), .foo:matches(.bar, .baz), .foo:matches(.bar, .baz)"));
+            Assert.That(((ICssStyleRule)sheet.Rules[0]).Style["prop"], Is.EqualTo(@"value"));
 
-            Assert.AreEqual(null, ((ICssStyleRule)sheet.Rules[1]).SelectorText);
-            Assert.AreEqual(@"anothervalue", ((ICssStyleRule)sheet.Rules[1]).Style["anotherprop"]);
+            Assert.That(((ICssStyleRule)sheet.Rules[1]).SelectorText, Is.EqualTo(null));
+            Assert.That(((ICssStyleRule)sheet.Rules[1]).Style["anotherprop"], Is.EqualTo(@"anothervalue"));
 		}
 
 		[Test]
@@ -159,14 +159,14 @@ namespace AngleSharp.Css.Tests.Styling
     padding/*4815162342*/: 1px /**/ 2px /*13*/ 3px;
     border/*\**/: solid; font-family/*\**/: none\9;
 }");
-			Assert.AreEqual(1, sheet.Rules.Length);
+			Assert.That(sheet.Rules.Length, Is.EqualTo(1));
             var rule = sheet.Rules[0];
 
-            Assert.AreEqual(@"a", ((ICssStyleRule)rule).SelectorText);
-            Assert.AreEqual(@"rgba(255, 0, 0, 1)", ((ICssStyleRule)rule).Style["color"]);
-            Assert.AreEqual(@"1px 2px 3px", ((ICssStyleRule)rule).Style["padding"]);
-            Assert.AreEqual(@"solid", ((ICssStyleRule)rule).Style["border"]);
-            Assert.AreEqual("none\t", ((ICssStyleRule)rule).Style["font-family"]);
+            Assert.That(((ICssStyleRule)rule).SelectorText, Is.EqualTo(@"a"));
+            Assert.That(((ICssStyleRule)rule).Style["color"], Is.EqualTo(@"rgba(255, 0, 0, 1)"));
+            Assert.That(((ICssStyleRule)rule).Style["padding"], Is.EqualTo(@"1px 2px 3px"));
+            Assert.That(((ICssStyleRule)rule).Style["border"], Is.EqualTo(@"solid"));
+            Assert.That(((ICssStyleRule)rule).Style["font-family"], Is.EqualTo("none\t"));
 		}
 
 		[Test]
@@ -179,10 +179,10 @@ foo { /*/*/
   /* something */
   bar: baz; /* http://foo.com/bar/baz.html */
 }");
-			Assert.AreEqual(1, sheet.Rules.Length);
+			Assert.That(sheet.Rules.Length, Is.EqualTo(1));
 
-            Assert.AreEqual(@"foo", ((ICssStyleRule)sheet.Rules[0]).SelectorText);
-            Assert.AreEqual(@"baz", ((ICssStyleRule)sheet.Rules[0]).Style["bar"]);
+            Assert.That(((ICssStyleRule)sheet.Rules[0]).SelectorText, Is.EqualTo(@"foo"));
+            Assert.That(((ICssStyleRule)sheet.Rules[0]).Style["bar"], Is.EqualTo(@"baz"));
 		}
 
 		[Test]
@@ -197,10 +197,10 @@ head, /* footer, */body/*, nav */ { /* 2 */
 } /* 5 */
 
 /* 6 */");
-			Assert.AreEqual(1, sheet.Rules.Length);
+			Assert.That(sheet.Rules.Length, Is.EqualTo(1));
 
-            Assert.AreEqual(@"head, body", ((ICssStyleRule)sheet.Rules[0]).SelectorText);
-            Assert.AreEqual(@"'bar'", ((ICssStyleRule)sheet.Rules[0]).Style["foo"]);
+            Assert.That(((ICssStyleRule)sheet.Rules[0]).SelectorText, Is.EqualTo(@"head, body"));
+            Assert.That(((ICssStyleRule)sheet.Rules[0]).Style["foo"], Is.EqualTo(@"'bar'"));
 		}
 
 		[Test]
@@ -210,7 +210,7 @@ head, /* footer, */body/*, nav */ { /* 2 */
     --test
     (min-width: 200px)
 ;");
-			Assert.AreEqual(1, sheet.Rules.Length);
+			Assert.That(sheet.Rules.Length, Is.EqualTo(1));
 		}
 
 		[Test]
@@ -219,7 +219,7 @@ head, /* footer, */body/*, nav */ { /* 2 */
 			var sheet = ParseSheet(@"@custom-media --narrow-window (max-width: 30em);
 @custom-media --wide-window screen and (min-width: 40em);
 ");
-			Assert.AreEqual(2, sheet.Rules.Length);
+			Assert.That(sheet.Rules.Length, Is.EqualTo(2));
 		}
 
 		[Test]
@@ -234,7 +234,7 @@ head, /* footer, */body/*, nav */ { /* 2 */
         }
 
     }");
-			Assert.AreEqual(1, sheet.Rules.Length);
+			Assert.That(sheet.Rules.Length, Is.EqualTo(1));
 		}
 
 		[Test]
@@ -251,14 +251,14 @@ head, /* footer, */body/*, nav */ { /* 2 */
     height: .9em;
   }
 }");
-			Assert.AreEqual(1, sheet.Rules.Length);
+			Assert.That(sheet.Rules.Length, Is.EqualTo(1));
 		}
 
 		[Test]
 		public void StyleSheetEmpty()
 		{
 			var sheet = ParseSheet(@"");
-			Assert.AreEqual(0, sheet.Rules.Length);
+			Assert.That(sheet.Rules.Length, Is.EqualTo(0));
 		}
 
 		[Test]
@@ -318,87 +318,87 @@ li{background:orange;}
 
 /* css-parse does not yet pass this test */
 /*#\{\}{background:lime;}*/");
-			Assert.AreEqual(42, sheet.Rules.Length);
+			Assert.That(sheet.Rules.Length, Is.EqualTo(42));
 
-            Assert.AreEqual(@".\:\`\(", ((ICssStyleRule)sheet.Rules[0]).SelectorText);
-            Assert.AreEqual(@".\31 a2b3c", ((ICssStyleRule)sheet.Rules[1]).SelectorText);
-            Assert.AreEqual(@"#\#fake-id", ((ICssStyleRule)sheet.Rules[2]).SelectorText);
-            Assert.AreEqual(@"#---", ((ICssStyleRule)sheet.Rules[3]).SelectorText);
-            Assert.AreEqual(@"#-a-b-c-", ((ICssStyleRule)sheet.Rules[4]).SelectorText);
-            Assert.AreEqual(@"#©", ((ICssStyleRule)sheet.Rules[5]).SelectorText);
-            Assert.AreEqual(@"html", ((ICssStyleRule)sheet.Rules[6]).SelectorText);
-            Assert.AreEqual(@"1.2em / 1.6 Arial", ((ICssStyleRule)sheet.Rules[6]).Style["font"]);
-            Assert.AreEqual(@"code", ((ICssStyleRule)sheet.Rules[7]).SelectorText);
-            Assert.AreEqual(@"Consolas", ((ICssStyleRule)sheet.Rules[7]).Style["font-family"]);
-            Assert.AreEqual(@"li code", ((ICssStyleRule)sheet.Rules[8]).SelectorText);
-            Assert.AreEqual(@"rgba(255, 255, 255, 0.5)", ((ICssStyleRule)sheet.Rules[8]).Style["background"]);
-            Assert.AreEqual(@"0.3em", ((ICssStyleRule)sheet.Rules[8]).Style["padding"]);
-            Assert.AreEqual(@"li", ((ICssStyleRule)sheet.Rules[9]).SelectorText);
-            Assert.AreEqual(@"rgba(255, 165, 0, 1)", ((ICssStyleRule)sheet.Rules[9]).Style["background"]);
-            Assert.AreEqual(@"#♥", ((ICssStyleRule)sheet.Rules[10]).SelectorText);
-            Assert.AreEqual(@"rgba(0, 255, 0, 1)", ((ICssStyleRule)sheet.Rules[10]).Style["background"]);
-            Assert.AreEqual(@"#©", ((ICssStyleRule)sheet.Rules[11]).SelectorText);
-            Assert.AreEqual(@"rgba(0, 255, 0, 1)", ((ICssStyleRule)sheet.Rules[11]).Style["background"]);
-            Assert.AreEqual(@"#“‘’”", ((ICssStyleRule)sheet.Rules[12]).SelectorText);
-            Assert.AreEqual(@"rgba(0, 255, 0, 1)", ((ICssStyleRule)sheet.Rules[12]).Style["background"]);
-            Assert.AreEqual(@"#☺☃", ((ICssStyleRule)sheet.Rules[13]).SelectorText);
-            Assert.AreEqual(@"rgba(0, 255, 0, 1)", ((ICssStyleRule)sheet.Rules[13]).Style["background"]);
-            Assert.AreEqual(@"#⌘⌥", ((ICssStyleRule)sheet.Rules[14]).SelectorText);
-            Assert.AreEqual(@"rgba(0, 255, 0, 1)", ((ICssStyleRule)sheet.Rules[14]).Style["background"]);
-            Assert.AreEqual(@"#𝄞♪♩♫♬", ((ICssStyleRule)sheet.Rules[15]).SelectorText);
-            Assert.AreEqual(@"rgba(0, 255, 0, 1)", ((ICssStyleRule)sheet.Rules[15]).Style["background"]);
-            Assert.AreEqual(@"#\?", ((ICssStyleRule)sheet.Rules[16]).SelectorText);
-            Assert.AreEqual(@"rgba(0, 255, 0, 1)", ((ICssStyleRule)sheet.Rules[16]).Style["background"]);
-            Assert.AreEqual(@"#\@", ((ICssStyleRule)sheet.Rules[17]).SelectorText);
-            Assert.AreEqual(@"rgba(0, 255, 0, 1)", ((ICssStyleRule)sheet.Rules[17]).Style["background"]);
-            Assert.AreEqual(@"#\.", ((ICssStyleRule)sheet.Rules[18]).SelectorText);
-            Assert.AreEqual(@"rgba(0, 255, 0, 1)", ((ICssStyleRule)sheet.Rules[18]).Style["background"]);
-            Assert.AreEqual(@"#\:\)", ((ICssStyleRule)sheet.Rules[19]).SelectorText);
-            Assert.AreEqual(@"rgba(0, 255, 0, 1)", ((ICssStyleRule)sheet.Rules[19]).Style["background"]);
-            Assert.AreEqual(@"#\:\`\(", ((ICssStyleRule)sheet.Rules[20]).SelectorText);
-            Assert.AreEqual(@"rgba(0, 255, 0, 1)", ((ICssStyleRule)sheet.Rules[20]).Style["background"]);
-            Assert.AreEqual(@"#\31 23", ((ICssStyleRule)sheet.Rules[21]).SelectorText);
-            Assert.AreEqual(@"rgba(0, 255, 0, 1)", ((ICssStyleRule)sheet.Rules[21]).Style["background"]);
-            Assert.AreEqual(@"#\31 a2b3c", ((ICssStyleRule)sheet.Rules[22]).SelectorText);
-            Assert.AreEqual(@"rgba(0, 255, 0, 1)", ((ICssStyleRule)sheet.Rules[22]).Style["background"]);
-            Assert.AreEqual(@"#\<p\>", ((ICssStyleRule)sheet.Rules[23]).SelectorText);
-            Assert.AreEqual(@"rgba(0, 255, 0, 1)", ((ICssStyleRule)sheet.Rules[23]).Style["background"]);
-            Assert.AreEqual(@"#\<\>\<\<\<\>\>\<\>", ((ICssStyleRule)sheet.Rules[24]).SelectorText);
-            Assert.AreEqual(@"rgba(0, 255, 0, 1)", ((ICssStyleRule)sheet.Rules[24]).Style["background"]);
-            Assert.AreEqual("#\\+\\+\\+\\+\\+\\+\\+\\+\\+\\+\\[\\>\\+\\+\\+\\+\\+\\+\\+\\>\\+\\+\\+\\+\\+\\+\\+\\+\\+\\+\\>\\+\\+\\+\\>\\+\\<\\<\\<\\<-\\]\\>\\+\\+\\.\\>\\+\\.\\+\\+\\+\\+\\+\\+\\+\\.\\.\\+\\+\\+\\.\\>\\+\\+\\.\\<\\<\\+\\+\\+\\+\\+\\+\\+\\+\\+\\+\\+\\+\\+\\+\\+\\.\\>\\.\\+\\+\\+\\.------\\.--------\\.\\>\\+\\.\\>\\.", ((ICssStyleRule)sheet.Rules[25]).SelectorText);
-            Assert.AreEqual(@"rgba(0, 255, 0, 1)", ((ICssStyleRule)sheet.Rules[25]).Style["background"]);
-            Assert.AreEqual(@"#\#", ((ICssStyleRule)sheet.Rules[26]).SelectorText);
-            Assert.AreEqual(@"rgba(0, 255, 0, 1)", ((ICssStyleRule)sheet.Rules[26]).Style["background"]);
-            Assert.AreEqual(@"#\#\#", ((ICssStyleRule)sheet.Rules[27]).SelectorText);
-            Assert.AreEqual(@"rgba(0, 255, 0, 1)", ((ICssStyleRule)sheet.Rules[27]).Style["background"]);
-            Assert.AreEqual(@"#\#\.\#\.\#", ((ICssStyleRule)sheet.Rules[28]).SelectorText);
-            Assert.AreEqual(@"rgba(0, 255, 0, 1)", ((ICssStyleRule)sheet.Rules[28]).Style["background"]);
-            Assert.AreEqual(@"#_", ((ICssStyleRule)sheet.Rules[29]).SelectorText);
-            Assert.AreEqual(@"rgba(0, 255, 0, 1)", ((ICssStyleRule)sheet.Rules[29]).Style["background"]);
-            Assert.AreEqual(@"#\.fake-class", ((ICssStyleRule)sheet.Rules[30]).SelectorText);
-            Assert.AreEqual(@"rgba(0, 255, 0, 1)", ((ICssStyleRule)sheet.Rules[30]).Style["background"]);
-            Assert.AreEqual(@"#foo\.bar", ((ICssStyleRule)sheet.Rules[31]).SelectorText);
-            Assert.AreEqual(@"rgba(0, 255, 0, 1)", ((ICssStyleRule)sheet.Rules[31]).Style["background"]);
-            Assert.AreEqual(@"#\:hover", ((ICssStyleRule)sheet.Rules[32]).SelectorText);
-            Assert.AreEqual(@"rgba(0, 255, 0, 1)", ((ICssStyleRule)sheet.Rules[32]).Style["background"]);
-            Assert.AreEqual(@"#\:hover\:focus\:active", ((ICssStyleRule)sheet.Rules[33]).SelectorText);
-            Assert.AreEqual(@"rgba(0, 255, 0, 1)", ((ICssStyleRule)sheet.Rules[33]).Style["background"]);
-            Assert.AreEqual(@"#\[attr\=value\]", ((ICssStyleRule)sheet.Rules[34]).SelectorText);
-            Assert.AreEqual(@"rgba(0, 255, 0, 1)", ((ICssStyleRule)sheet.Rules[34]).Style["background"]);
-            Assert.AreEqual(@"#f\/o\/o", ((ICssStyleRule)sheet.Rules[35]).SelectorText);
-            Assert.AreEqual(@"rgba(0, 255, 0, 1)", ((ICssStyleRule)sheet.Rules[35]).Style["background"]);
-            Assert.AreEqual(@"#f\\o\\o", ((ICssStyleRule)sheet.Rules[36]).SelectorText);
-            Assert.AreEqual(@"rgba(0, 255, 0, 1)", ((ICssStyleRule)sheet.Rules[36]).Style["background"]);
-            Assert.AreEqual(@"#f\*o\*o", ((ICssStyleRule)sheet.Rules[37]).SelectorText);
-            Assert.AreEqual(@"rgba(0, 255, 0, 1)", ((ICssStyleRule)sheet.Rules[37]).Style["background"]);
-            Assert.AreEqual(@"#f\!o\!o", ((ICssStyleRule)sheet.Rules[38]).SelectorText);
-            Assert.AreEqual(@"rgba(0, 255, 0, 1)", ((ICssStyleRule)sheet.Rules[38]).Style["background"]);
-            Assert.AreEqual(@"#f\'o\'o", ((ICssStyleRule)sheet.Rules[39]).SelectorText);
-            Assert.AreEqual(@"rgba(0, 255, 0, 1)", ((ICssStyleRule)sheet.Rules[39]).Style["background"]);
-            Assert.AreEqual(@"#f\~o\~o", ((ICssStyleRule)sheet.Rules[40]).SelectorText);
-            Assert.AreEqual(@"rgba(0, 255, 0, 1)", ((ICssStyleRule)sheet.Rules[40]).Style["background"]);
-            Assert.AreEqual(@"#f\+o\+o", ((ICssStyleRule)sheet.Rules[41]).SelectorText);
-            Assert.AreEqual(@"rgba(0, 255, 0, 1)", ((ICssStyleRule)sheet.Rules[41]).Style["background"]);
+            Assert.That(((ICssStyleRule)sheet.Rules[0]).SelectorText, Is.EqualTo(@".\:\`\("));
+            Assert.That(((ICssStyleRule)sheet.Rules[1]).SelectorText, Is.EqualTo(@".\31 a2b3c"));
+            Assert.That(((ICssStyleRule)sheet.Rules[2]).SelectorText, Is.EqualTo(@"#\#fake-id"));
+            Assert.That(((ICssStyleRule)sheet.Rules[3]).SelectorText, Is.EqualTo(@"#---"));
+            Assert.That(((ICssStyleRule)sheet.Rules[4]).SelectorText, Is.EqualTo(@"#-a-b-c-"));
+            Assert.That(((ICssStyleRule)sheet.Rules[5]).SelectorText, Is.EqualTo(@"#©"));
+            Assert.That(((ICssStyleRule)sheet.Rules[6]).SelectorText, Is.EqualTo(@"html"));
+            Assert.That(((ICssStyleRule)sheet.Rules[6]).Style["font"], Is.EqualTo(@"1.2em / 1.6 Arial"));
+            Assert.That(((ICssStyleRule)sheet.Rules[7]).SelectorText, Is.EqualTo(@"code"));
+            Assert.That(((ICssStyleRule)sheet.Rules[7]).Style["font-family"], Is.EqualTo(@"Consolas"));
+            Assert.That(((ICssStyleRule)sheet.Rules[8]).SelectorText, Is.EqualTo(@"li code"));
+            Assert.That(((ICssStyleRule)sheet.Rules[8]).Style["background"], Is.EqualTo(@"rgba(255, 255, 255, 0.5)"));
+            Assert.That(((ICssStyleRule)sheet.Rules[8]).Style["padding"], Is.EqualTo(@"0.3em"));
+            Assert.That(((ICssStyleRule)sheet.Rules[9]).SelectorText, Is.EqualTo(@"li"));
+            Assert.That(((ICssStyleRule)sheet.Rules[9]).Style["background"], Is.EqualTo(@"rgba(255, 165, 0, 1)"));
+            Assert.That(((ICssStyleRule)sheet.Rules[10]).SelectorText, Is.EqualTo(@"#♥"));
+            Assert.That(((ICssStyleRule)sheet.Rules[10]).Style["background"], Is.EqualTo(@"rgba(0, 255, 0, 1)"));
+            Assert.That(((ICssStyleRule)sheet.Rules[11]).SelectorText, Is.EqualTo(@"#©"));
+            Assert.That(((ICssStyleRule)sheet.Rules[11]).Style["background"], Is.EqualTo(@"rgba(0, 255, 0, 1)"));
+            Assert.That(((ICssStyleRule)sheet.Rules[12]).SelectorText, Is.EqualTo(@"#“‘’”"));
+            Assert.That(((ICssStyleRule)sheet.Rules[12]).Style["background"], Is.EqualTo(@"rgba(0, 255, 0, 1)"));
+            Assert.That(((ICssStyleRule)sheet.Rules[13]).SelectorText, Is.EqualTo(@"#☺☃"));
+            Assert.That(((ICssStyleRule)sheet.Rules[13]).Style["background"], Is.EqualTo(@"rgba(0, 255, 0, 1)"));
+            Assert.That(((ICssStyleRule)sheet.Rules[14]).SelectorText, Is.EqualTo(@"#⌘⌥"));
+            Assert.That(((ICssStyleRule)sheet.Rules[14]).Style["background"], Is.EqualTo(@"rgba(0, 255, 0, 1)"));
+            Assert.That(((ICssStyleRule)sheet.Rules[15]).SelectorText, Is.EqualTo(@"#𝄞♪♩♫♬"));
+            Assert.That(((ICssStyleRule)sheet.Rules[15]).Style["background"], Is.EqualTo(@"rgba(0, 255, 0, 1)"));
+            Assert.That(((ICssStyleRule)sheet.Rules[16]).SelectorText, Is.EqualTo(@"#\?"));
+            Assert.That(((ICssStyleRule)sheet.Rules[16]).Style["background"], Is.EqualTo(@"rgba(0, 255, 0, 1)"));
+            Assert.That(((ICssStyleRule)sheet.Rules[17]).SelectorText, Is.EqualTo(@"#\@"));
+            Assert.That(((ICssStyleRule)sheet.Rules[17]).Style["background"], Is.EqualTo(@"rgba(0, 255, 0, 1)"));
+            Assert.That(((ICssStyleRule)sheet.Rules[18]).SelectorText, Is.EqualTo(@"#\."));
+            Assert.That(((ICssStyleRule)sheet.Rules[18]).Style["background"], Is.EqualTo(@"rgba(0, 255, 0, 1)"));
+            Assert.That(((ICssStyleRule)sheet.Rules[19]).SelectorText, Is.EqualTo(@"#\:\)"));
+            Assert.That(((ICssStyleRule)sheet.Rules[19]).Style["background"], Is.EqualTo(@"rgba(0, 255, 0, 1)"));
+            Assert.That(((ICssStyleRule)sheet.Rules[20]).SelectorText, Is.EqualTo(@"#\:\`\("));
+            Assert.That(((ICssStyleRule)sheet.Rules[20]).Style["background"], Is.EqualTo(@"rgba(0, 255, 0, 1)"));
+            Assert.That(((ICssStyleRule)sheet.Rules[21]).SelectorText, Is.EqualTo(@"#\31 23"));
+            Assert.That(((ICssStyleRule)sheet.Rules[21]).Style["background"], Is.EqualTo(@"rgba(0, 255, 0, 1)"));
+            Assert.That(((ICssStyleRule)sheet.Rules[22]).SelectorText, Is.EqualTo(@"#\31 a2b3c"));
+            Assert.That(((ICssStyleRule)sheet.Rules[22]).Style["background"], Is.EqualTo(@"rgba(0, 255, 0, 1)"));
+            Assert.That(((ICssStyleRule)sheet.Rules[23]).SelectorText, Is.EqualTo(@"#\<p\>"));
+            Assert.That(((ICssStyleRule)sheet.Rules[23]).Style["background"], Is.EqualTo(@"rgba(0, 255, 0, 1)"));
+            Assert.That(((ICssStyleRule)sheet.Rules[24]).SelectorText, Is.EqualTo(@"#\<\>\<\<\<\>\>\<\>"));
+            Assert.That(((ICssStyleRule)sheet.Rules[24]).Style["background"], Is.EqualTo(@"rgba(0, 255, 0, 1)"));
+            Assert.That(((ICssStyleRule)sheet.Rules[25]).SelectorText, Is.EqualTo("#\\+\\+\\+\\+\\+\\+\\+\\+\\+\\+\\[\\>\\+\\+\\+\\+\\+\\+\\+\\>\\+\\+\\+\\+\\+\\+\\+\\+\\+\\+\\>\\+\\+\\+\\>\\+\\<\\<\\<\\<-\\]\\>\\+\\+\\.\\>\\+\\.\\+\\+\\+\\+\\+\\+\\+\\.\\.\\+\\+\\+\\.\\>\\+\\+\\.\\<\\<\\+\\+\\+\\+\\+\\+\\+\\+\\+\\+\\+\\+\\+\\+\\+\\.\\>\\.\\+\\+\\+\\.------\\.--------\\.\\>\\+\\.\\>\\."));
+            Assert.That(((ICssStyleRule)sheet.Rules[25]).Style["background"], Is.EqualTo(@"rgba(0, 255, 0, 1)"));
+            Assert.That(((ICssStyleRule)sheet.Rules[26]).SelectorText, Is.EqualTo(@"#\#"));
+            Assert.That(((ICssStyleRule)sheet.Rules[26]).Style["background"], Is.EqualTo(@"rgba(0, 255, 0, 1)"));
+            Assert.That(((ICssStyleRule)sheet.Rules[27]).SelectorText, Is.EqualTo(@"#\#\#"));
+            Assert.That(((ICssStyleRule)sheet.Rules[27]).Style["background"], Is.EqualTo(@"rgba(0, 255, 0, 1)"));
+            Assert.That(((ICssStyleRule)sheet.Rules[28]).SelectorText, Is.EqualTo(@"#\#\.\#\.\#"));
+            Assert.That(((ICssStyleRule)sheet.Rules[28]).Style["background"], Is.EqualTo(@"rgba(0, 255, 0, 1)"));
+            Assert.That(((ICssStyleRule)sheet.Rules[29]).SelectorText, Is.EqualTo(@"#_"));
+            Assert.That(((ICssStyleRule)sheet.Rules[29]).Style["background"], Is.EqualTo(@"rgba(0, 255, 0, 1)"));
+            Assert.That(((ICssStyleRule)sheet.Rules[30]).SelectorText, Is.EqualTo(@"#\.fake-class"));
+            Assert.That(((ICssStyleRule)sheet.Rules[30]).Style["background"], Is.EqualTo(@"rgba(0, 255, 0, 1)"));
+            Assert.That(((ICssStyleRule)sheet.Rules[31]).SelectorText, Is.EqualTo(@"#foo\.bar"));
+            Assert.That(((ICssStyleRule)sheet.Rules[31]).Style["background"], Is.EqualTo(@"rgba(0, 255, 0, 1)"));
+            Assert.That(((ICssStyleRule)sheet.Rules[32]).SelectorText, Is.EqualTo(@"#\:hover"));
+            Assert.That(((ICssStyleRule)sheet.Rules[32]).Style["background"], Is.EqualTo(@"rgba(0, 255, 0, 1)"));
+            Assert.That(((ICssStyleRule)sheet.Rules[33]).SelectorText, Is.EqualTo(@"#\:hover\:focus\:active"));
+            Assert.That(((ICssStyleRule)sheet.Rules[33]).Style["background"], Is.EqualTo(@"rgba(0, 255, 0, 1)"));
+            Assert.That(((ICssStyleRule)sheet.Rules[34]).SelectorText, Is.EqualTo(@"#\[attr\=value\]"));
+            Assert.That(((ICssStyleRule)sheet.Rules[34]).Style["background"], Is.EqualTo(@"rgba(0, 255, 0, 1)"));
+            Assert.That(((ICssStyleRule)sheet.Rules[35]).SelectorText, Is.EqualTo(@"#f\/o\/o"));
+            Assert.That(((ICssStyleRule)sheet.Rules[35]).Style["background"], Is.EqualTo(@"rgba(0, 255, 0, 1)"));
+            Assert.That(((ICssStyleRule)sheet.Rules[36]).SelectorText, Is.EqualTo(@"#f\\o\\o"));
+            Assert.That(((ICssStyleRule)sheet.Rules[36]).Style["background"], Is.EqualTo(@"rgba(0, 255, 0, 1)"));
+            Assert.That(((ICssStyleRule)sheet.Rules[37]).SelectorText, Is.EqualTo(@"#f\*o\*o"));
+            Assert.That(((ICssStyleRule)sheet.Rules[37]).Style["background"], Is.EqualTo(@"rgba(0, 255, 0, 1)"));
+            Assert.That(((ICssStyleRule)sheet.Rules[38]).SelectorText, Is.EqualTo(@"#f\!o\!o"));
+            Assert.That(((ICssStyleRule)sheet.Rules[38]).Style["background"], Is.EqualTo(@"rgba(0, 255, 0, 1)"));
+            Assert.That(((ICssStyleRule)sheet.Rules[39]).SelectorText, Is.EqualTo(@"#f\'o\'o"));
+            Assert.That(((ICssStyleRule)sheet.Rules[39]).Style["background"], Is.EqualTo(@"rgba(0, 255, 0, 1)"));
+            Assert.That(((ICssStyleRule)sheet.Rules[40]).SelectorText, Is.EqualTo(@"#f\~o\~o"));
+            Assert.That(((ICssStyleRule)sheet.Rules[40]).Style["background"], Is.EqualTo(@"rgba(0, 255, 0, 1)"));
+            Assert.That(((ICssStyleRule)sheet.Rules[41]).SelectorText, Is.EqualTo(@"#f\+o\+o"));
+            Assert.That(((ICssStyleRule)sheet.Rules[41]).Style["background"], Is.EqualTo(@"rgba(0, 255, 0, 1)"));
 		}
 
 		[Test]
@@ -414,10 +414,10 @@ li{background:orange;}
 body {
   font-family: ""Bitstream Vera Serif Bold"", serif;
 }");
-			Assert.AreEqual(2, sheet.Rules.Length);
+			Assert.That(sheet.Rules.Length, Is.EqualTo(2));
 
-            Assert.AreEqual(@"body", ((ICssStyleRule)sheet.Rules[1]).SelectorText);
-            Assert.AreEqual(@"""Bitstream Vera Serif Bold"", serif", ((ICssStyleRule)sheet.Rules[1]).Style["font-family"]);
+            Assert.That(((ICssStyleRule)sheet.Rules[1]).SelectorText, Is.EqualTo(@"body"));
+            Assert.That(((ICssStyleRule)sheet.Rules[1]).Style["font-family"], Is.EqualTo(@"""Bitstream Vera Serif Bold"", serif"));
 		}
 
 		[Test]
@@ -431,10 +431,10 @@ body {
 body {
   font-family: ""Bitstream Vera Serif Bold"", serif;
 }");
-			Assert.AreEqual(2, sheet.Rules.Length);
+			Assert.That(sheet.Rules.Length, Is.EqualTo(2));
 
-            Assert.AreEqual(@"body", ((ICssStyleRule)sheet.Rules[1]).SelectorText);
-            Assert.AreEqual(@"""Bitstream Vera Serif Bold"", serif", ((ICssStyleRule)sheet.Rules[1]).Style["font-family"]);
+            Assert.That(((ICssStyleRule)sheet.Rules[1]).SelectorText, Is.EqualTo(@"body"));
+            Assert.That(((ICssStyleRule)sheet.Rules[1]).Style["font-family"], Is.EqualTo(@"""Bitstream Vera Serif Bold"", serif"));
 		}
 
 		[Test]
@@ -444,7 +444,7 @@ body {
     {
         :scope { color: white; }
     }");
-			Assert.AreEqual(1, sheet.Rules.Length);
+			Assert.That(sheet.Rules.Length, Is.EqualTo(1));
 		}
 
 		[Test]
@@ -455,7 +455,7 @@ body {
     display: block;
   }
 }");
-			Assert.AreEqual(1, sheet.Rules.Length);
+			Assert.That(sheet.Rules.Length, Is.EqualTo(1));
 		}
 
 		[Test]
@@ -465,9 +465,9 @@ body {
     url(test.css)
     screen
     ;");
-			Assert.AreEqual(1, sheet.Rules.Length);
+			Assert.That(sheet.Rules.Length, Is.EqualTo(1));
 
-            Assert.AreEqual(@"test.css", ((ICssImportRule)sheet.Rules[0]).Href);
+            Assert.That(((ICssImportRule)sheet.Rules[0]).Href, Is.EqualTo(@"test.css"));
 		}
 
 		[Test]
@@ -480,22 +480,22 @@ body {
   @import ""common.css"" screen, projection  ;
 
   @import url('landscape.css') screen and (orientation:landscape);");
-			Assert.AreEqual(5, sheet.Rules.Length);
+			Assert.That(sheet.Rules.Length, Is.EqualTo(5));
 
-            Assert.AreEqual(@"fineprint.css", ((ICssImportRule)sheet.Rules[0]).Href);
-            Assert.AreEqual(@"print", ((ICssImportRule)sheet.Rules[0]).Media.MediaText);
+            Assert.That(((ICssImportRule)sheet.Rules[0]).Href, Is.EqualTo(@"fineprint.css"));
+            Assert.That(((ICssImportRule)sheet.Rules[0]).Media.MediaText, Is.EqualTo(@"print"));
 
-            Assert.AreEqual(@"bluish.css", ((ICssImportRule)sheet.Rules[1]).Href);
-            Assert.AreEqual(@"projection, tv", ((ICssImportRule)sheet.Rules[1]).Media.MediaText);
+            Assert.That(((ICssImportRule)sheet.Rules[1]).Href, Is.EqualTo(@"bluish.css"));
+            Assert.That(((ICssImportRule)sheet.Rules[1]).Media.MediaText, Is.EqualTo(@"projection, tv"));
 
-            Assert.AreEqual(@"custom.css", ((ICssImportRule)sheet.Rules[2]).Href);
-            Assert.AreEqual(@"", ((ICssImportRule)sheet.Rules[2]).Media.MediaText);
+            Assert.That(((ICssImportRule)sheet.Rules[2]).Href, Is.EqualTo(@"custom.css"));
+            Assert.That(((ICssImportRule)sheet.Rules[2]).Media.MediaText, Is.EqualTo(@""));
 
-            Assert.AreEqual(@"common.css", ((ICssImportRule)sheet.Rules[3]).Href);
-            Assert.AreEqual(@"screen, projection", ((ICssImportRule)sheet.Rules[3]).Media.MediaText);
+            Assert.That(((ICssImportRule)sheet.Rules[3]).Href, Is.EqualTo(@"common.css"));
+            Assert.That(((ICssImportRule)sheet.Rules[3]).Media.MediaText, Is.EqualTo(@"screen, projection"));
 
-            Assert.AreEqual(@"landscape.css", ((ICssImportRule)sheet.Rules[4]).Href);
-            Assert.AreEqual(@"screen and (orientation: landscape)", ((ICssImportRule)sheet.Rules[4]).Media.MediaText);
+            Assert.That(((ICssImportRule)sheet.Rules[4]).Href, Is.EqualTo(@"landscape.css"));
+            Assert.That(((ICssImportRule)sheet.Rules[4]).Media.MediaText, Is.EqualTo(@"screen and (orientation: landscape)"));
 		}
 
 		[Test]
@@ -506,22 +506,22 @@ body {
 @import 'custom.css';
 @import ""common.css"" screen, projection;
 @import url('landscape.css') screen and (orientation:landscape);");
-			Assert.AreEqual(5, sheet.Rules.Length);
+			Assert.That(sheet.Rules.Length, Is.EqualTo(5));
 
-            Assert.AreEqual(@"fineprint.css", ((ICssImportRule)sheet.Rules[0]).Href);
-            Assert.AreEqual(@"print", ((ICssImportRule)sheet.Rules[0]).Media.MediaText);
+            Assert.That(((ICssImportRule)sheet.Rules[0]).Href, Is.EqualTo(@"fineprint.css"));
+            Assert.That(((ICssImportRule)sheet.Rules[0]).Media.MediaText, Is.EqualTo(@"print"));
 
-            Assert.AreEqual(@"bluish.css", ((ICssImportRule)sheet.Rules[1]).Href);
-            Assert.AreEqual(@"projection, tv", ((ICssImportRule)sheet.Rules[1]).Media.MediaText);
+            Assert.That(((ICssImportRule)sheet.Rules[1]).Href, Is.EqualTo(@"bluish.css"));
+            Assert.That(((ICssImportRule)sheet.Rules[1]).Media.MediaText, Is.EqualTo(@"projection, tv"));
 
-            Assert.AreEqual(@"custom.css", ((ICssImportRule)sheet.Rules[2]).Href);
-            Assert.AreEqual(@"", ((ICssImportRule)sheet.Rules[2]).Media.MediaText);
+            Assert.That(((ICssImportRule)sheet.Rules[2]).Href, Is.EqualTo(@"custom.css"));
+            Assert.That(((ICssImportRule)sheet.Rules[2]).Media.MediaText, Is.EqualTo(@""));
 
-            Assert.AreEqual(@"common.css", ((ICssImportRule)sheet.Rules[3]).Href);
-            Assert.AreEqual(@"screen, projection", ((ICssImportRule)sheet.Rules[3]).Media.MediaText);
+            Assert.That(((ICssImportRule)sheet.Rules[3]).Href, Is.EqualTo(@"common.css"));
+            Assert.That(((ICssImportRule)sheet.Rules[3]).Media.MediaText, Is.EqualTo(@"screen, projection"));
 
-            Assert.AreEqual(@"landscape.css", ((ICssImportRule)sheet.Rules[4]).Href);
-            Assert.AreEqual(@"screen and (orientation: landscape)", ((ICssImportRule)sheet.Rules[4]).Media.MediaText);
+            Assert.That(((ICssImportRule)sheet.Rules[4]).Href, Is.EqualTo(@"landscape.css"));
+            Assert.That(((ICssImportRule)sheet.Rules[4]).Media.MediaText, Is.EqualTo(@"screen and (orientation: landscape)"));
 		}
 
 		[Test]
@@ -540,7 +540,7 @@ body {
     opacity: 1;
   }
 }");
-			Assert.AreEqual(1, sheet.Rules.Length);
+			Assert.That(sheet.Rules.Length, Is.EqualTo(1));
 		}
 
 		[Test]
@@ -554,7 +554,7 @@ body {
       , 85% { left: 50px }
   100% { top: 100px; left: 100% }
 }");
-			Assert.AreEqual(1, sheet.Rules.Length);
+			Assert.That(sheet.Rules.Length, Is.EqualTo(1));
 		}
 
 		[Test]
@@ -567,7 +567,7 @@ body {
         to { opacity: 0; }
     }
 ");
-			Assert.AreEqual(1, sheet.Rules.Length);
+			Assert.That(sheet.Rules.Length, Is.EqualTo(1));
 		}
 
 		[Test]
@@ -579,7 +579,7 @@ body {
 to
   {
      opacity: 1;}}");
-			Assert.AreEqual(1, sheet.Rules.Length);
+			Assert.That(sheet.Rules.Length, Is.EqualTo(1));
 		}
 
 		[Test]
@@ -590,7 +590,7 @@ to
   to { opacity: 1 }
 }
 ");
-			Assert.AreEqual(1, sheet.Rules.Length);
+			Assert.That(sheet.Rules.Length, Is.EqualTo(1));
 		}
 
 		[Test]
@@ -609,7 +609,7 @@ to
     opacity: 1;
   }
 }");
-			Assert.AreEqual(1, sheet.Rules.Length);
+			Assert.That(sheet.Rules.Length, Is.EqualTo(1));
 		}
 
 		[Test]
@@ -623,15 +623,15 @@ to
 {
     .test { width: 100px; }
 }");
-			Assert.AreEqual(1, sheet.Rules.Length);
+			Assert.That(sheet.Rules.Length, Is.EqualTo(1));
             var rule = (ICssMediaRule)sheet.Rules[0];
 
-            Assert.AreEqual(@"(min-width: 300px)", rule.Media.MediaText);
-            Assert.AreEqual(1, rule.Rules.Length);
+            Assert.That(rule.Media.MediaText, Is.EqualTo(@"(min-width: 300px)"));
+            Assert.That(rule.Rules.Length, Is.EqualTo(1));
 
             var subrule = rule.Rules[0];
-            Assert.AreEqual(@".test", ((ICssStyleRule)subrule).SelectorText);
-            Assert.AreEqual(@"100px", ((ICssStyleRule)subrule).Style["width"]);
+            Assert.That(((ICssStyleRule)subrule).SelectorText, Is.EqualTo(@".test"));
+            Assert.That(((ICssStyleRule)subrule).Style["width"], Is.EqualTo(@"100px"));
 		}
 
 		[Test]
@@ -664,45 +664,45 @@ background: #fffef0;
               border: 0.5pt solid #666;
               }
 }");
-			Assert.AreEqual(2, sheet.Rules.Length);
+			Assert.That(sheet.Rules.Length, Is.EqualTo(2));
 
             {
                 var rule = sheet.Rules[0];
-                Assert.AreEqual(@"screen, projection", ((ICssMediaRule)rule).Media.MediaText);
-                Assert.AreEqual(2, ((ICssMediaRule)rule).Rules.Length);
+                Assert.That(((ICssMediaRule)rule).Media.MediaText, Is.EqualTo(@"screen, projection"));
+                Assert.That(((ICssMediaRule)rule).Rules.Length, Is.EqualTo(2));
 
                 {
                     var subrule = ((ICssMediaRule)rule).Rules[0];
-                    Assert.AreEqual(@"html", ((ICssStyleRule)subrule).SelectorText);
-                    Assert.AreEqual(@"rgba(255, 254, 240, 1)", ((ICssStyleRule)subrule).Style["background"]);
-                    Assert.AreEqual(@"rgba(51, 0, 0, 1)", ((ICssStyleRule)subrule).Style["color"]);
+                    Assert.That(((ICssStyleRule)subrule).SelectorText, Is.EqualTo(@"html"));
+                    Assert.That(((ICssStyleRule)subrule).Style["background"], Is.EqualTo(@"rgba(255, 254, 240, 1)"));
+                    Assert.That(((ICssStyleRule)subrule).Style["color"], Is.EqualTo(@"rgba(51, 0, 0, 1)"));
                 }
 
                 {
                     var subrule = ((ICssMediaRule)rule).Rules[1];
-                    Assert.AreEqual(@"body", ((ICssStyleRule)subrule).SelectorText);
-                    Assert.AreEqual(@"35em", ((ICssStyleRule)subrule).Style["max-width"]);
-                    Assert.AreEqual(@"0 auto", ((ICssStyleRule)subrule).Style["margin"]);
+                    Assert.That(((ICssStyleRule)subrule).SelectorText, Is.EqualTo(@"body"));
+                    Assert.That(((ICssStyleRule)subrule).Style["max-width"], Is.EqualTo(@"35em"));
+                    Assert.That(((ICssStyleRule)subrule).Style["margin"], Is.EqualTo(@"0 auto"));
                 }
             }
 
             {
                 var rule = sheet.Rules[1];
-                Assert.AreEqual(@"print", ((ICssMediaRule)rule).Media.MediaText);
-                Assert.AreEqual(2, ((ICssMediaRule)rule).Rules.Length);
+                Assert.That(((ICssMediaRule)rule).Media.MediaText, Is.EqualTo(@"print"));
+                Assert.That(((ICssMediaRule)rule).Rules.Length, Is.EqualTo(2));
 
                 {
                     var subrule = ((ICssMediaRule)rule).Rules[0];
-                    Assert.AreEqual(@"html", ((ICssStyleRule)subrule).SelectorText);
-                    Assert.AreEqual(@"rgba(255, 255, 255, 1)", ((ICssStyleRule)subrule).Style["background"]);
-                    Assert.AreEqual(@"rgba(0, 0, 0, 1)", ((ICssStyleRule)subrule).Style["color"]);
+                    Assert.That(((ICssStyleRule)subrule).SelectorText, Is.EqualTo(@"html"));
+                    Assert.That(((ICssStyleRule)subrule).Style["background"], Is.EqualTo(@"rgba(255, 255, 255, 1)"));
+                    Assert.That(((ICssStyleRule)subrule).Style["color"], Is.EqualTo(@"rgba(0, 0, 0, 1)"));
                 }
 
                 {
                     var subrule = ((ICssMediaRule)rule).Rules[1];
-                    Assert.AreEqual(@"body", ((ICssStyleRule)subrule).SelectorText);
-                    Assert.AreEqual(@"1in", ((ICssStyleRule)subrule).Style["padding"]);
-                    Assert.AreEqual(@"0.5pt solid rgba(102, 102, 102, 1)", ((ICssStyleRule)subrule).Style["border"]);
+                    Assert.That(((ICssStyleRule)subrule).SelectorText, Is.EqualTo(@"body"));
+                    Assert.That(((ICssStyleRule)subrule).Style["padding"], Is.EqualTo(@"1in"));
+                    Assert.That(((ICssStyleRule)subrule).Style["border"], Is.EqualTo(@"0.5pt solid rgba(102, 102, 102, 1)"));
                 }
             }
 		}
@@ -736,29 +736,29 @@ background: #fffef0;
     border: 0.5pt solid #666;
   }
 }");
-			Assert.AreEqual(2, sheet.Rules.Length);
+			Assert.That(sheet.Rules.Length, Is.EqualTo(2));
 
-            Assert.AreEqual(@"screen, projection", ((ICssMediaRule)sheet.Rules[0]).Media.MediaText);
-            Assert.AreEqual(2, ((ICssMediaRule)sheet.Rules[0]).Rules.Length);
+            Assert.That(((ICssMediaRule)sheet.Rules[0]).Media.MediaText, Is.EqualTo(@"screen, projection"));
+            Assert.That(((ICssMediaRule)sheet.Rules[0]).Rules.Length, Is.EqualTo(2));
 
-            Assert.AreEqual(@"html", ((ICssStyleRule)((ICssMediaRule)sheet.Rules[0]).Rules[0]).SelectorText);
-            Assert.AreEqual(@"rgba(255, 254, 240, 1)", ((ICssStyleRule)((ICssMediaRule)sheet.Rules[0]).Rules[0]).Style["background"]);
-            Assert.AreEqual(@"rgba(51, 0, 0, 1)", ((ICssStyleRule)((ICssMediaRule)sheet.Rules[0]).Rules[0]).Style["color"]);
+            Assert.That(((ICssStyleRule)((ICssMediaRule)sheet.Rules[0]).Rules[0]).SelectorText, Is.EqualTo(@"html"));
+            Assert.That(((ICssStyleRule)((ICssMediaRule)sheet.Rules[0]).Rules[0]).Style["background"], Is.EqualTo(@"rgba(255, 254, 240, 1)"));
+            Assert.That(((ICssStyleRule)((ICssMediaRule)sheet.Rules[0]).Rules[0]).Style["color"], Is.EqualTo(@"rgba(51, 0, 0, 1)"));
 
-            Assert.AreEqual(@"body", ((ICssStyleRule)((ICssMediaRule)sheet.Rules[0]).Rules[1]).SelectorText);
-            Assert.AreEqual(@"35em", ((ICssStyleRule)((ICssMediaRule)sheet.Rules[0]).Rules[1]).Style["max-width"]);
-            Assert.AreEqual(@"0 auto", ((ICssStyleRule)((ICssMediaRule)sheet.Rules[0]).Rules[1]).Style["margin"]);
+            Assert.That(((ICssStyleRule)((ICssMediaRule)sheet.Rules[0]).Rules[1]).SelectorText, Is.EqualTo(@"body"));
+            Assert.That(((ICssStyleRule)((ICssMediaRule)sheet.Rules[0]).Rules[1]).Style["max-width"], Is.EqualTo(@"35em"));
+            Assert.That(((ICssStyleRule)((ICssMediaRule)sheet.Rules[0]).Rules[1]).Style["margin"], Is.EqualTo(@"0 auto"));
 
-            Assert.AreEqual(@"print", ((ICssMediaRule)sheet.Rules[1]).Media.MediaText);
-			Assert.AreEqual(2, ((ICssMediaRule)sheet.Rules[1]).Rules.Length);
+            Assert.That(((ICssMediaRule)sheet.Rules[1]).Media.MediaText, Is.EqualTo(@"print"));
+			Assert.That(((ICssMediaRule)sheet.Rules[1]).Rules.Length, Is.EqualTo(2));
 
-            Assert.AreEqual(@"html", ((ICssStyleRule)((ICssMediaRule)sheet.Rules[1]).Rules[0]).SelectorText);
-            Assert.AreEqual(@"rgba(255, 255, 255, 1)", ((ICssStyleRule)((ICssMediaRule)sheet.Rules[1]).Rules[0]).Style["background"]);
-            Assert.AreEqual(@"rgba(0, 0, 0, 1)", ((ICssStyleRule)((ICssMediaRule)sheet.Rules[1]).Rules[0]).Style["color"]);
+            Assert.That(((ICssStyleRule)((ICssMediaRule)sheet.Rules[1]).Rules[0]).SelectorText, Is.EqualTo(@"html"));
+            Assert.That(((ICssStyleRule)((ICssMediaRule)sheet.Rules[1]).Rules[0]).Style["background"], Is.EqualTo(@"rgba(255, 255, 255, 1)"));
+            Assert.That(((ICssStyleRule)((ICssMediaRule)sheet.Rules[1]).Rules[0]).Style["color"], Is.EqualTo(@"rgba(0, 0, 0, 1)"));
 
-            Assert.AreEqual(@"body", ((ICssStyleRule)((ICssMediaRule)sheet.Rules[1]).Rules[1]).SelectorText);
-            Assert.AreEqual(@"1in", ((ICssStyleRule)((ICssMediaRule)sheet.Rules[1]).Rules[1]).Style["padding"]);
-            Assert.AreEqual(@"0.5pt solid rgba(102, 102, 102, 1)", ((ICssStyleRule)((ICssMediaRule)sheet.Rules[1]).Rules[1]).Style["border"]);
+            Assert.That(((ICssStyleRule)((ICssMediaRule)sheet.Rules[1]).Rules[1]).SelectorText, Is.EqualTo(@"body"));
+            Assert.That(((ICssStyleRule)((ICssMediaRule)sheet.Rules[1]).Rules[1]).Style["padding"], Is.EqualTo(@"1in"));
+            Assert.That(((ICssStyleRule)((ICssMediaRule)sheet.Rules[1]).Rules[1]).Style["border"], Is.EqualTo(@"0.5pt solid rgba(102, 102, 102, 1)"));
 		}
 
 		[Test]
@@ -780,18 +780,18 @@ background: #fffef0;
      baz
      }
 ");
-			Assert.AreEqual(3, sheet.Rules.Length);
+			Assert.That(sheet.Rules.Length, Is.EqualTo(3));
 
-            Assert.AreEqual(@"body", ((ICssStyleRule)sheet.Rules[0]).SelectorText);
-            Assert.AreEqual(@"'bar'", ((ICssStyleRule)sheet.Rules[0]).Style["foo"]);
+            Assert.That(((ICssStyleRule)sheet.Rules[0]).SelectorText, Is.EqualTo(@"body"));
+            Assert.That(((ICssStyleRule)sheet.Rules[0]).Style["foo"], Is.EqualTo(@"'bar'"));
 
-            Assert.AreEqual(@"body", ((ICssStyleRule)sheet.Rules[1]).SelectorText);
-            Assert.AreEqual(@"bar", ((ICssStyleRule)sheet.Rules[1]).Style["foo"]);
-            Assert.AreEqual(@"baz", ((ICssStyleRule)sheet.Rules[1]).Style["bar"]);
+            Assert.That(((ICssStyleRule)sheet.Rules[1]).SelectorText, Is.EqualTo(@"body"));
+            Assert.That(((ICssStyleRule)sheet.Rules[1]).Style["foo"], Is.EqualTo(@"bar"));
+            Assert.That(((ICssStyleRule)sheet.Rules[1]).Style["bar"], Is.EqualTo(@"baz"));
 
-            Assert.AreEqual(@"body", ((ICssStyleRule)sheet.Rules[2]).SelectorText);
-            Assert.AreEqual(@"bar", ((ICssStyleRule)sheet.Rules[2]).Style["foo"]);
-            Assert.AreEqual(@"baz", ((ICssStyleRule)sheet.Rules[2]).Style["bar"]);
+            Assert.That(((ICssStyleRule)sheet.Rules[2]).SelectorText, Is.EqualTo(@"body"));
+            Assert.That(((ICssStyleRule)sheet.Rules[2]).Style["foo"], Is.EqualTo(@"bar"));
+            Assert.That(((ICssStyleRule)sheet.Rules[2]).Style["bar"], Is.EqualTo(@"baz"));
 		}
 
 		[Test]
@@ -800,7 +800,7 @@ background: #fffef0;
 			var sheet = ParseSheet(@"@namespace
     ""http://www.w3.org/1999/xhtml""
     ;");
-			Assert.AreEqual(1, sheet.Rules.Length);
+			Assert.That(sheet.Rules.Length, Is.EqualTo(1));
 		}
 
 		[Test]
@@ -808,7 +808,7 @@ background: #fffef0;
 		{
 			var sheet = ParseSheet(@"@namespace ""http://www.w3.org/1999/xhtml"";
 @namespace svg ""http://www.w3.org/2000/svg"";");
-			Assert.AreEqual(2, sheet.Rules.Length);
+			Assert.That(sheet.Rules.Length, Is.EqualTo(2));
 		}
 
 		[Test]
@@ -819,13 +819,13 @@ tobi loki jane {
   are: 'all';
   the-species: called ""ferrets""
 }");
-			Assert.AreEqual(1, sheet.Rules.Length);
+			Assert.That(sheet.Rules.Length, Is.EqualTo(1));
 
 			foreach (var rule in sheet.Rules)
 			{
-				Assert.AreEqual(@"tobi loki jane", ((ICssStyleRule)rule).SelectorText);
-				Assert.AreEqual(@"'all'", ((ICssStyleRule)rule).Style["are"]);
-				Assert.AreEqual(@"called ""ferrets""", ((ICssStyleRule)rule).Style["the-species"]);
+				Assert.That(((ICssStyleRule)rule).SelectorText, Is.EqualTo(@"tobi loki jane"));
+				Assert.That(((ICssStyleRule)rule).Style["are"], Is.EqualTo(@"'all'"));
+				Assert.That(((ICssStyleRule)rule).Style["the-species"], Is.EqualTo(@"called ""ferrets"""));
 			}
 		}
 
@@ -837,7 +837,7 @@ tobi loki jane {
     {
         color: black;
     }");
-			Assert.AreEqual(1, sheet.Rules.Length);
+			Assert.That(sheet.Rules.Length, Is.EqualTo(1));
 		}
 
 		[Test]
@@ -857,21 +857,21 @@ tobi loki jane {
 @page :left {
   margin-left: 5cm;
 }");
-			Assert.AreEqual(3, sheet.Rules.Length);
+			Assert.That(sheet.Rules.Length, Is.EqualTo(3));
 
             var page1 = sheet.Rules[0] as ICssPageRule;
             var page2 = sheet.Rules[1] as ICssPageRule;
             var page3 = sheet.Rules[2] as ICssPageRule;
 
-            Assert.AreEqual(1, page1.Style.Length);
-            Assert.AreEqual("rgba(0, 128, 0, 1)", page1.Style["color"]);
+            Assert.That(page1.Style.Length, Is.EqualTo(1));
+            Assert.That(page1.Style["color"], Is.EqualTo("rgba(0, 128, 0, 1)"));
 
-            Assert.AreEqual(2, page2.Style.Length);
-            Assert.AreEqual("16pt", page2.Style["font-size"]);
-            Assert.AreEqual("rgba(255, 0, 0, 1)", page2.Style["color"]);
+            Assert.That(page2.Style.Length, Is.EqualTo(2));
+            Assert.That(page2.Style["font-size"], Is.EqualTo("16pt"));
+            Assert.That(page2.Style["color"], Is.EqualTo("rgba(255, 0, 0, 1)"));
 
-            Assert.AreEqual(1, page3.Style.Length);
-            Assert.AreEqual("5cm", page3.Style["margin-left"]);
+            Assert.That(page3.Style.Length, Is.EqualTo(1));
+            Assert.That(page3.Style["margin-left"], Is.EqualTo("5cm"));
 		}
 
 		[Test]
@@ -883,12 +883,12 @@ tobi loki jane {
   the-species: called ""ferrets"";
   *even: 'ie crap';
 }");
-			Assert.AreEqual(1, sheet.Rules.Length);
+			Assert.That(sheet.Rules.Length, Is.EqualTo(1));
 
-            Assert.AreEqual(@"tobi loki jane", ((ICssStyleRule)sheet.Rules[0]).SelectorText);
-            Assert.AreEqual(@"'all'", ((ICssStyleRule)sheet.Rules[0]).Style["are"]);
-            Assert.AreEqual(@"called ""ferrets""", ((ICssStyleRule)sheet.Rules[0]).Style["the-species"]);
-            Assert.AreEqual(@"'ie crap'", ((ICssStyleRule)sheet.Rules[0]).Style["*even"]);
+            Assert.That(((ICssStyleRule)sheet.Rules[0]).SelectorText, Is.EqualTo(@"tobi loki jane"));
+            Assert.That(((ICssStyleRule)sheet.Rules[0]).Style["are"], Is.EqualTo(@"'all'"));
+            Assert.That(((ICssStyleRule)sheet.Rules[0]).Style["the-species"], Is.EqualTo(@"called ""ferrets"""));
+            Assert.That(((ICssStyleRule)sheet.Rules[0]).Style["*even"], Is.EqualTo(@"'ie crap'"));
 		}
 
 		[Test]
@@ -896,10 +896,10 @@ tobi loki jane {
 		{
 			var sheet = ParseSheet(@"p[qwe=""a\"",b""] { color: red }
 ");
-			Assert.AreEqual(1, sheet.Rules.Length);
+			Assert.That(sheet.Rules.Length, Is.EqualTo(1));
 
-            Assert.AreEqual(@"p[qwe=""a\"",b""]", ((ICssStyleRule)sheet.Rules[0]).SelectorText);
-            Assert.AreEqual(@"rgba(255, 0, 0, 1)", ((ICssStyleRule)sheet.Rules[0]).Style["color"]);
+            Assert.That(((ICssStyleRule)sheet.Rules[0]).SelectorText, Is.EqualTo(@"p[qwe=""a\"",b""]"));
+            Assert.That(((ICssStyleRule)sheet.Rules[0]).Style["color"], Is.EqualTo(@"rgba(255, 0, 0, 1)"));
 		}
 
 		[Test]
@@ -908,10 +908,10 @@ tobi loki jane {
 			var sheet = ParseSheet(@"body {
   background: url('some;stuff;here') 50% 50% no-repeat;
 }");
-			Assert.AreEqual(1, sheet.Rules.Length);
+			Assert.That(sheet.Rules.Length, Is.EqualTo(1));
 
-            Assert.AreEqual(@"body", ((ICssStyleRule)sheet.Rules[0]).SelectorText);
-            Assert.AreEqual(@"url(""some;stuff;here"") center no-repeat", ((ICssStyleRule)sheet.Rules[0]).Style["background"]);
+            Assert.That(((ICssStyleRule)sheet.Rules[0]).SelectorText, Is.EqualTo(@"body"));
+            Assert.That(((ICssStyleRule)sheet.Rules[0]).Style["background"], Is.EqualTo(@"url(""some;stuff;here"") center no-repeat"));
 		}
 
 		[Test]
@@ -920,10 +920,10 @@ tobi loki jane {
 			var sheet = ParseSheet(@"foo {
   bar: 'baz';
 }");
-			Assert.AreEqual(1, sheet.Rules.Length);
+			Assert.That(sheet.Rules.Length, Is.EqualTo(1));
 
-            Assert.AreEqual(@"foo", ((ICssStyleRule)sheet.Rules[0]).SelectorText);
-            Assert.AreEqual(@"'baz'", ((ICssStyleRule)sheet.Rules[0]).Style["bar"]);
+            Assert.That(((ICssStyleRule)sheet.Rules[0]).SelectorText, Is.EqualTo(@"foo"));
+            Assert.That(((ICssStyleRule)sheet.Rules[0]).Style["bar"], Is.EqualTo(@"'baz'"));
 		}
 
 		[Test]
@@ -938,15 +938,15 @@ loki {
   name: 'loki';
   age: 1;
 }");
-			Assert.AreEqual(2, sheet.Rules.Length);
+			Assert.That(sheet.Rules.Length, Is.EqualTo(2));
 
-            Assert.AreEqual(@"tobi", ((ICssStyleRule)sheet.Rules[0]).SelectorText);
-            Assert.AreEqual(@"'tobi'", ((ICssStyleRule)sheet.Rules[0]).Style["name"]);
-            Assert.AreEqual(@"2", ((ICssStyleRule)sheet.Rules[0]).Style["age"]);
+            Assert.That(((ICssStyleRule)sheet.Rules[0]).SelectorText, Is.EqualTo(@"tobi"));
+            Assert.That(((ICssStyleRule)sheet.Rules[0]).Style["name"], Is.EqualTo(@"'tobi'"));
+            Assert.That(((ICssStyleRule)sheet.Rules[0]).Style["age"], Is.EqualTo(@"2"));
 
-            Assert.AreEqual(@"loki", ((ICssStyleRule)sheet.Rules[1]).SelectorText);
-            Assert.AreEqual(@"'loki'", ((ICssStyleRule)sheet.Rules[1]).Style["name"]);
-            Assert.AreEqual(@"1", ((ICssStyleRule)sheet.Rules[1]).Style["age"]);
+            Assert.That(((ICssStyleRule)sheet.Rules[1]).SelectorText, Is.EqualTo(@"loki"));
+            Assert.That(((ICssStyleRule)sheet.Rules[1]).Style["name"], Is.EqualTo(@"'loki'"));
+            Assert.That(((ICssStyleRule)sheet.Rules[1]).Style["age"], Is.EqualTo(@"1"));
 		}
 
 		[Test]
@@ -957,10 +957,10 @@ bar,
 baz {
   color: black;
 }");
-			Assert.AreEqual(1, sheet.Rules.Length);
+			Assert.That(sheet.Rules.Length, Is.EqualTo(1));
 
-            Assert.AreEqual(@"foo, bar, baz", ((ICssStyleRule)sheet.Rules[0]).SelectorText);
-            Assert.AreEqual(@"rgba(0, 0, 0, 1)", ((ICssStyleRule)sheet.Rules[0]).Style["color"]);
+            Assert.That(((ICssStyleRule)sheet.Rules[0]).SelectorText, Is.EqualTo(@"foo, bar, baz"));
+            Assert.That(((ICssStyleRule)sheet.Rules[0]).Style["color"], Is.EqualTo(@"rgba(0, 0, 0, 1)"));
 		}
 
 		[Test]
@@ -971,7 +971,7 @@ baz {
     {
         .test { display: flex; }
     }");
-			Assert.AreEqual(1, sheet.Rules.Length);
+			Assert.That(sheet.Rules.Length, Is.EqualTo(1));
 		}
 
 		[Test]
@@ -989,7 +989,7 @@ baz {
     something: else;
   }
 }");
-			Assert.AreEqual(1, sheet.Rules.Length);
+			Assert.That(sheet.Rules.Length, Is.EqualTo(1));
 		}
 
 		[Test]
@@ -1000,14 +1000,14 @@ baz {
   //max-height: 110px;
   #height: 18px;
 }");
-			Assert.AreEqual(1, sheet.Rules.Length);
+			Assert.That(sheet.Rules.Length, Is.EqualTo(1));
 
 			foreach (var rule in sheet.Rules)
 			{
-				Assert.AreEqual(@".wtf", ((ICssStyleRule)rule).SelectorText);
-				Assert.AreEqual(@"hidden", ((ICssStyleRule)rule).Style["*overflow-x"]);
-				Assert.AreEqual(@"110px", ((ICssStyleRule)rule).Style["//max-height"]);
-				Assert.AreEqual(@"18px", ((ICssStyleRule)rule).Style["#height"]);
+				Assert.That(((ICssStyleRule)rule).SelectorText, Is.EqualTo(@".wtf"));
+				Assert.That(((ICssStyleRule)rule).Style["*overflow-x"], Is.EqualTo(@"hidden"));
+				Assert.That(((ICssStyleRule)rule).Style["//max-height"], Is.EqualTo(@"110px"));
+				Assert.That(((ICssStyleRule)rule).Style["#height"], Is.EqualTo(@"18px"));
 			}
 		}
 
@@ -1016,24 +1016,24 @@ baz {
         {
             var sheet = ParseSheet(@"h1 { background-color: \000062
 lack; }");
-            Assert.AreEqual(@"rgba(0, 0, 0, 1)", ((ICssStyleRule)sheet.Rules[0]).Style["background-color"]);
+            Assert.That(((ICssStyleRule)sheet.Rules[0]).Style["background-color"], Is.EqualTo(@"rgba(0, 0, 0, 1)"));
         }
 
         [Test]
         public void StyleSheetUnicodeEscapeVarious()
         {
             var sheet = ParseSheet("h1 { background-color: \\000062\r\nlack; color: \\000062\tlack; border-color: \\000062\nlack; outline-color: \\000062 lack }");
-            Assert.AreEqual(@"rgba(0, 0, 0, 1)", ((ICssStyleRule)sheet.Rules[0]).Style["background-color"]);
-            Assert.AreEqual(@"rgba(0, 0, 0, 1)", ((ICssStyleRule)sheet.Rules[0]).Style["color"]);
-            Assert.AreEqual(@"rgba(0, 0, 0, 1)", ((ICssStyleRule)sheet.Rules[0]).Style["border-color"]);
-            Assert.AreEqual(@"rgba(0, 0, 0, 1)", ((ICssStyleRule)sheet.Rules[0]).Style["outline-color"]);
+            Assert.That(((ICssStyleRule)sheet.Rules[0]).Style["background-color"], Is.EqualTo(@"rgba(0, 0, 0, 1)"));
+            Assert.That(((ICssStyleRule)sheet.Rules[0]).Style["color"], Is.EqualTo(@"rgba(0, 0, 0, 1)"));
+            Assert.That(((ICssStyleRule)sheet.Rules[0]).Style["border-color"], Is.EqualTo(@"rgba(0, 0, 0, 1)"));
+            Assert.That(((ICssStyleRule)sheet.Rules[0]).Style["outline-color"], Is.EqualTo(@"rgba(0, 0, 0, 1)"));
         }
 
         [Test]
         public void StyleSheetUnicodeEscapeLeadingSingleCarriageReturn()
         {
             var sheet = ParseSheet("h1 { background-image: \\000075\r\nrl('foo') }");
-            Assert.AreEqual("url(\"foo\")", ((ICssStyleRule)sheet.Rules[0]).Style["background-image"]);
+            Assert.That(((ICssStyleRule)sheet.Rules[0]).Style["background-image"], Is.EqualTo("url(\"foo\")"));
         }
     }
 }

--- a/src/AngleSharp.Css.Tests/Styling/CssSheet.cs
+++ b/src/AngleSharp.Css.Tests/Styling/CssSheet.cs
@@ -19,12 +19,12 @@ namespace AngleSharp.Css.Tests.Styling
 h1 {
  color: red;
  font-weight: bold");
-            Assert.AreEqual(1, sheet.Rules.Length);
+            Assert.That(sheet.Rules.Length, Is.EqualTo(1));
             Assert.IsInstanceOf<CssStyleRule>(sheet.Rules[0]);
             var h1 = sheet.Rules[0] as ICssStyleRule;
-            Assert.AreEqual("h1", h1.SelectorText);
-            Assert.AreEqual("rgba(255, 0, 0, 1)", h1.Style.GetColor());
-            Assert.AreEqual("bold", h1.Style.GetFontWeight());
+            Assert.That(h1.SelectorText, Is.EqualTo("h1"));
+            Assert.That(h1.Style.GetColor(), Is.EqualTo("rgba(255, 0, 0, 1)"));
+            Assert.That(h1.Style.GetFontWeight(), Is.EqualTo("bold"));
         }
 
         [Test]
@@ -38,10 +38,10 @@ h1 {
             .dis2 { display: block; }
             ");
             var css = sheet.ToCss();
-            Assert.AreEqual(3, sheet.Rules.Length);
-            Assert.AreEqual(".dis-none { display: none }", sheet.Rules[0].CssText);
-            Assert.AreEqual(".dis { display: block }", sheet.Rules[1].CssText);
-            Assert.AreEqual(".dis2 { display: block }", sheet.Rules[2].CssText);
+            Assert.That(sheet.Rules.Length, Is.EqualTo(3));
+            Assert.That(sheet.Rules[0].CssText, Is.EqualTo(".dis-none { display: none }"));
+            Assert.That(sheet.Rules[1].CssText, Is.EqualTo(".dis { display: block }"));
+            Assert.That(sheet.Rules[2].CssText, Is.EqualTo(".dis2 { display: block }"));
         }
 
         [Test]
@@ -53,9 +53,9 @@ h1 {
             .dis { display: block; }
             ");
             var css = sheet.ToCss();
-            Assert.AreEqual(2, sheet.Rules.Length);
-            Assert.AreEqual(".dis-none { display: none }", sheet.Rules[0].CssText);
-            Assert.AreEqual(".dis { display: block }", sheet.Rules[1].CssText);
+            Assert.That(sheet.Rules.Length, Is.EqualTo(2));
+            Assert.That(sheet.Rules[0].CssText, Is.EqualTo(".dis-none { display: none }"));
+            Assert.That(sheet.Rules[1].CssText, Is.EqualTo(".dis { display: block }"));
         }
 
         [Test]
@@ -65,7 +65,7 @@ h1 {
             var expected = ".T1 { list-style: none }";
             var stylesheet = ParseStyleSheet(cssSrc);
             var cssText = stylesheet.ToCss();
-            Assert.AreEqual(expected, cssText);
+            Assert.That(cssText, Is.EqualTo(expected));
         }
 
         [Test]
@@ -75,7 +75,7 @@ h1 {
             var expected = ".T2 { border: 1px outset }";
             var stylesheet = ParseStyleSheet(cssSrc);
             var cssText = stylesheet.ToCss();
-            Assert.AreEqual(expected, cssText);
+            Assert.That(cssText, Is.EqualTo(expected));
         }
 
         [Test]
@@ -85,7 +85,7 @@ h1 {
             var expected = "#rule1 { border-top: none; border-right: 1px solid rgba(187, 204, 235, 1); border-bottom: 1px solid rgba(187, 204, 235, 1); border-left: 1px solid rgba(187, 204, 235, 1) }";
             var stylesheet = ParseStyleSheet(cssSrc);
             var cssText = stylesheet.ToCss();
-            Assert.AreEqual(expected, cssText);
+            Assert.That(cssText, Is.EqualTo(expected));
         }
 
         [Test]
@@ -95,7 +95,7 @@ h1 {
             var expected = "#rule2 { background: url(\"/_static/img/bx_tile.gif\") left top repeat-x }";
             var stylesheet = ParseStyleSheet(cssSrc);
             var cssText = stylesheet.ToCss();
-            Assert.AreEqual(expected, cssText);
+            Assert.That(cssText, Is.EqualTo(expected));
         }
 
         [Test]
@@ -113,10 +113,10 @@ h1 {
   background: linear-gradient(red, green);
 }";
             var stylesheet = ParseStyleSheet(css);
-            Assert.AreEqual(1, stylesheet.Rules.Length);
+            Assert.That(stylesheet.Rules.Length, Is.EqualTo(1));
             var style = stylesheet.Rules[0] as ICssStyleRule;
             Assert.IsNotNull(style);
-            Assert.AreEqual(15, style.Style.Length);
+            Assert.That(style.Style.Length, Is.EqualTo(15));
         }
 
         [Test]
@@ -124,10 +124,10 @@ h1 {
         {
             var css = @"html { font-family: sans-serif }";
             var stylesheet = ParseStyleSheet(css);
-            Assert.AreEqual(1, stylesheet.Rules.Length);
+            Assert.That(stylesheet.Rules.Length, Is.EqualTo(1));
             var rule = stylesheet.Rules[0];
             Assert.IsInstanceOf<CssStyleRule>(rule);
-            Assert.AreEqual(css, rule.CssText);
+            Assert.That(rule.CssText, Is.EqualTo(css));
         }
 
         [Test]
@@ -139,14 +139,14 @@ h1 {
         color: red;
         color: green;
       }");
-            Assert.AreEqual(1, sheet.Rules.Length);
+            Assert.That(sheet.Rules.Length, Is.EqualTo(1));
             Assert.IsInstanceOf<CssStyleRule>(sheet.Rules[0]);
             var p = sheet.Rules[0] as ICssStyleRule;
-            Assert.AreEqual(1, p.Style.Length);
-            Assert.AreEqual("p", p.SelectorText);
-            Assert.AreEqual("color", p.Style[0]);
-            Assert.AreEqual("rgba(0, 128, 0, 1)", p.Style.GetColor());
-            Assert.AreEqual("", p.Style.GetFontFamily());
+            Assert.That(p.Style.Length, Is.EqualTo(1));
+            Assert.That(p.SelectorText, Is.EqualTo("p"));
+            Assert.That(p.Style[0], Is.EqualTo("color"));
+            Assert.That(p.Style.GetColor(), Is.EqualTo("rgba(0, 128, 0, 1)"));
+            Assert.That(p.Style.GetFontFamily(), Is.EqualTo(""));
         }
 
         [Test]
@@ -155,11 +155,11 @@ h1 {
             var sheet = ParseStyleSheet(@"
 #something {
  content: 'hi there");
-            Assert.AreEqual(1, sheet.Rules.Length);
+            Assert.That(sheet.Rules.Length, Is.EqualTo(1));
             Assert.IsInstanceOf<CssStyleRule>(sheet.Rules[0]);
             var id = sheet.Rules[0] as ICssStyleRule;
-            Assert.AreEqual("#something", id.SelectorText);
-            Assert.AreEqual("\"hi there\"", id.Style.GetContent());
+            Assert.That(id.SelectorText, Is.EqualTo("#something"));
+            Assert.That(id.Style.GetContent(), Is.EqualTo("\"hi there\""));
         }
 
         [Test]
@@ -167,28 +167,28 @@ h1 {
         {
             var sheet = ParseStyleSheet(@"  @media screen {
     p:before { content: 'Hello");
-            Assert.AreEqual(1, sheet.Rules.Length);
+            Assert.That(sheet.Rules.Length, Is.EqualTo(1));
             Assert.IsInstanceOf<CssMediaRule>(sheet.Rules[0]);
             var media = sheet.Rules[0] as CssMediaRule;
-            Assert.AreEqual("screen", media.Media.MediaText);
-            Assert.AreEqual(1, media.Rules.Length);
+            Assert.That(media.Media.MediaText, Is.EqualTo("screen"));
+            Assert.That(media.Rules.Length, Is.EqualTo(1));
             Assert.IsInstanceOf<CssStyleRule>(media.Rules[0]);
             var p = media.Rules[0] as ICssStyleRule;
-            Assert.AreEqual("p:before", p.SelectorText);
-            Assert.AreEqual("\"Hello\"", p.Style.GetContent());
+            Assert.That(p.SelectorText, Is.EqualTo("p:before"));
+            Assert.That(p.Style.GetContent(), Is.EqualTo("\"Hello\""));
         }
 
         [Test]
         public void CssSheetDoIgnoreUnknownPropertyByDefault()
         {
             var sheet = ParseStyleSheet(@"h1 { color: red; rotation: 70minutes }");
-            Assert.AreEqual(1, sheet.Rules.Length);
+            Assert.That(sheet.Rules.Length, Is.EqualTo(1));
             Assert.IsInstanceOf<CssStyleRule>(sheet.Rules[0]);
             var h1 = sheet.Rules[0] as ICssStyleRule;
-            Assert.AreEqual("h1", h1.SelectorText);
-            Assert.AreEqual(1, h1.Style.Length);
-            Assert.AreEqual("color", h1.Style[0]);
-            Assert.AreEqual("rgba(255, 0, 0, 1)", h1.Style.GetColor());
+            Assert.That(h1.SelectorText, Is.EqualTo("h1"));
+            Assert.That(h1.Style.Length, Is.EqualTo(1));
+            Assert.That(h1.Style[0], Is.EqualTo("color"));
+            Assert.That(h1.Style.GetColor(), Is.EqualTo("rgba(255, 0, 0, 1)"));
         }
 
         [Test]
@@ -198,36 +198,36 @@ h1 {
             {
                 IsIncludingUnknownDeclarations = true,
             });
-            Assert.AreEqual(1, sheet.Rules.Length);
+            Assert.That(sheet.Rules.Length, Is.EqualTo(1));
             Assert.IsInstanceOf<CssStyleRule>(sheet.Rules[0]);
             var h1 = sheet.Rules[0] as ICssStyleRule;
-            Assert.AreEqual("h1", h1.SelectorText);
-            Assert.AreEqual(2, h1.Style.Length);
-            Assert.AreEqual("color", h1.Style[0]);
-            Assert.AreEqual("rgba(255, 0, 0, 1)", h1.Style.GetColor());
-            Assert.AreEqual("rotation", h1.Style[1]);
+            Assert.That(h1.SelectorText, Is.EqualTo("h1"));
+            Assert.That(h1.Style.Length, Is.EqualTo(2));
+            Assert.That(h1.Style[0], Is.EqualTo("color"));
+            Assert.That(h1.Style.GetColor(), Is.EqualTo("rgba(255, 0, 0, 1)"));
+            Assert.That(h1.Style[1], Is.EqualTo("rotation"));
         }
 
         [Test]
         public void CssSheetInvalidStatementRulesetUnexpectedAtKeyword()
         {
             var sheet = ParseStyleSheet(@"p @here {color: red}");
-            Assert.AreEqual(1, sheet.Rules.Length);
-            Assert.AreEqual(null, (sheet.Rules[0] as ICssStyleRule).SelectorText);
+            Assert.That(sheet.Rules.Length, Is.EqualTo(1));
+            Assert.That((sheet.Rules[0] as ICssStyleRule).SelectorText, Is.EqualTo(null));
         }
 
         [Test]
         public void CssSheetInvalidStatementAtRuleUnexpectedAtKeyword()
         {
             var sheet = ParseStyleSheet(@"@foo @bar;");
-            Assert.AreEqual(0, sheet.Rules.Length);
+            Assert.That(sheet.Rules.Length, Is.EqualTo(0));
         }
 
         [Test]
         public void CssSheetInvalidStatementRulesetUnexpectedRightBrace()
         {
             var sheet = ParseStyleSheet(@"}} {{ - }}");
-            Assert.AreEqual(0, sheet.Rules.Length);
+            Assert.That(sheet.Rules.Length, Is.EqualTo(0));
         }
 
         [Test]
@@ -235,31 +235,31 @@ h1 {
         {
             var sheet = ParseStyleSheet(@"}} {{ - }}
 #hi { color: green; }");
-            Assert.AreEqual(1, sheet.Rules.Length);
+            Assert.That(sheet.Rules.Length, Is.EqualTo(1));
             var style = sheet.Rules[0] as ICssStyleRule;
             Assert.NotNull(style);
-            Assert.AreEqual("#hi", style.SelectorText);
-            Assert.AreEqual(1, style.Style.Length);
-            Assert.AreEqual("rgba(0, 128, 0, 1)", style.Style.GetColor());
+            Assert.That(style.SelectorText, Is.EqualTo("#hi"));
+            Assert.That(style.Style.Length, Is.EqualTo(1));
+            Assert.That(style.Style.GetColor(), Is.EqualTo("rgba(0, 128, 0, 1)"));
         }
 
         [Test]
         public void CssSheetInvalidStatementRulesetUnexpectedRightParenthesis()
         {
             var sheet = ParseStyleSheet(@") ( {} ) p {color: red }");
-            Assert.AreEqual(0, sheet.Rules.Length);
+            Assert.That(sheet.Rules.Length, Is.EqualTo(0));
         }
 
         [Test]
         public void CssSheetInvalidStatementRulesetUnexpectedRightParenthesisWithValidQualifiedRule()
         {
             var sheet = ParseStyleSheet(@") {} p {color: green }");
-            Assert.AreEqual(1, sheet.Rules.Length);
+            Assert.That(sheet.Rules.Length, Is.EqualTo(1));
             var style = sheet.Rules[0] as ICssStyleRule;
             Assert.NotNull(style);
-            Assert.AreEqual("p", style.SelectorText);
-            Assert.AreEqual(1, style.Style.Length);
-            Assert.AreEqual("rgba(0, 128, 0, 1)", style.Style.GetColor());
+            Assert.That(style.SelectorText, Is.EqualTo("p"));
+            Assert.That(style.Style.Length, Is.EqualTo(1));
+            Assert.That(style.Style.GetColor(), Is.EqualTo("rgba(0, 128, 0, 1)"));
         }
 
         [Test]
@@ -273,139 +273,139 @@ h1 {
   h1 { color: red }
 }
 h1 { color: blue }");
-            Assert.AreEqual(1, sheet.Rules.Length);
+            Assert.That(sheet.Rules.Length, Is.EqualTo(1));
             Assert.IsInstanceOf<CssStyleRule>(sheet.Rules[0]);
             var h1 = sheet.Rules[0] as ICssStyleRule;
-            Assert.AreEqual("h1", h1.SelectorText);
-            Assert.AreEqual(1, h1.Style.Length);
-            Assert.AreEqual("color", h1.Style[0]);
-            Assert.AreEqual("rgba(0, 0, 255, 1)", h1.Style.GetColor());
+            Assert.That(h1.SelectorText, Is.EqualTo("h1"));
+            Assert.That(h1.Style.Length, Is.EqualTo(1));
+            Assert.That(h1.Style[0], Is.EqualTo("color"));
+            Assert.That(h1.Style.GetColor(), Is.EqualTo("rgba(0, 0, 255, 1)"));
         }
 
         [Test]
         public void CssSheetKeepValidValueFloat()
         {
             var sheet = ParseStyleSheet(@"img { float: left }");
-            Assert.AreEqual(1, sheet.Rules.Length);
+            Assert.That(sheet.Rules.Length, Is.EqualTo(1));
             Assert.IsInstanceOf<CssStyleRule>(sheet.Rules[0]);
             var img = sheet.Rules[0] as ICssStyleRule;
-            Assert.AreEqual("img", img.SelectorText);
-            Assert.AreEqual(1, img.Style.Length);
-            Assert.AreEqual("float", img.Style[0]);
-            Assert.AreEqual("left", img.Style.GetFloat());
+            Assert.That(img.SelectorText, Is.EqualTo("img"));
+            Assert.That(img.Style.Length, Is.EqualTo(1));
+            Assert.That(img.Style[0], Is.EqualTo("float"));
+            Assert.That(img.Style.GetFloat(), Is.EqualTo("left"));
         }
 
         [Test]
         public void CssSheetIgnoreInvalidValueFloat()
         {
             var sheet = ParseStyleSheet(@"img { float: left here }");
-            Assert.AreEqual(1, sheet.Rules.Length);
+            Assert.That(sheet.Rules.Length, Is.EqualTo(1));
             Assert.IsInstanceOf<CssStyleRule>(sheet.Rules[0]);
             var img = sheet.Rules[0] as ICssStyleRule;
-            Assert.AreEqual("img", img.SelectorText);
-            Assert.AreEqual(0, img.Style.Length);
-            Assert.AreEqual("", img.Style.GetFloat());
+            Assert.That(img.SelectorText, Is.EqualTo("img"));
+            Assert.That(img.Style.Length, Is.EqualTo(0));
+            Assert.That(img.Style.GetFloat(), Is.EqualTo(""));
         }
 
         [Test]
         public void CssSheetIgnoreInvalidValueBackground()
         {
             var sheet = ParseStyleSheet(@"img { background: ""red"" }");
-            Assert.AreEqual(1, sheet.Rules.Length);
+            Assert.That(sheet.Rules.Length, Is.EqualTo(1));
             Assert.IsInstanceOf<CssStyleRule>(sheet.Rules[0]);
             var img = sheet.Rules[0] as ICssStyleRule;
-            Assert.AreEqual("img", img.SelectorText);
-            Assert.AreEqual(0, img.Style.Length);
-            Assert.AreEqual("", img.Style.GetBackground());
+            Assert.That(img.SelectorText, Is.EqualTo("img"));
+            Assert.That(img.Style.Length, Is.EqualTo(0));
+            Assert.That(img.Style.GetBackground(), Is.EqualTo(""));
         }
 
         [Test]
         public void CssSheetIgnoreInvalidValueBorderWidth()
         {
             var sheet = ParseStyleSheet(@"img { border-width: 3 }");
-            Assert.AreEqual(1, sheet.Rules.Length);
+            Assert.That(sheet.Rules.Length, Is.EqualTo(1));
             Assert.IsInstanceOf<CssStyleRule>(sheet.Rules[0]);
             var img = sheet.Rules[0] as ICssStyleRule;
-            Assert.AreEqual("img", img.SelectorText);
-            Assert.AreEqual(0, img.Style.Length);
+            Assert.That(img.SelectorText, Is.EqualTo("img"));
+            Assert.That(img.Style.Length, Is.EqualTo(0));
         }
 
         [Test]
         public void CssSheetWellformedDeclaration()
         {
             var sheet = ParseStyleSheet(@"p { color:green; }");
-            Assert.AreEqual(1, sheet.Rules.Length);
+            Assert.That(sheet.Rules.Length, Is.EqualTo(1));
             Assert.IsInstanceOf<CssStyleRule>(sheet.Rules[0]);
             var p = sheet.Rules[0] as ICssStyleRule;
-            Assert.AreEqual("p", p.SelectorText);
-            Assert.AreEqual(1, p.Style.Length);
-            Assert.AreEqual("color", p.Style[0]);
-            Assert.AreEqual("rgba(0, 128, 0, 1)", p.Style.GetColor());
+            Assert.That(p.SelectorText, Is.EqualTo("p"));
+            Assert.That(p.Style.Length, Is.EqualTo(1));
+            Assert.That(p.Style[0], Is.EqualTo("color"));
+            Assert.That(p.Style.GetColor(), Is.EqualTo("rgba(0, 128, 0, 1)"));
         }
 
         [Test]
         public void CssSheetMalformedDeclarationMissingColon()
         {
             var sheet = ParseStyleSheet(@"p { color:green; color }");
-            Assert.AreEqual(1, sheet.Rules.Length);
+            Assert.That(sheet.Rules.Length, Is.EqualTo(1));
             Assert.IsInstanceOf<CssStyleRule>(sheet.Rules[0]);
             var p = sheet.Rules[0] as ICssStyleRule;
-            Assert.AreEqual("p", p.SelectorText);
-            Assert.AreEqual(1, p.Style.Length);
-            Assert.AreEqual("color", p.Style[0]);
-            Assert.AreEqual("rgba(0, 128, 0, 1)", p.Style.GetColor());
+            Assert.That(p.SelectorText, Is.EqualTo("p"));
+            Assert.That(p.Style.Length, Is.EqualTo(1));
+            Assert.That(p.Style[0], Is.EqualTo("color"));
+            Assert.That(p.Style.GetColor(), Is.EqualTo("rgba(0, 128, 0, 1)"));
         }
 
         [Test]
         public void CssSheetMalformedDeclarationMissingColonWithRecovery()
         {
             var sheet = ParseStyleSheet(@"p { color:red;   color; color:green }");
-            Assert.AreEqual(1, sheet.Rules.Length);
+            Assert.That(sheet.Rules.Length, Is.EqualTo(1));
             Assert.IsInstanceOf<CssStyleRule>(sheet.Rules[0]);
             var p = sheet.Rules[0] as ICssStyleRule;
-            Assert.AreEqual("p", p.SelectorText);
-            Assert.AreEqual(1, p.Style.Length);
-            Assert.AreEqual("color", p.Style[0]);
-            Assert.AreEqual("rgba(0, 128, 0, 1)", p.Style.GetColor());
+            Assert.That(p.SelectorText, Is.EqualTo("p"));
+            Assert.That(p.Style.Length, Is.EqualTo(1));
+            Assert.That(p.Style[0], Is.EqualTo("color"));
+            Assert.That(p.Style.GetColor(), Is.EqualTo("rgba(0, 128, 0, 1)"));
         }
 
         [Test]
         public void CssSheetMalformedDeclarationMissingValue()
         {
             var sheet = ParseStyleSheet(@"p { color:green; color: }");
-            Assert.AreEqual(1, sheet.Rules.Length);
+            Assert.That(sheet.Rules.Length, Is.EqualTo(1));
             Assert.IsInstanceOf<CssStyleRule>(sheet.Rules[0]);
             var p = sheet.Rules[0] as ICssStyleRule;
-            Assert.AreEqual("p", p.SelectorText);
-            Assert.AreEqual(1, p.Style.Length);
-            Assert.AreEqual("color", p.Style[0]);
-            Assert.AreEqual("rgba(0, 128, 0, 1)", p.Style.GetColor());
+            Assert.That(p.SelectorText, Is.EqualTo("p"));
+            Assert.That(p.Style.Length, Is.EqualTo(1));
+            Assert.That(p.Style[0], Is.EqualTo("color"));
+            Assert.That(p.Style.GetColor(), Is.EqualTo("rgba(0, 128, 0, 1)"));
         }
 
         [Test]
         public void CssSheetMalformedDeclarationUnexpectedTokens()
         {
             var sheet = ParseStyleSheet(@"p { color:green; color{;color:maroon} }");
-            Assert.AreEqual(1, sheet.Rules.Length);
+            Assert.That(sheet.Rules.Length, Is.EqualTo(1));
             Assert.IsInstanceOf<CssStyleRule>(sheet.Rules[0]);
             var p = sheet.Rules[0] as ICssStyleRule;
-            Assert.AreEqual("p", p.SelectorText);
-            Assert.AreEqual(1, p.Style.Length);
-            Assert.AreEqual("color", p.Style[0]);
-            Assert.AreEqual("rgba(0, 128, 0, 1)", p.Style.GetColor());
+            Assert.That(p.SelectorText, Is.EqualTo("p"));
+            Assert.That(p.Style.Length, Is.EqualTo(1));
+            Assert.That(p.Style[0], Is.EqualTo("color"));
+            Assert.That(p.Style.GetColor(), Is.EqualTo("rgba(0, 128, 0, 1)"));
         }
 
         [Test]
         public void CssSheetMalformedDeclarationUnexpectedTokensWithRecovery()
         {
             var sheet = ParseStyleSheet(@"p { color:red;   color{;color:maroon}; color:green }");
-            Assert.AreEqual(1, sheet.Rules.Length);
+            Assert.That(sheet.Rules.Length, Is.EqualTo(1));
             Assert.IsInstanceOf<CssStyleRule>(sheet.Rules[0]);
             var p = sheet.Rules[0] as ICssStyleRule;
-            Assert.AreEqual("p", p.SelectorText);
-            Assert.AreEqual(1, p.Style.Length);
-            Assert.AreEqual("color", p.Style[0]);
-            Assert.AreEqual("rgba(0, 128, 0, 1)", p.Style.GetColor());
+            Assert.That(p.SelectorText, Is.EqualTo("p"));
+            Assert.That(p.Style.Length, Is.EqualTo(1));
+            Assert.That(p.Style[0], Is.EqualTo("color"));
+            Assert.That(p.Style.GetColor(), Is.EqualTo("rgba(0, 128, 0, 1)"));
         }
 
         [Test]
@@ -512,16 +512,16 @@ h1 { color: blue }");
             var names = new[] { "border-top-color", "border-right-color", "border-bottom-color", "border-left-color" };
             var decls = ParseDeclarations("border-color: rgba(82, 168, 236, 0.8)");
             Assert.IsNotNull(decls);
-            Assert.AreEqual(4, decls.Length);
+            Assert.That(decls.Length, Is.EqualTo(4));
 
             for (int i = 0; i < decls.Length; i++)
             {
                 var propertyName = decls[i];
                 var property = decls.GetProperty(propertyName);
-                Assert.AreEqual(names[i], property.Name);
-                Assert.AreEqual(propertyName, property.Name);
-                Assert.IsFalse(property.IsImportant);
-                Assert.AreEqual("rgba(82, 168, 236, 0.8)", property.Value);
+                Assert.That(property.Name, Is.EqualTo(names[i]));
+                Assert.That(property.Name, Is.EqualTo(propertyName));
+                Assert.That(property.IsImportant, Is.False);
+                Assert.That(property.Value, Is.EqualTo("rgba(82, 168, 236, 0.8)"));
             }
         }
 
@@ -531,16 +531,16 @@ h1 { color: blue }");
             var names = new[] { "margin-top", "margin-right", "margin-bottom", "margin-left" };
             var decls = ParseDeclarations("margin: 20px;");
             Assert.IsNotNull(decls);
-            Assert.AreEqual(4, decls.Length);
+            Assert.That(decls.Length, Is.EqualTo(4));
 
             for (int i = 0; i < decls.Length; i++)
             {
                 var propertyName = decls[i];
                 var decl = decls.GetProperty(propertyName);
-                Assert.AreEqual(names[i], decl.Name);
-                Assert.AreEqual(propertyName, decl.Name);
-                Assert.IsFalse(decl.IsImportant);
-                Assert.AreEqual("20px", decl.Value);
+                Assert.That(decl.Name, Is.EqualTo(names[i]));
+                Assert.That(decl.Name, Is.EqualTo(propertyName));
+                Assert.That(decl.IsImportant, Is.False);
+                Assert.That(decl.Value, Is.EqualTo("20px"));
             }
         }
 
@@ -548,9 +548,9 @@ h1 { color: blue }");
         public void CssSeveralFontFamily()
         {
             var prop = ParseDeclaration("font-family: \"Helvetica Neue\", Helvetica, Arial, sans-serif");
-            Assert.AreEqual("font-family", prop.Name);
-            Assert.IsFalse(prop.IsImportant);
-            Assert.AreEqual("\"Helvetica Neue\", Helvetica, Arial, sans-serif", prop.Value);
+            Assert.That(prop.Name, Is.EqualTo("font-family"));
+            Assert.That(prop.IsImportant, Is.False);
+            Assert.That(prop.Value, Is.EqualTo("\"Helvetica Neue\", Helvetica, Arial, sans-serif"));
         }
 
         [Test]
@@ -558,70 +558,70 @@ h1 { color: blue }");
         {
             var decl = ParseDeclarations("font: bold 1em/2em monospace; content: \" (\" attr(href) \")\"");
             Assert.IsNotNull(decl);
-            Assert.AreEqual(8, decl.Length);
+            Assert.That(decl.Length, Is.EqualTo(8));
 
-            Assert.AreEqual("bold 1em / 2em monospace", decl.GetPropertyValue("font"));
+            Assert.That(decl.GetPropertyValue("font"), Is.EqualTo("bold 1em / 2em monospace"));
 
             var content = decl.GetProperty("content");
-            Assert.AreEqual("content", content.Name);
-            Assert.IsFalse(content.IsImportant);
-            Assert.AreEqual("\" (\" attr(href) \")\"", content.Value);
+            Assert.That(content.Name, Is.EqualTo("content"));
+            Assert.That(content.IsImportant, Is.False);
+            Assert.That(content.Value, Is.EqualTo("\" (\" attr(href) \")\""));
         }
 
         [Test]
         public void CssBackgroundWebkitGradientIsInvalid()
         {
             var background = ParseDeclaration("background: -webkit-gradient(linear, left top, left bottom, color-stop(0%, #FFA84C), color-stop(100%, #FF7B0D))");
-            Assert.IsFalse(background.HasValue);
+            Assert.That(background.HasValue, Is.False);
         }
 
         [Test]
         public void CssBackgroundColorRgba()
         {
             var background = ParseDeclaration("background-color: rgba(255, 123, 13, 1)");
-            Assert.AreEqual("background-color", background.Name);
-            Assert.IsFalse(background.IsImportant);
-            Assert.AreEqual("rgba(255, 123, 13, 1)", background.Value);
+            Assert.That(background.Name, Is.EqualTo("background-color"));
+            Assert.That(background.IsImportant, Is.False);
+            Assert.That(background.Value, Is.EqualTo("rgba(255, 123, 13, 1)"));
         }
 
         [Test]
         public void CssFontWithFraction()
         {
             var font = ParseDeclaration("font:bold 40px/1.13 'PT Sans Narrow', sans-serif");
-            Assert.AreEqual("font", font.Name);
-            Assert.IsFalse(font.IsImportant);
+            Assert.That(font.Name, Is.EqualTo("font"));
+            Assert.That(font.IsImportant, Is.False);
         }
 
         [Test]
         public void CssTextShadow()
         {
             var textShadow = ParseDeclaration("text-shadow: 0 0 10px #000");
-            Assert.AreEqual("text-shadow", textShadow.Name);
-            Assert.IsFalse(textShadow.IsImportant);
+            Assert.That(textShadow.Name, Is.EqualTo("text-shadow"));
+            Assert.That(textShadow.IsImportant, Is.False);
         }
 
         [Test]
         public void CssBackgroundWithImage()
         {
             var background = ParseDeclaration("background:url(../images/ribbon.svg) no-repeat");
-            Assert.AreEqual("background", background.Name);
-            Assert.IsFalse(background.IsImportant);
+            Assert.That(background.Name, Is.EqualTo("background"));
+            Assert.That(background.IsImportant, Is.False);
         }
 
         [Test]
         public void CssContentWithCounter()
         {
             var content = ParseDeclaration("content:counter(paging, decimal-leading-zero)");
-            Assert.AreEqual("content", content.Name);
-            Assert.IsFalse(content.IsImportant);
+            Assert.That(content.Name, Is.EqualTo("content"));
+            Assert.That(content.IsImportant, Is.False);
         }
 
         [Test]
         public void CssBackgroundColorRgb()
         {
             var backgroundColor = ParseDeclaration("background-color: rgb(245, 0, 111)");
-            Assert.AreEqual("background-color", backgroundColor.Name);
-            Assert.IsFalse(backgroundColor.IsImportant);
+            Assert.That(backgroundColor.Name, Is.EqualTo("background-color"));
+            Assert.That(backgroundColor.IsImportant, Is.False);
         }
 
         [Test]
@@ -632,31 +632,31 @@ h1 { color: blue }");
             Assert.IsNotNull(decl);
             Assert.IsInstanceOf<CssImportRule>(decl);
             var importRule = (CssImportRule)decl;
-            Assert.AreEqual("fonts.css", importRule.Href);
+            Assert.That(importRule.Href, Is.EqualTo("fonts.css"));
         }
 
         [Test]
         public void CssContentEscaped()
         {
             var content = ParseDeclaration("content:'\005E'");
-            Assert.AreEqual("content", content.Name);
-            Assert.IsFalse(content.IsImportant);
+            Assert.That(content.Name, Is.EqualTo("content"));
+            Assert.That(content.IsImportant, Is.False);
         }
 
         [Test]
         public void CssContentCounter()
         {
             var content = ParseDeclaration("content:counter(list)'.'");
-            Assert.AreEqual("content", content.Name);
-            Assert.IsFalse(content.IsImportant);
+            Assert.That(content.Name, Is.EqualTo("content"));
+            Assert.That(content.IsImportant, Is.False);
         }
 
         [Test]
         public void CssTransformTranslate()
         {
             var transform = ParseDeclaration("transform:translateY(-50%)");
-            Assert.AreEqual("transform", transform.Name);
-            Assert.IsFalse(transform.IsImportant);
+            Assert.That(transform.Name, Is.EqualTo("transform"));
+            Assert.That(transform.IsImportant, Is.False);
         }
 
         [Test]
@@ -666,17 +666,17 @@ h1 { color: blue }");
         box-shadow:
 			0 0 0 10px rgba(60, 61, 64, 0.6),
 			0 0 50px #3C3D40;");
-            Assert.AreEqual("box-shadow", boxShadow.Name);
-            Assert.IsFalse(boxShadow.IsImportant);
+            Assert.That(boxShadow.Name, Is.EqualTo("box-shadow"));
+            Assert.That(boxShadow.IsImportant, Is.False);
         }
 
         [Test]
         public void CssDisplayBlock()
         {
             var display = ParseDeclaration("display:block");
-            Assert.AreEqual("display", display.Name);
-            Assert.IsFalse(display.IsImportant);
-            Assert.AreEqual("block", display.Value);
+            Assert.That(display.Name, Is.EqualTo("display"));
+            Assert.That(display.IsImportant, Is.False);
+            Assert.That(display.Value, Is.EqualTo("block"));
         }
 
         [Test]
@@ -684,16 +684,16 @@ h1 { color: blue }");
         {
             var sheet = ParseStyleSheet(".App_Header_ .logo { background-image: url(\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEcAAAAcCAMAAAAEJ1IZAAAABGdBTUEAALGPC/xhBQAAVAI/VAI/VAI/VAI/VAI/VAI/VAAAA////AI/VRZ0U8AAAAFJ0Uk5TYNV4S2UbgT/Gk6uQt585w2wGXS0zJO2lhGttJK6j4YqZSobH1AAAAAElFTkSuQmCC\"); background-size: 71px 28px; background-position: 0 19px; width: 71px; }");
             Assert.IsNotNull(sheet);
-            Assert.AreEqual(1, sheet.Rules.Length);
+            Assert.That(sheet.Rules.Length, Is.EqualTo(1));
             var rule = sheet.Rules[0] as CssStyleRule;
             Assert.IsNotNull(rule);
-            Assert.AreEqual(5, rule.Style.Length);
-            Assert.AreEqual(".App_Header_ .logo", rule.SelectorText);
+            Assert.That(rule.Style.Length, Is.EqualTo(5));
+            Assert.That(rule.SelectorText, Is.EqualTo(".App_Header_ .logo"));
             var decl = rule.Style as ICssStyleDeclaration;
-            Assert.AreEqual("url(\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEcAAAAcCAMAAAAEJ1IZAAAABGdBTUEAALGPC/xhBQAAVAI/VAI/VAI/VAI/VAI/VAI/VAAAA////AI/VRZ0U8AAAAFJ0Uk5TYNV4S2UbgT/Gk6uQt585w2wGXS0zJO2lhGttJK6j4YqZSobH1AAAAAElFTkSuQmCC\")", decl.GetBackgroundImage());
-            Assert.AreEqual("71px 28px", decl.GetBackgroundSize());
-            Assert.AreEqual("0 19px", decl.GetBackgroundPosition());
-            Assert.AreEqual("71px", decl.GetWidth());
+            Assert.That(decl.GetBackgroundImage(), Is.EqualTo("url(\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEcAAAAcCAMAAAAEJ1IZAAAABGdBTUEAALGPC/xhBQAAVAI/VAI/VAI/VAI/VAI/VAI/VAAAA////AI/VRZ0U8AAAAFJ0Uk5TYNV4S2UbgT/Gk6uQt585w2wGXS0zJO2lhGttJK6j4YqZSobH1AAAAAElFTkSuQmCC\")"));
+            Assert.That(decl.GetBackgroundSize(), Is.EqualTo("71px 28px"));
+            Assert.That(decl.GetBackgroundPosition(), Is.EqualTo("0 19px"));
+            Assert.That(decl.GetWidth(), Is.EqualTo("71px"));
         }
 
         [Test]
@@ -724,7 +724,7 @@ h1 { color: blue }");
             {
                 var sheet = ParseStyleSheet(memoryStream);
                 Assert.IsNotNull(sheet);
-                Assert.AreEqual(0, sheet.Rules.Length);
+                Assert.That(sheet.Rules.Length, Is.EqualTo(0));
             }
         }
 
@@ -733,7 +733,7 @@ h1 { color: blue }");
         {
             var sheet = ParseStyleSheet("U+???\0");
             Assert.IsNotNull(sheet);
-            Assert.AreEqual(0, sheet.Rules.Length);
+            Assert.That(sheet.Rules.Length, Is.EqualTo(0));
         }
 
         [Test]
@@ -758,38 +758,38 @@ p.info span::after {
             var initialSourceCode = initialSheet.ToCss();
             var finalSheet = ParseStyleSheet(initialSourceCode);
             var finalSourceCode = finalSheet.ToCss();
-            Assert.AreEqual(initialSourceCode, finalSourceCode);
-            Assert.AreEqual(initialSheet.Rules.Length, finalSheet.Rules.Length);
+            Assert.That(finalSourceCode, Is.EqualTo(initialSourceCode));
+            Assert.That(finalSheet.Rules.Length, Is.EqualTo(initialSheet.Rules.Length));
         }
 
         [Test]
         public void CssParseSheetWithStyleMediaAndStyleRule()
         {
             var sheet = ParseStyleSheet(@".mobile,.tablet{display:none;} @media only screen and(max-width:51.875em){.tablet{display:block;}} .disp {display:block;}");
-            Assert.AreEqual(3, sheet.Rules.Length);
-            Assert.AreEqual(CssRuleType.Style, sheet.Rules[0].Type);
-            Assert.AreEqual(CssRuleType.Media, sheet.Rules[1].Type);
-            Assert.AreEqual(CssRuleType.Style, sheet.Rules[2].Type);
+            Assert.That(sheet.Rules.Length, Is.EqualTo(3));
+            Assert.That(sheet.Rules[0].Type, Is.EqualTo(CssRuleType.Style));
+            Assert.That(sheet.Rules[1].Type, Is.EqualTo(CssRuleType.Media));
+            Assert.That(sheet.Rules[2].Type, Is.EqualTo(CssRuleType.Style));
         }
 
         [Test]
         public void CssParseSheetWithMediaAndTwoStyleRules()
         {
             var sheet = ParseStyleSheet(@"@media only screen and(max-width:51.875em){.tablet{display:block;}} .mobile,.tablet{display:none;} .disp {display:block;}");
-            Assert.AreEqual(3, sheet.Rules.Length);
-            Assert.AreEqual(CssRuleType.Media, sheet.Rules[0].Type);
-            Assert.AreEqual(CssRuleType.Style, sheet.Rules[1].Type);
-            Assert.AreEqual(CssRuleType.Style, sheet.Rules[2].Type);
+            Assert.That(sheet.Rules.Length, Is.EqualTo(3));
+            Assert.That(sheet.Rules[0].Type, Is.EqualTo(CssRuleType.Media));
+            Assert.That(sheet.Rules[1].Type, Is.EqualTo(CssRuleType.Style));
+            Assert.That(sheet.Rules[2].Type, Is.EqualTo(CssRuleType.Style));
         }
 
         [Test]
         public void CssParseSheetWithTwoStyleAndMediaRule()
         {
             var sheet = ParseStyleSheet(@".mobile,.tablet{display:none;} .disp {display:block;} @media only screen and(max-width:51.875em){.tablet{display:block;}}");
-            Assert.AreEqual(3, sheet.Rules.Length);
-            Assert.AreEqual(CssRuleType.Style, sheet.Rules[0].Type);
-            Assert.AreEqual(CssRuleType.Style, sheet.Rules[1].Type);
-            Assert.AreEqual(CssRuleType.Media, sheet.Rules[2].Type);
+            Assert.That(sheet.Rules.Length, Is.EqualTo(3));
+            Assert.That(sheet.Rules[0].Type, Is.EqualTo(CssRuleType.Style));
+            Assert.That(sheet.Rules[1].Type, Is.EqualTo(CssRuleType.Style));
+            Assert.That(sheet.Rules[2].Type, Is.EqualTo(CssRuleType.Media));
         }
 
         [Test]
@@ -797,16 +797,16 @@ p.info span::after {
         {
             var src = "@import url(import3.css); p { color : #f00; }";
             var sheet = ParseStyleSheet(src);
-            Assert.AreEqual(2, sheet.Rules.Length);
+            Assert.That(sheet.Rules.Length, Is.EqualTo(2));
             var import = sheet.Rules[0] as ICssImportRule;
             var style = sheet.Rules[1] as ICssStyleRule;
             Assert.IsNotNull(import);
             Assert.IsNotNull(style);
-            Assert.AreEqual(0, import.Media.Length);
-            Assert.AreEqual("", import.Media.MediaText);
-            Assert.AreEqual("import3.css", import.Href);
-            Assert.AreEqual("p", style.Selector.Text);
-            Assert.AreEqual(1, style.Style.Length);
+            Assert.That(import.Media.Length, Is.EqualTo(0));
+            Assert.That(import.Media.MediaText, Is.EqualTo(""));
+            Assert.That(import.Href, Is.EqualTo("import3.css"));
+            Assert.That(style.Selector.Text, Is.EqualTo("p"));
+            Assert.That(style.Style.Length, Is.EqualTo(1));
         }
 
         [Test]
@@ -814,11 +814,11 @@ p.info span::after {
         {
             var src = "@media only screen and (min--moz-device-pixel-ratio:1.5),only screen and (-o-min-device-pixel-ratio:3/2),only screen and (-webkit-min-device-pixel-ratio:1.5),only screen and (min-device-pixel-ratio:1.5){.favicon{background-image:url('../img/favicons-sprite32.png?v=1b9547cf9cee3350a5b4875951e3e552');background-size:16px 5634px}}";
             var sheet = ParseStyleSheet(src);
-            Assert.AreEqual(1, sheet.Rules.Length);
+            Assert.That(sheet.Rules.Length, Is.EqualTo(1));
             var media = sheet.Rules[0] as ICssMediaRule;
             Assert.IsNotNull(media);
-            Assert.AreEqual(4, media.Media.Length);
-            Assert.AreEqual(1, media.Rules.Length);
+            Assert.That(media.Media.Length, Is.EqualTo(4));
+            Assert.That(media.Rules.Length, Is.EqualTo(1));
         }
 
         [Test]
@@ -832,11 +832,11 @@ font-family:""Cambria"",""serif"";
 color:#4F81BD;
 font-weight:bold;}";
             var sheet = ParseStyleSheet(src);
-            Assert.AreEqual(1, sheet.Rules.Length);
+            Assert.That(sheet.Rules.Length, Is.EqualTo(1));
             var style = sheet.Rules[0] as ICssStyleRule;
             Assert.IsNotNull(style);
-            Assert.AreEqual("span.berschrift2Zchn", style.SelectorText);
-            Assert.AreEqual(3, style.Style.Length);
+            Assert.That(style.SelectorText, Is.EqualTo("span.berschrift2Zchn"));
+            Assert.That(style.Style.Length, Is.EqualTo(3));
         }
 
         [Test]
@@ -845,7 +845,7 @@ font-weight:bold;}";
             var css = "@-ms-viewport{width:device-width} .dsip { display: block; }";
             var doc = ParseStyleSheet(css);
             var result = doc.ToCss();
-            Assert.AreEqual(".dsip { display: block }", result);
+            Assert.That(result, Is.EqualTo(".dsip { display: block }"));
         }
 
         [Test]
@@ -859,7 +859,7 @@ font-weight:bold;}";
             var css = "@-ms-viewport{width:device-width} .dsip { display: block; }";
             var doc = ParseStyleSheet(css, options);
             var result = doc.ToCss();
-            Assert.AreEqual("@-ms-viewport{width:device-width}" + Environment.NewLine + ".dsip { display: block }", result);
+            Assert.That(result, Is.EqualTo("@-ms-viewport{width:device-width}" + Environment.NewLine + ".dsip { display: block }"));
         }
 
         [Test]
@@ -868,7 +868,7 @@ font-weight:bold;}";
             var css = "@media screen and (max-width: 400px) {  @-ms-viewport { width: 320px; }  }  .dsip { display: block; }";
             var doc = ParseStyleSheet(css);
             var result = doc.ToCss();
-            Assert.AreEqual("@media screen and (max-width: 400px) { }" + Environment.NewLine + ".dsip { display: block }", result);
+            Assert.That(result, Is.EqualTo("@media screen and (max-width: 400px) { }" + Environment.NewLine + ".dsip { display: block }"));
         }
 
         [Test]
@@ -882,26 +882,26 @@ font-weight:bold;}";
             var css = "@media screen and (max-width: 400px) {  @-ms-viewport { width: 320px; }  }  .dsip { display: block; }";
             var doc = ParseStyleSheet(css, options);
             var result = doc.ToCss();
-            Assert.AreEqual("@media screen and (max-width: 400px) { @-ms-viewport { width: 320px; } }" + Environment.NewLine + ".dsip { display: block }", result);
+            Assert.That(result, Is.EqualTo("@media screen and (max-width: 400px) { @-ms-viewport { width: 320px; } }" + Environment.NewLine + ".dsip { display: block }"));
         }
 
         [Test]
         public void CssStyleSheetInsertAndDeleteShouldWork()
         {
             var s = ParseStyleSheet(String.Empty);
-            Assert.AreEqual(0, s.Rules.Length);
+            Assert.That(s.Rules.Length, Is.EqualTo(0));
 
             s.Insert("a {color: blue}", 0);
-            Assert.AreEqual(1, s.Rules.Length);
+            Assert.That(s.Rules.Length, Is.EqualTo(1));
 
             s.Insert("a *:first-child, a img {border: none}", 1);
-            Assert.AreEqual(2, s.Rules.Length);
+            Assert.That(s.Rules.Length, Is.EqualTo(2));
 
             s.RemoveAt(1);
-            Assert.AreEqual(1, s.Rules.Length);
+            Assert.That(s.Rules.Length, Is.EqualTo(1));
 
             s.RemoveAt(0);
-            Assert.AreEqual(0, s.Rules.Length);
+            Assert.That(s.Rules.Length, Is.EqualTo(0));
         }
 
         [Test]
@@ -910,19 +910,19 @@ font-weight:bold;}";
             var parser = new CssParser();
             var source = "<!-- body { font-family: Verdana } div.hidden { display: none } -->";
             var sheet = parser.ParseStyleSheet(source);
-            Assert.AreEqual(2, sheet.Rules.Length);
+            Assert.That(sheet.Rules.Length, Is.EqualTo(2));
 
-            Assert.AreEqual(CssRuleType.Style, sheet.Rules[0].Type);
+            Assert.That(sheet.Rules[0].Type, Is.EqualTo(CssRuleType.Style));
             var body = sheet.Rules[0] as ICssStyleRule;
-            Assert.AreEqual("body", body.SelectorText);
-            Assert.AreEqual(1, body.Style.Length);
-            Assert.AreEqual("Verdana", body.Style.GetFontFamily());
+            Assert.That(body.SelectorText, Is.EqualTo("body"));
+            Assert.That(body.Style.Length, Is.EqualTo(1));
+            Assert.That(body.Style.GetFontFamily(), Is.EqualTo("Verdana"));
 
-            Assert.AreEqual(CssRuleType.Style, sheet.Rules[1].Type);
+            Assert.That(sheet.Rules[1].Type, Is.EqualTo(CssRuleType.Style));
             var div = sheet.Rules[1] as ICssStyleRule;
-            Assert.AreEqual("div.hidden", div.SelectorText);
-            Assert.AreEqual(1, div.Style.Length);
-            Assert.AreEqual("none", div.Style.GetDisplay());
+            Assert.That(div.SelectorText, Is.EqualTo("div.hidden"));
+            Assert.That(div.Style.Length, Is.EqualTo(1));
+            Assert.That(div.Style.GetDisplay(), Is.EqualTo("none"));
         }
 
         [Test]
@@ -932,16 +932,16 @@ font-weight:bold;}";
             var source = "body { border-color: red }";
             var sheet = parser.ParseStyleSheet(source);
 
-            Assert.AreEqual(1, sheet.Rules.Length);
-            Assert.AreEqual(CssRuleType.Style, sheet.Rules[0].Type);
+            Assert.That(sheet.Rules.Length, Is.EqualTo(1));
+            Assert.That(sheet.Rules[0].Type, Is.EqualTo(CssRuleType.Style));
 
             var body = sheet.Rules[0] as ICssStyleRule;
-            Assert.AreEqual("border-color: rgba(255, 0, 0, 1)", body.Style.CssText);
-            Assert.AreEqual("rgba(255, 0, 0, 1)", body.Style.GetBorderColor());
-            Assert.AreEqual("rgba(255, 0, 0, 1)", body.Style.GetBorderLeftColor());
-            Assert.AreEqual("rgba(255, 0, 0, 1)", body.Style.GetBorderRightColor());
-            Assert.AreEqual("rgba(255, 0, 0, 1)", body.Style.GetBorderTopColor());
-            Assert.AreEqual("rgba(255, 0, 0, 1)", body.Style.GetBorderBottomColor());
+            Assert.That(body.Style.CssText, Is.EqualTo("border-color: rgba(255, 0, 0, 1)"));
+            Assert.That(body.Style.GetBorderColor(), Is.EqualTo("rgba(255, 0, 0, 1)"));
+            Assert.That(body.Style.GetBorderLeftColor(), Is.EqualTo("rgba(255, 0, 0, 1)"));
+            Assert.That(body.Style.GetBorderRightColor(), Is.EqualTo("rgba(255, 0, 0, 1)"));
+            Assert.That(body.Style.GetBorderTopColor(), Is.EqualTo("rgba(255, 0, 0, 1)"));
+            Assert.That(body.Style.GetBorderBottomColor(), Is.EqualTo("rgba(255, 0, 0, 1)"));
         }
 
         [Test]
@@ -954,12 +954,12 @@ font-weight:bold;}";
             var body = sheet.Rules[0] as ICssStyleRule;
             body.Style.SetBorderLeftColor("blue");
             body.Style.SetBorderRightColor("blue");
-            Assert.AreEqual("border-color: rgba(255, 0, 0, 1) rgba(0, 0, 255, 1)", body.Style.CssText);
-            Assert.AreEqual("rgba(255, 0, 0, 1) rgba(0, 0, 255, 1)", body.Style.GetBorderColor());
-            Assert.AreEqual("rgba(0, 0, 255, 1)", body.Style.GetBorderLeftColor());
-            Assert.AreEqual("rgba(0, 0, 255, 1)", body.Style.GetBorderRightColor());
-            Assert.AreEqual("rgba(255, 0, 0, 1)", body.Style.GetBorderTopColor());
-            Assert.AreEqual("rgba(255, 0, 0, 1)", body.Style.GetBorderBottomColor());
+            Assert.That(body.Style.CssText, Is.EqualTo("border-color: rgba(255, 0, 0, 1) rgba(0, 0, 255, 1)"));
+            Assert.That(body.Style.GetBorderColor(), Is.EqualTo("rgba(255, 0, 0, 1) rgba(0, 0, 255, 1)"));
+            Assert.That(body.Style.GetBorderLeftColor(), Is.EqualTo("rgba(0, 0, 255, 1)"));
+            Assert.That(body.Style.GetBorderRightColor(), Is.EqualTo("rgba(0, 0, 255, 1)"));
+            Assert.That(body.Style.GetBorderTopColor(), Is.EqualTo("rgba(255, 0, 0, 1)"));
+            Assert.That(body.Style.GetBorderBottomColor(), Is.EqualTo("rgba(255, 0, 0, 1)"));
         }
 
         [Test]
@@ -970,13 +970,13 @@ font-weight:bold;}";
             var sheet = parser.ParseStyleSheet(source);
 
             var body = sheet.Rules[0] as ICssStyleRule;
-            Assert.AreEqual("border: 1px solid rgba(255, 0, 0, 1)", body.Style.CssText);
+            Assert.That(body.Style.CssText, Is.EqualTo("border: 1px solid rgba(255, 0, 0, 1)"));
             body.Style.SetBorderLeftColor("blue");
             body.Style.SetBorderTopWidth("medium");
-            Assert.AreEqual("border-top: 3px solid rgba(255, 0, 0, 1); border-right: 1px solid rgba(255, 0, 0, 1); border-bottom: 1px solid rgba(255, 0, 0, 1); border-left: 1px solid rgba(0, 0, 255, 1)", body.Style.CssText);
-            Assert.AreEqual("rgba(255, 0, 0, 1) rgba(255, 0, 0, 1) rgba(255, 0, 0, 1) rgba(0, 0, 255, 1)", body.Style.GetBorderColor());
-            Assert.AreEqual("3px 1px 1px", body.Style.GetBorderWidth());
-            Assert.AreEqual("solid", body.Style.GetBorderStyle());
+            Assert.That(body.Style.CssText, Is.EqualTo("border-top: 3px solid rgba(255, 0, 0, 1); border-right: 1px solid rgba(255, 0, 0, 1); border-bottom: 1px solid rgba(255, 0, 0, 1); border-left: 1px solid rgba(0, 0, 255, 1)"));
+            Assert.That(body.Style.GetBorderColor(), Is.EqualTo("rgba(255, 0, 0, 1) rgba(255, 0, 0, 1) rgba(255, 0, 0, 1) rgba(0, 0, 255, 1)"));
+            Assert.That(body.Style.GetBorderWidth(), Is.EqualTo("3px 1px 1px"));
+            Assert.That(body.Style.GetBorderStyle(), Is.EqualTo("solid"));
         }
 
         [Test]
@@ -984,7 +984,7 @@ font-weight:bold;}";
         {
             var s = ParseStyleSheet(String.Empty);
             s.Insert("a {color: blue}", 0);
-            Assert.AreEqual(s, s.Rules[0].Owner);
+            Assert.That(s.Rules[0].Owner, Is.EqualTo(s));
         }
 
         [Test]
@@ -993,7 +993,7 @@ font-weight:bold;}";
             var s = ParseStyleSheet("body { background: url(http://example.com/foo.png) no-repeat }");
             var rule = s.GetStyleRuleWith("body");
             var url = rule.GetValueOf("background-image").AsUrl();
-            Assert.AreEqual("http://example.com/foo.png", url);
+            Assert.That(url, Is.EqualTo("http://example.com/foo.png"));
         }
 
         [Test]
@@ -1002,7 +1002,7 @@ font-weight:bold;}";
             var s = ParseStyleSheet("p > a { border: 1px solid red }");
             var rule = s.GetStyleRuleWith("p > a");
             var color = rule.GetValueOf("border-right-color").AsRgba();
-            Assert.AreEqual(0x00_00_ff_ff, color);
+            Assert.That(color, Is.EqualTo(0x00_00_ff_ff));
         }
 
         [Test]
@@ -1026,7 +1026,7 @@ font-weight:bold;}";
 .hwbAlpha { color: hwb(120, 10%, 50%, 0.5); }
 .hwbAngleAlpha { color: hwb(120deg, 10%, 50%, 0.5); }";
             var sheet = parser.ParseStyleSheet(source);
-            Assert.AreEqual(15, sheet.Rules.Length);
+            Assert.That(sheet.Rules.Length, Is.EqualTo(15));
 
             var rgbNumber = (sheet.Rules[0] as ICssStyleRule).Style.GetColor();
             var rgbPercent = (sheet.Rules[1] as ICssStyleRule).Style.GetColor();

--- a/src/AngleSharp.Css.Tests/Styling/HtmlCssIntegration.cs
+++ b/src/AngleSharp.Css.Tests/Styling/HtmlCssIntegration.cs
@@ -36,19 +36,19 @@ namespace AngleSharp.Css.Tests.Styling
 </body>
 </html>";
             var doc = ParseDocument(source);
-            Assert.AreEqual(1, doc.StyleSheets.Length);
+            Assert.That(doc.StyleSheets.Length, Is.EqualTo(1));
             var css = doc.StyleSheets[0] as CssStyleSheet;
-            Assert.AreEqual(1, css.Rules.Length);
+            Assert.That(css.Rules.Length, Is.EqualTo(1));
             var style = css.Rules[0] as CssStyleRule;
-            Assert.AreEqual("body", style.SelectorText);
-            Assert.AreEqual(1, style.Style.Length);
+            Assert.That(style.SelectorText, Is.EqualTo("body"));
+            Assert.That(style.Style.Length, Is.EqualTo(1));
             var decl = style.Style;
             Assert.IsInstanceOf<CssStyleDeclaration>(decl);
             var rule = decl.GetProperty("background-color");
-            Assert.IsTrue(rule.IsImportant);
-            Assert.AreEqual("background-color", rule.Name);
-            Assert.AreEqual(rule.Name, decl[0]);
-            Assert.AreEqual("rgba(0, 128, 0, 1)", rule.Value);
+            Assert.That(rule.IsImportant, Is.True);
+            Assert.That(rule.Name, Is.EqualTo("background-color"));
+            Assert.That(decl[0], Is.EqualTo(rule.Name));
+            Assert.That(rule.Value, Is.EqualTo("rgba(0, 128, 0, 1)"));
         }
 
         [Test]
@@ -61,8 +61,8 @@ namespace AngleSharp.Css.Tests.Styling
                 IsIncludingUnknownRules = true
             });
             var div = doc.QuerySelector<IHtmlElement>("div");
-            Assert.AreEqual("", div.GetStyle()["background-color"]);
-            Assert.AreEqual("", div.GetStyle().CssText);
+            Assert.That(div.GetStyle()["background-color"], Is.EqualTo(""));
+            Assert.That(div.GetStyle().CssText, Is.EqualTo(""));
         }
 
         [Test]
@@ -93,37 +93,37 @@ namespace AngleSharp.Css.Tests.Styling
 
             var origin = link.Sheet as ICssStyleSheet;
             Assert.IsNotNull(origin);
-            Assert.AreEqual("http://localhost/origin.css", origin.Href);
-            Assert.AreEqual(1, origin.Rules.Length);
-            Assert.AreEqual(CssRuleType.Import, origin.Rules[0].Type);
+            Assert.That(origin.Href, Is.EqualTo("http://localhost/origin.css"));
+            Assert.That(origin.Rules.Length, Is.EqualTo(1));
+            Assert.That(origin.Rules[0].Type, Is.EqualTo(CssRuleType.Import));
 
             var linked1 = (origin.Rules[0] as ICssImportRule).Sheet;
             Assert.IsNotNull(linked1);
-            Assert.AreEqual("http://localhost/linked1.css", linked1.Href);
-            Assert.AreEqual(0, linked1.Rules.Length);
+            Assert.That(linked1.Href, Is.EqualTo("http://localhost/linked1.css"));
+            Assert.That(linked1.Rules.Length, Is.EqualTo(0));
 
             var styleSheet = style.Sheet as ICssStyleSheet;
             Assert.IsNotNull(styleSheet);
-            Assert.AreEqual(null, styleSheet.Href);
-            Assert.AreEqual(1, styleSheet.Rules.Length);
-            Assert.AreEqual(CssRuleType.Import, styleSheet.Rules[0].Type);
+            Assert.That(styleSheet.Href, Is.EqualTo(null));
+            Assert.That(styleSheet.Rules.Length, Is.EqualTo(1));
+            Assert.That(styleSheet.Rules[0].Type, Is.EqualTo(CssRuleType.Import));
 
             var linked2 = (styleSheet.Rules[0] as ICssImportRule).Sheet;
             Assert.IsNotNull(linked2);
-            Assert.AreEqual("http://localhost/linked2.css", linked2.Href);
-            Assert.AreEqual(2, linked2.Rules.Length);
-            Assert.AreEqual(CssRuleType.Import, linked2.Rules[0].Type);
-            Assert.AreEqual(CssRuleType.Import, linked2.Rules[1].Type);
+            Assert.That(linked2.Href, Is.EqualTo("http://localhost/linked2.css"));
+            Assert.That(linked2.Rules.Length, Is.EqualTo(2));
+            Assert.That(linked2.Rules[0].Type, Is.EqualTo(CssRuleType.Import));
+            Assert.That(linked2.Rules[1].Type, Is.EqualTo(CssRuleType.Import));
 
             var linked3 = (linked2.Rules[0] as ICssImportRule).Sheet;
             Assert.IsNotNull(linked3);
-            Assert.AreEqual("http://localhost/linked3.css", linked3.Href);
-            Assert.AreEqual(0, linked3.Rules.Length);
+            Assert.That(linked3.Href, Is.EqualTo("http://localhost/linked3.css"));
+            Assert.That(linked3.Rules.Length, Is.EqualTo(0));
 
             var linked4 = (linked2.Rules[1] as ICssImportRule).Sheet;
             Assert.IsNotNull(linked4);
-            Assert.AreEqual("http://localhost/linked4.css", linked4.Href);
-            Assert.AreEqual(0, linked4.Rules.Length);
+            Assert.That(linked4.Href, Is.EqualTo("http://localhost/linked4.css"));
+            Assert.That(linked4.Rules.Length, Is.EqualTo(0));
         }
 
         [Test]
@@ -149,14 +149,14 @@ namespace AngleSharp.Css.Tests.Styling
 
             var origin = link.Sheet as ICssStyleSheet;
             Assert.IsNotNull(origin);
-            Assert.AreEqual("http://localhost/origin.css", origin.Href);
-            Assert.AreEqual(1, origin.Rules.Length);
-            Assert.AreEqual(CssRuleType.Import, origin.Rules[0].Type);
+            Assert.That(origin.Href, Is.EqualTo("http://localhost/origin.css"));
+            Assert.That(origin.Rules.Length, Is.EqualTo(1));
+            Assert.That(origin.Rules[0].Type, Is.EqualTo(CssRuleType.Import));
 
             var linked = (origin.Rules[0] as ICssImportRule).Sheet;
             Assert.IsNotNull(linked);
-            Assert.AreEqual("http://localhost/linked.css", linked.Href);
-            Assert.AreEqual(1, linked.Rules.Length);
+            Assert.That(linked.Href, Is.EqualTo("http://localhost/linked.css"));
+            Assert.That(linked.Rules.Length, Is.EqualTo(1));
 
             var originAborted = (linked.Rules[0] as ICssImportRule).Sheet;
             Assert.IsNull(originAborted);
@@ -188,47 +188,47 @@ namespace AngleSharp.Css.Tests.Styling
             var doc = ParseDocument(@"<table><tr style=""display: none;"">");
 
             var dochtml0 = doc.ChildNodes[0] as IElement;
-            Assert.AreEqual(2, dochtml0.ChildNodes.Length);
-            Assert.AreEqual(0, dochtml0.Attributes.Length);
-            Assert.AreEqual("html", dochtml0.GetTagName());
-            Assert.AreEqual(NodeType.Element, dochtml0.NodeType);
+            Assert.That(dochtml0.ChildNodes.Length, Is.EqualTo(2));
+            Assert.That(dochtml0.Attributes.Length, Is.EqualTo(0));
+            Assert.That(dochtml0.GetTagName(), Is.EqualTo("html"));
+            Assert.That(dochtml0.NodeType, Is.EqualTo(NodeType.Element));
 
             var dochtml0head0 = dochtml0.ChildNodes[0] as IElement;
-            Assert.AreEqual(0, dochtml0head0.ChildNodes.Length);
-            Assert.AreEqual(0, dochtml0head0.Attributes.Length);
-            Assert.AreEqual("head", dochtml0head0.GetTagName());
-            Assert.AreEqual(NodeType.Element, dochtml0head0.NodeType);
+            Assert.That(dochtml0head0.ChildNodes.Length, Is.EqualTo(0));
+            Assert.That(dochtml0head0.Attributes.Length, Is.EqualTo(0));
+            Assert.That(dochtml0head0.GetTagName(), Is.EqualTo("head"));
+            Assert.That(dochtml0head0.NodeType, Is.EqualTo(NodeType.Element));
 
             var dochtml0body1 = dochtml0.ChildNodes[1] as IElement;
-            Assert.AreEqual(1, dochtml0body1.ChildNodes.Length);
-            Assert.AreEqual(0, dochtml0body1.Attributes.Length);
-            Assert.AreEqual("body", dochtml0body1.GetTagName());
-            Assert.AreEqual(NodeType.Element, dochtml0body1.NodeType);
+            Assert.That(dochtml0body1.ChildNodes.Length, Is.EqualTo(1));
+            Assert.That(dochtml0body1.Attributes.Length, Is.EqualTo(0));
+            Assert.That(dochtml0body1.GetTagName(), Is.EqualTo("body"));
+            Assert.That(dochtml0body1.NodeType, Is.EqualTo(NodeType.Element));
 
             var dochtml0body1table0 = dochtml0body1.ChildNodes[0] as IElement;
-            Assert.AreEqual(1, dochtml0body1table0.ChildNodes.Length);
-            Assert.AreEqual(0, dochtml0body1table0.Attributes.Length);
-            Assert.AreEqual("table", dochtml0body1table0.GetTagName());
-            Assert.AreEqual(NodeType.Element, dochtml0body1table0.NodeType);
+            Assert.That(dochtml0body1table0.ChildNodes.Length, Is.EqualTo(1));
+            Assert.That(dochtml0body1table0.Attributes.Length, Is.EqualTo(0));
+            Assert.That(dochtml0body1table0.GetTagName(), Is.EqualTo("table"));
+            Assert.That(dochtml0body1table0.NodeType, Is.EqualTo(NodeType.Element));
 
             var dochtml0body1table0tbody0 = dochtml0body1table0.ChildNodes[0] as IElement;
-            Assert.AreEqual(1, dochtml0body1table0tbody0.ChildNodes.Length);
-            Assert.AreEqual(0, dochtml0body1table0tbody0.Attributes.Length);
-            Assert.AreEqual("tbody", dochtml0body1table0tbody0.GetTagName());
-            Assert.AreEqual(NodeType.Element, dochtml0body1table0tbody0.NodeType);
+            Assert.That(dochtml0body1table0tbody0.ChildNodes.Length, Is.EqualTo(1));
+            Assert.That(dochtml0body1table0tbody0.Attributes.Length, Is.EqualTo(0));
+            Assert.That(dochtml0body1table0tbody0.GetTagName(), Is.EqualTo("tbody"));
+            Assert.That(dochtml0body1table0tbody0.NodeType, Is.EqualTo(NodeType.Element));
 
             var dochtml0body1table0tbody0tr0 = dochtml0body1table0tbody0.ChildNodes[0] as IElement;
-            Assert.AreEqual(0, dochtml0body1table0tbody0tr0.ChildNodes.Length);
-            Assert.AreEqual(1, dochtml0body1table0tbody0tr0.Attributes.Length);
-            Assert.AreEqual("tr", dochtml0body1table0tbody0tr0.GetTagName());
-            Assert.AreEqual(NodeType.Element, dochtml0body1table0tbody0tr0.NodeType);
+            Assert.That(dochtml0body1table0tbody0tr0.ChildNodes.Length, Is.EqualTo(0));
+            Assert.That(dochtml0body1table0tbody0tr0.Attributes.Length, Is.EqualTo(1));
+            Assert.That(dochtml0body1table0tbody0tr0.GetTagName(), Is.EqualTo("tr"));
+            Assert.That(dochtml0body1table0tbody0tr0.NodeType, Is.EqualTo(NodeType.Element));
 
             var styleAttribute = dochtml0body1table0tbody0tr0.Attributes[0];
-            Assert.AreEqual("style", styleAttribute.Name);
-            Assert.AreEqual("display: none;", styleAttribute.Value);
+            Assert.That(styleAttribute.Name, Is.EqualTo("style"));
+            Assert.That(styleAttribute.Value, Is.EqualTo("display: none;"));
 
             var style = ((IHtmlElement)dochtml0body1table0tbody0tr0).GetStyle();
-            Assert.AreEqual("none", style.GetDisplay());
+            Assert.That(style.GetDisplay(), Is.EqualTo("none"));
         }
 
         [Test]
@@ -237,41 +237,41 @@ namespace AngleSharp.Css.Tests.Styling
             var doc = ParseDocument(@"<table><tr style=""display: none;"">");
 
             var html = doc.ChildNodes[0] as IElement;
-            Assert.AreEqual(2, html.ChildNodes.Length);
-            Assert.AreEqual(0, html.Attributes.Length);
-            Assert.AreEqual("html", html.GetTagName());
-            Assert.AreEqual(NodeType.Element, html.NodeType);
+            Assert.That(html.ChildNodes.Length, Is.EqualTo(2));
+            Assert.That(html.Attributes.Length, Is.EqualTo(0));
+            Assert.That(html.GetTagName(), Is.EqualTo("html"));
+            Assert.That(html.NodeType, Is.EqualTo(NodeType.Element));
 
             var body = html.ChildNodes[1] as IElement;
-            Assert.AreEqual(1, body.ChildNodes.Length);
-            Assert.AreEqual(0, body.Attributes.Length);
-            Assert.AreEqual("body", body.GetTagName());
-            Assert.AreEqual(NodeType.Element, body.NodeType);
+            Assert.That(body.ChildNodes.Length, Is.EqualTo(1));
+            Assert.That(body.Attributes.Length, Is.EqualTo(0));
+            Assert.That(body.GetTagName(), Is.EqualTo("body"));
+            Assert.That(body.NodeType, Is.EqualTo(NodeType.Element));
 
             var table = body.ChildNodes[0] as IElement;
-            Assert.AreEqual(1, table.ChildNodes.Length);
-            Assert.AreEqual(0, table.Attributes.Length);
-            Assert.AreEqual("table", table.GetTagName());
-            Assert.AreEqual(NodeType.Element, table.NodeType);
+            Assert.That(table.ChildNodes.Length, Is.EqualTo(1));
+            Assert.That(table.Attributes.Length, Is.EqualTo(0));
+            Assert.That(table.GetTagName(), Is.EqualTo("table"));
+            Assert.That(table.NodeType, Is.EqualTo(NodeType.Element));
 
             var tableBody = table.ChildNodes[0] as IElement;
-            Assert.AreEqual(1, tableBody.ChildNodes.Length);
-            Assert.AreEqual(0, tableBody.Attributes.Length);
-            Assert.AreEqual("tbody", tableBody.GetTagName());
-            Assert.AreEqual(NodeType.Element, tableBody.NodeType);
+            Assert.That(tableBody.ChildNodes.Length, Is.EqualTo(1));
+            Assert.That(tableBody.Attributes.Length, Is.EqualTo(0));
+            Assert.That(tableBody.GetTagName(), Is.EqualTo("tbody"));
+            Assert.That(tableBody.NodeType, Is.EqualTo(NodeType.Element));
 
             var tableRow = tableBody.ChildNodes[0] as IElement;
-            Assert.AreEqual(0, tableRow.ChildNodes.Length);
-            Assert.AreEqual(1, tableRow.Attributes.Length);
-            Assert.AreEqual("tr", tableRow.GetTagName());
-            Assert.AreEqual(NodeType.Element, tableRow.NodeType);
+            Assert.That(tableRow.ChildNodes.Length, Is.EqualTo(0));
+            Assert.That(tableRow.Attributes.Length, Is.EqualTo(1));
+            Assert.That(tableRow.GetTagName(), Is.EqualTo("tr"));
+            Assert.That(tableRow.NodeType, Is.EqualTo(NodeType.Element));
 
             var tr = (IHtmlElement)tableRow;
             var style = tr.GetStyle();
-            Assert.AreEqual("none", style.GetDisplay());
+            Assert.That(style.GetDisplay(), Is.EqualTo("none"));
 
             style.SetDisplay("block");
-            Assert.AreEqual("block", style.GetDisplay());
+            Assert.That(style.GetDisplay(), Is.EqualTo("block"));
         }
 
         [Test]
@@ -280,40 +280,40 @@ namespace AngleSharp.Css.Tests.Styling
             var doc = ParseDocument(@"<table><tr>");
 
             var html = doc.ChildNodes[0] as IElement;
-            Assert.AreEqual(2, html.ChildNodes.Length);
-            Assert.AreEqual(0, html.Attributes.Length);
-            Assert.AreEqual("html", html.GetTagName());
-            Assert.AreEqual(NodeType.Element, html.NodeType);
+            Assert.That(html.ChildNodes.Length, Is.EqualTo(2));
+            Assert.That(html.Attributes.Length, Is.EqualTo(0));
+            Assert.That(html.GetTagName(), Is.EqualTo("html"));
+            Assert.That(html.NodeType, Is.EqualTo(NodeType.Element));
 
             var body = html.ChildNodes[1] as IElement;
-            Assert.AreEqual(1, body.ChildNodes.Length);
-            Assert.AreEqual(0, body.Attributes.Length);
-            Assert.AreEqual("body", body.GetTagName());
-            Assert.AreEqual(NodeType.Element, body.NodeType);
+            Assert.That(body.ChildNodes.Length, Is.EqualTo(1));
+            Assert.That(body.Attributes.Length, Is.EqualTo(0));
+            Assert.That(body.GetTagName(), Is.EqualTo("body"));
+            Assert.That(body.NodeType, Is.EqualTo(NodeType.Element));
 
             var table = body.ChildNodes[0] as IElement;
-            Assert.AreEqual(1, table.ChildNodes.Length);
-            Assert.AreEqual(0, table.Attributes.Length);
-            Assert.AreEqual("table", table.GetTagName());
-            Assert.AreEqual(NodeType.Element, table.NodeType);
+            Assert.That(table.ChildNodes.Length, Is.EqualTo(1));
+            Assert.That(table.Attributes.Length, Is.EqualTo(0));
+            Assert.That(table.GetTagName(), Is.EqualTo("table"));
+            Assert.That(table.NodeType, Is.EqualTo(NodeType.Element));
 
             var tableBody = table.ChildNodes[0] as IElement;
-            Assert.AreEqual(1, tableBody.ChildNodes.Length);
-            Assert.AreEqual(0, tableBody.Attributes.Length);
-            Assert.AreEqual("tbody", tableBody.GetTagName());
-            Assert.AreEqual(NodeType.Element, tableBody.NodeType);
+            Assert.That(tableBody.ChildNodes.Length, Is.EqualTo(1));
+            Assert.That(tableBody.Attributes.Length, Is.EqualTo(0));
+            Assert.That(tableBody.GetTagName(), Is.EqualTo("tbody"));
+            Assert.That(tableBody.NodeType, Is.EqualTo(NodeType.Element));
 
             var tableRow = tableBody.ChildNodes[0] as IElement;
-            Assert.AreEqual(0, tableRow.ChildNodes.Length);
-            Assert.AreEqual(0, tableRow.Attributes.Length);
-            Assert.AreEqual("tr", tableRow.GetTagName());
-            Assert.AreEqual(NodeType.Element, tableRow.NodeType);
+            Assert.That(tableRow.ChildNodes.Length, Is.EqualTo(0));
+            Assert.That(tableRow.Attributes.Length, Is.EqualTo(0));
+            Assert.That(tableRow.GetTagName(), Is.EqualTo("tr"));
+            Assert.That(tableRow.NodeType, Is.EqualTo(NodeType.Element));
 
             var tr = (IHtmlElement)tableRow;
             var style = tr.GetStyle();
 
             style.SetDisplay("none");
-            Assert.AreEqual("none", style.GetDisplay());
+            Assert.That(style.GetDisplay(), Is.EqualTo("none"));
         }
 
         [Test]
@@ -326,7 +326,7 @@ namespace AngleSharp.Css.Tests.Styling
             // hang occurs only if this line is executed prior to setting the attribute
             // hang occurs when executing next line
             div.SetAttribute("style", "background-color: http://www.codeplex.com?url=&lt;SCRIPT&gt;a=/XSS/alert(a.source)&lt;/SCRIPT&gt;");
-            Assert.AreEqual("", div.GetStyle().GetBackgroundColor());
+            Assert.That(div.GetStyle().GetBackgroundColor(), Is.EqualTo(""));
         }
 
         [Test]
@@ -334,13 +334,13 @@ namespace AngleSharp.Css.Tests.Styling
         {
             var document = ParseDocument("<ul><li>First element");
             var elements = document.QuerySelectorAll("li").Css("color", "red");
-            Assert.AreEqual(1, elements.Length);
+            Assert.That(elements.Length, Is.EqualTo(1));
 
             var style = (elements[0] as IHtmlElement).GetStyle();
-            Assert.AreEqual(1, style.Length);
+            Assert.That(style.Length, Is.EqualTo(1));
 
-            Assert.AreEqual("color", style[0]);
-            Assert.AreEqual("rgba(255, 0, 0, 1)", style.GetColor());
+            Assert.That(style[0], Is.EqualTo("color"));
+            Assert.That(style.GetColor(), Is.EqualTo("rgba(255, 0, 0, 1)"));
         }
 
         [Test]
@@ -354,15 +354,15 @@ namespace AngleSharp.Css.Tests.Styling
                 font = "10px 'Tahoma'",
                 opacity = "0.5"
             });
-            Assert.AreEqual(1, elements.Length);
+            Assert.That(elements.Length, Is.EqualTo(1));
 
             var style = (elements[0] as IHtmlElement).GetStyle();
 
-            Assert.AreEqual("rgba(255, 0, 0, 1)", style.GetColor());
-            Assert.AreEqual("rgba(0, 128, 0, 1)", style.GetBackgroundColor());
-            Assert.AreEqual("\"Tahoma\"", style.GetFontFamily());
-            Assert.AreEqual("10px", style.GetFontSize());
-            Assert.AreEqual("0.5", style.GetOpacity());
+            Assert.That(style.GetColor(), Is.EqualTo("rgba(255, 0, 0, 1)"));
+            Assert.That(style.GetBackgroundColor(), Is.EqualTo("rgba(0, 128, 0, 1)"));
+            Assert.That(style.GetFontFamily(), Is.EqualTo("\"Tahoma\""));
+            Assert.That(style.GetFontSize(), Is.EqualTo("10px"));
+            Assert.That(style.GetOpacity(), Is.EqualTo("0.5"));
         }
 
         [Test]
@@ -370,39 +370,39 @@ namespace AngleSharp.Css.Tests.Styling
         {
             var document = ParseDocument("<ul><li>First element<li>Second element<li>third<li style='background-color:blue'>Last");
             var elements = document.QuerySelectorAll("li").Css("color", "red");
-            Assert.AreEqual(4, elements.Length);
+            Assert.That(elements.Length, Is.EqualTo(4));
 
             var style1 = (elements[0] as IHtmlElement).GetStyle();
-            Assert.AreEqual(1, style1.Length);
+            Assert.That(style1.Length, Is.EqualTo(1));
 
             var test1 = style1[0];
-            Assert.AreEqual("color", test1);
-            Assert.AreEqual("rgba(255, 0, 0, 1)", style1.GetPropertyValue(test1));
+            Assert.That(test1, Is.EqualTo("color"));
+            Assert.That(style1.GetPropertyValue(test1), Is.EqualTo("rgba(255, 0, 0, 1)"));
 
             var style2 = (elements[1] as IHtmlElement).GetStyle();
-            Assert.AreEqual(1, style2.Length);
+            Assert.That(style2.Length, Is.EqualTo(1));
 
             var test2 = style2[0];
-            Assert.AreEqual("color", test2);
-            Assert.AreEqual("rgba(255, 0, 0, 1)", style2.GetPropertyValue(test2));
+            Assert.That(test2, Is.EqualTo("color"));
+            Assert.That(style2.GetPropertyValue(test2), Is.EqualTo("rgba(255, 0, 0, 1)"));
 
             var style3 = (elements[2] as IHtmlElement).GetStyle();
-            Assert.AreEqual(1, style3.Length);
+            Assert.That(style3.Length, Is.EqualTo(1));
 
             var test3 = style3[0];
-            Assert.AreEqual("color", test3);
-            Assert.AreEqual("rgba(255, 0, 0, 1)", style3.GetPropertyValue(test3));
+            Assert.That(test3, Is.EqualTo("color"));
+            Assert.That(style3.GetPropertyValue(test3), Is.EqualTo("rgba(255, 0, 0, 1)"));
 
             var style4 = (elements[3] as IHtmlElement).GetStyle();
-            Assert.AreEqual(2, style4.Length);
+            Assert.That(style4.Length, Is.EqualTo(2));
 
             var background = style4[0];
-            Assert.AreEqual("background-color", background);
-            Assert.AreEqual("rgba(0, 0, 255, 1)", style4.GetPropertyValue(background));
+            Assert.That(background, Is.EqualTo("background-color"));
+            Assert.That(style4.GetPropertyValue(background), Is.EqualTo("rgba(0, 0, 255, 1)"));
 
             var color = style4[1];
-            Assert.AreEqual("color", color);
-            Assert.AreEqual("rgba(255, 0, 0, 1)", style4.GetPropertyValue(color));
+            Assert.That(color, Is.EqualTo("color"));
+            Assert.That(style4.GetPropertyValue(color), Is.EqualTo("rgba(255, 0, 0, 1)"));
         }
 
         [Test]
@@ -412,7 +412,7 @@ namespace AngleSharp.Css.Tests.Styling
             var div = dom.QuerySelector("div");
             var style = div.GetStyle();
 
-            Assert.AreEqual("background: left", style.CssText);
+            Assert.That(style.CssText, Is.EqualTo("background: left"));
         }
 
         [Test]
@@ -425,7 +425,7 @@ namespace AngleSharp.Css.Tests.Styling
             style.RemoveProperty("background-position-x");
             style.RemoveProperty("background-position-y");
 
-            Assert.AreEqual("background-image: initial; background-size: initial; background-repeat: initial; background-attachment: initial; background-origin: initial; background-clip: initial; background-color: initial", style.CssText);
+            Assert.That(style.CssText, Is.EqualTo("background-image: initial; background-size: initial; background-repeat: initial; background-attachment: initial; background-origin: initial; background-clip: initial; background-color: initial"));
         }
 
         [Test]
@@ -438,7 +438,7 @@ namespace AngleSharp.Css.Tests.Styling
             element.GetStyle().SetBorderWidth("1px");
             element.GetStyle().SetBorderStyle("solid");
             element.GetStyle().SetBorderColor("black");
-            Assert.AreEqual(expected, element.ToHtml());
+            Assert.That(element.ToHtml(), Is.EqualTo(expected));
         }
 
         [Test]
@@ -448,7 +448,7 @@ namespace AngleSharp.Css.Tests.Styling
             var htmlParser = browsingContext.GetService<IHtmlParser>();
             var document = htmlParser.ParseDocument("<html><body><b>Hello, World!</b></body></html>");
             var boldStyle = document.Body.FirstElementChild.ComputeCurrentStyle();
-            Assert.AreEqual("bolder", boldStyle.GetFontWeight());
+            Assert.That(boldStyle.GetFontWeight(), Is.EqualTo("bolder"));
         }
 
         [Test]
@@ -474,7 +474,7 @@ namespace AngleSharp.Css.Tests.Styling
             var htmlParser = browsingContext.GetService<IHtmlParser>();
             var document = htmlParser.ParseDocument("<html><head><style>body { color: red } @media only screen and (min-width: 600px) { body { color: green } }</style></head><body></body></html>");
             var style = document.Body.ComputeCurrentStyle();
-            Assert.AreEqual("rgba(0, 128, 0, 1)", style.GetColor());
+            Assert.That(style.GetColor(), Is.EqualTo("rgba(0, 128, 0, 1)"));
         }
 
         [Test]
@@ -490,7 +490,7 @@ namespace AngleSharp.Css.Tests.Styling
             var htmlParser = browsingContext.GetService<IHtmlParser>();
             var document = htmlParser.ParseDocument("<html><head><style>body { color: red } @media only screen and (min-width: 600px) { body { color: green } }</style></head><body></body></html>");
             var style = document.Body.ComputeCurrentStyle();
-            Assert.AreEqual("rgba(255, 0, 0, 1)", style.GetColor());
+            Assert.That(style.GetColor(), Is.EqualTo("rgba(255, 0, 0, 1)"));
         }
     }
 }

--- a/src/AngleSharp.Css.Tests/TestExtensions.cs
+++ b/src/AngleSharp.Css.Tests/TestExtensions.cs
@@ -16,7 +16,7 @@ namespace AngleSharp.Css.Tests
         {
             var element = node as IElement;
 
-            Assert.AreEqual(NodeType.Element, node.NodeType);
+            Assert.That(node.NodeType, Is.EqualTo(NodeType.Element));
             Assert.IsNotNull(element);
             Assert.IsNull(element.Prefix);
 

--- a/src/AngleSharp.Css.Tests/Values/Calc.cs
+++ b/src/AngleSharp.Css.Tests/Values/Calc.cs
@@ -13,7 +13,7 @@ namespace AngleSharp.Css.Tests.Values
         {
             var source = new StringSource(@"calc(5)");
             var calc = CalcParser.ParseCalc(source);
-            Assert.AreEqual("calc(5)", calc.CssText);
+            Assert.That(calc.CssText, Is.EqualTo("calc(5)"));
         }
 
         [Test]
@@ -21,7 +21,7 @@ namespace AngleSharp.Css.Tests.Values
         {
             var source = new StringSource(@"calc(5px)");
             var calc = CalcParser.ParseCalc(source);
-            Assert.AreEqual("calc(5px)", calc.CssText);
+            Assert.That(calc.CssText, Is.EqualTo("calc(5px)"));
         }
 
         [Test]
@@ -29,7 +29,7 @@ namespace AngleSharp.Css.Tests.Values
         {
             var source = new StringSource(@"calc(5 + 3)");
             var calc = CalcParser.ParseCalc(source);
-            Assert.AreEqual("calc(5 + 3)", calc.CssText);
+            Assert.That(calc.CssText, Is.EqualTo("calc(5 + 3)"));
         }
 
         [Test]
@@ -37,7 +37,7 @@ namespace AngleSharp.Css.Tests.Values
         {
             var source = new StringSource(@"calc(5 + (3 + 7))");
             var calc = CalcParser.ParseCalc(source);
-            Assert.AreEqual("calc(5 + (3 + 7))", calc.CssText);
+            Assert.That(calc.CssText, Is.EqualTo("calc(5 + (3 + 7))"));
         }
 
         [Test]
@@ -45,7 +45,7 @@ namespace AngleSharp.Css.Tests.Values
         {
             var source = new StringSource(@"calc(5 + calc(3 + 7))");
             var calc = CalcParser.ParseCalc(source);
-            Assert.AreEqual("calc(5 + (3 + 7))", calc.CssText);
+            Assert.That(calc.CssText, Is.EqualTo("calc(5 + (3 + 7))"));
         }
 
         [Test]
@@ -53,7 +53,7 @@ namespace AngleSharp.Css.Tests.Values
         {
             var source = new StringSource(@"calc(50% + 3px / 2em + -1cm)");
             var calc = CalcParser.ParseCalc(source);
-            Assert.AreEqual("calc(50% + 3px / 2em + -1cm)", calc.CssText);
+            Assert.That(calc.CssText, Is.EqualTo("calc(50% + 3px / 2em + -1cm)"));
         }
 
         [Test]
@@ -61,8 +61,8 @@ namespace AngleSharp.Css.Tests.Values
         {
             var source = @"transform: rotate(calc(45deg *2))";
             var property = ParseDeclaration(source);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("rotate(calc(45deg * 2))", property.Value);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("rotate(calc(45deg * 2))"));
         }
 
         [Test]
@@ -70,8 +70,8 @@ namespace AngleSharp.Css.Tests.Values
         {
             var source = @"transition-duration: calc(30ms + 2s)";
             var property = ParseDeclaration(source);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("calc(30ms + 2s)", property.Value);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("calc(30ms + 2s)"));
         }
 
         [Test]
@@ -79,8 +79,8 @@ namespace AngleSharp.Css.Tests.Values
         {
             var source = @"width: calc(50% - 200px)";
             var property = ParseDeclaration(source);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("calc(50% - 200px)", property.Value);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("calc(50% - 200px)"));
         }
 
         [Test]
@@ -88,8 +88,8 @@ namespace AngleSharp.Css.Tests.Values
         {
             var source = @"flex-shrink: calc(20/6)";
             var property = ParseDeclaration(source);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("calc(20 / 6)", property.Value);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("calc(20 / 6)"));
         }
 
         [Test]
@@ -97,8 +97,8 @@ namespace AngleSharp.Css.Tests.Values
         {
             var source = @"column-count: calc(21  +  5 -  4  *   2)";
             var property = ParseDeclaration(source);
-            Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("calc(21 + 5 - 4 * 2)", property.Value);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.Value, Is.EqualTo("calc(21 + 5 - 4 * 2)"));
         }
     }
 }

--- a/src/AngleSharp.Css.Tests/Values/Color.cs
+++ b/src/AngleSharp.Css.Tests/Values/Color.cs
@@ -11,7 +11,7 @@ namespace AngleSharp.Css.Tests.Values
         {
             var color = "BCDEFG";
             var result = CssColorValue.TryFromHex(color, out var hc);
-            Assert.IsFalse(result);
+            Assert.That(result, Is.False);
         }
 
         [Test]
@@ -19,8 +19,8 @@ namespace AngleSharp.Css.Tests.Values
         {
             var color = "abcd";
             var result = CssColorValue.TryFromHex(color, out var hc);
-            Assert.AreEqual(new CssColorValue(170, 187, 204, 221), hc);
-            Assert.IsTrue(result);
+            Assert.That(hc, Is.EqualTo(new CssColorValue(170, 187, 204, 221)));
+            Assert.That(result, Is.True);
         }
 
         [Test]
@@ -28,7 +28,7 @@ namespace AngleSharp.Css.Tests.Values
         {
             var color = "abcde";
             var result = CssColorValue.TryFromHex(color, out var hc);
-            Assert.IsFalse(result);
+            Assert.That(result, Is.False);
         }
 
         [Test]
@@ -36,7 +36,7 @@ namespace AngleSharp.Css.Tests.Values
         {
             var color = "fff";
             var result = CssColorValue.TryFromHex(color, out var hc);
-            Assert.IsTrue(result);
+            Assert.That(result, Is.True);
         }
 
         [Test]
@@ -44,7 +44,7 @@ namespace AngleSharp.Css.Tests.Values
         {
             var color = "fffabc";
             var result = CssColorValue.TryFromHex(color, out var hc);
-            Assert.IsTrue(result);
+            Assert.That(result, Is.True);
         }
 
         [Test]
@@ -52,7 +52,7 @@ namespace AngleSharp.Css.Tests.Values
         {
             var color = "fff";
             var result = CssColorValue.FromHex(color);
-            Assert.AreEqual(CssColorValue.FromRgb(255, 255, 255), result);
+            Assert.That(result, Is.EqualTo(CssColorValue.FromRgb(255, 255, 255)));
         }
 
         [Test]
@@ -60,7 +60,7 @@ namespace AngleSharp.Css.Tests.Values
         {
             var color = "f00";
             var result = CssColorValue.FromHex(color);
-            Assert.AreEqual(CssColorValue.FromRgb(255, 0, 0), result);
+            Assert.That(result, Is.EqualTo(CssColorValue.FromRgb(255, 0, 0)));
         }
 
         [Test]
@@ -68,8 +68,8 @@ namespace AngleSharp.Css.Tests.Values
         {
             var color = "red";
             var result = CssColorValue.FromName(color);
-            Assert.IsTrue(result.HasValue);
-            Assert.AreEqual(CssColorValue.Red, result);
+            Assert.That(result.HasValue, Is.True);
+            Assert.That(result, Is.EqualTo(CssColorValue.Red));
         }
 
         [Test]
@@ -77,8 +77,8 @@ namespace AngleSharp.Css.Tests.Values
         {
             var color = "white";
             var result = CssColorValue.FromName(color);
-            Assert.IsTrue(result.HasValue);
-            Assert.AreEqual(CssColorValue.White, result);
+            Assert.That(result.HasValue, Is.True);
+            Assert.That(result, Is.EqualTo(CssColorValue.White));
         }
 
         [Test]
@@ -86,7 +86,7 @@ namespace AngleSharp.Css.Tests.Values
         {
             var color = "bla";
             var result = CssColorValue.FromName(color);
-            Assert.IsFalse(result.HasValue);
+            Assert.That(result.HasValue, Is.False);
         }
 
         [Test]
@@ -94,7 +94,7 @@ namespace AngleSharp.Css.Tests.Values
         {
             var color = "facc36";
             var result = CssColorValue.FromHex(color);
-            Assert.AreEqual(CssColorValue.FromRgb(250, 204, 54), result);
+            Assert.That(result, Is.EqualTo(CssColorValue.FromRgb(250, 204, 54)));
         }
 
         [Test]
@@ -102,7 +102,7 @@ namespace AngleSharp.Css.Tests.Values
         {
             var color = "facc3600";
             var result = CssColorValue.FromHex(color);
-            Assert.AreEqual(CssColorValue.FromRgba(250, 204, 54, 0), result);
+            Assert.That(result, Is.EqualTo(CssColorValue.FromRgba(250, 204, 54, 0)));
         }
 
         [Test]
@@ -110,7 +110,7 @@ namespace AngleSharp.Css.Tests.Values
         {
             var color = "facc36ff";
             var result = CssColorValue.FromHex(color);
-            Assert.AreEqual(CssColorValue.FromRgba(250, 204, 54, 1), result);
+            Assert.That(result, Is.EqualTo(CssColorValue.FromRgba(250, 204, 54, 1)));
         }
 
         [Test]
@@ -119,7 +119,7 @@ namespace AngleSharp.Css.Tests.Values
             var color1 = CssColorValue.Black;
             var color2 = CssColorValue.White;
             var mix = CssColorValue.Mix(0.5, color1, color2);
-            Assert.AreEqual(CssColorValue.FromRgb(127, 127, 127), mix);
+            Assert.That(mix, Is.EqualTo(CssColorValue.FromRgb(127, 127, 127)));
         }
 
         [Test]
@@ -128,7 +128,7 @@ namespace AngleSharp.Css.Tests.Values
             var color1 = CssColorValue.Red;
             var color2 = CssColorValue.White;
             var mix = CssColorValue.Mix(0.75, color1, color2);
-            Assert.AreEqual(CssColorValue.FromRgb(255, 63, 63), mix);
+            Assert.That(mix, Is.EqualTo(CssColorValue.FromRgb(255, 63, 63)));
         }
 
         [Test]
@@ -137,7 +137,7 @@ namespace AngleSharp.Css.Tests.Values
             var color1 = CssColorValue.Blue;
             var color2 = CssColorValue.White;
             var mix = CssColorValue.Mix(0.1, color1, color2);
-            Assert.AreEqual(CssColorValue.FromRgb(229, 229, 255), mix);
+            Assert.That(mix, Is.EqualTo(CssColorValue.FromRgb(229, 229, 255)));
         }
 
         [Test]
@@ -146,7 +146,7 @@ namespace AngleSharp.Css.Tests.Values
             var color1 = CssColorValue.PureGreen;
             var color2 = CssColorValue.Red;
             var mix = CssColorValue.Mix(0.3, color1, color2);
-            Assert.AreEqual(CssColorValue.FromRgb(178, 76, 0), mix);
+            Assert.That(mix, Is.EqualTo(CssColorValue.FromRgb(178, 76, 0)));
         }
 
         [Test]
@@ -155,175 +155,175 @@ namespace AngleSharp.Css.Tests.Values
             var color1 = CssColorValue.White;
             var color2 = CssColorValue.Black;
             var mix = CssColorValue.Mix(0.2, color1, color2);
-            Assert.AreEqual(CssColorValue.FromRgb(51, 51, 51), mix);
+            Assert.That(mix, Is.EqualTo(CssColorValue.FromRgb(51, 51, 51)));
         }
 
         [Test]
         public void CssColorValueHslBlackMixed()
         {
             var color = CssColorValue.FromHsl(0, 1, 0);
-            Assert.AreEqual(CssColorValue.Black, color);
+            Assert.That(color, Is.EqualTo(CssColorValue.Black));
         }
 
         [Test]
         public void CssColorValueHslBlackMixed1()
         {
             var color = CssColorValue.FromHsl(0, 1, 0);
-            Assert.AreEqual(CssColorValue.Black, color);
+            Assert.That(color, Is.EqualTo(CssColorValue.Black));
         }
 
         [Test]
         public void CssColorValueHslBlackMixed2()
         {
             var color = CssColorValue.FromHsl(0.5f, 1, 0);
-            Assert.AreEqual(CssColorValue.Black, color);
+            Assert.That(color, Is.EqualTo(CssColorValue.Black));
         }
 
         [Test]
         public void CssColorValueHslRedPure()
         {
             var color = CssColorValue.FromHsl(0, 1, 0.5f);
-            Assert.AreEqual(CssColorValue.Red, color);
+            Assert.That(color, Is.EqualTo(CssColorValue.Red));
         }
 
         [Test]
         public void CssColorValueHslGreenPure()
         {
             var color = CssColorValue.FromHsl(1f / 3f, 1, 0.5f);
-            Assert.AreEqual(CssColorValue.PureGreen, color);
+            Assert.That(color, Is.EqualTo(CssColorValue.PureGreen));
         }
 
         [Test]
         public void CssColorValueHslBluePure()
         {
             var color = CssColorValue.FromHsl(2f / 3f, 1, 0.5f);
-            Assert.AreEqual(CssColorValue.Blue, color);
+            Assert.That(color, Is.EqualTo(CssColorValue.Blue));
         }
 
         [Test]
         public void CssColorValueHslBlackPure()
         {
             var color = CssColorValue.FromHsl(0, 0, 0);
-            Assert.AreEqual(CssColorValue.Black, color);
+            Assert.That(color, Is.EqualTo(CssColorValue.Black));
         }
 
         [Test]
         public void CssColorValueHslMagentaPure()
         {
             var color = CssColorValue.FromHsl(300f / 360f, 1, 0.5f);
-            Assert.AreEqual(CssColorValue.Magenta, color);
+            Assert.That(color, Is.EqualTo(CssColorValue.Magenta));
         }
 
         [Test]
         public void CssColorValueHslYellowGreenMixed()
         {
             var color = CssColorValue.FromHsl(1f / 4f, 0.75f, 0.63f);
-            Assert.AreEqual(CssColorValue.FromRgb(161, 232, 90), color);
+            Assert.That(color, Is.EqualTo(CssColorValue.FromRgb(161, 232, 90)));
         }
 
         [Test]
         public void CssColorValueHslGrayBlueMixed()
         {
             var color = CssColorValue.FromHsl(210f / 360f, 0.25f, 0.25f);
-            Assert.AreEqual(CssColorValue.FromRgb(48, 64, 80), color);
+            Assert.That(color, Is.EqualTo(CssColorValue.FromRgb(48, 64, 80)));
         }
 
         [Test]
         public void CssColorValueFlexHexOneLetter()
         {
             var color = CssColorValue.FromFlexHex("F");
-            Assert.AreEqual(CssColorValue.FromRgb(0xf, 0x0, 0x0), color);
+            Assert.That(color, Is.EqualTo(CssColorValue.FromRgb(0xf, 0x0, 0x0)));
         }
 
         [Test]
         public void CssColorValueFlexHexTwoLetters()
         {
             var color = CssColorValue.FromFlexHex("0F");
-            Assert.AreEqual(CssColorValue.FromRgb(0x0, 0xf, 0x0), color);
+            Assert.That(color, Is.EqualTo(CssColorValue.FromRgb(0x0, 0xf, 0x0)));
         }
 
         [Test]
         public void CssColorValueFlexHexFourLetters()
         {
             var color = CssColorValue.FromFlexHex("0F0F");
-            Assert.AreEqual(CssColorValue.FromRgb(0xf, 0xf, 0x0), color);
+            Assert.That(color, Is.EqualTo(CssColorValue.FromRgb(0xf, 0xf, 0x0)));
         }
 
         [Test]
         public void CssColorValueFlexHexSevenLetters()
         {
             var color = CssColorValue.FromFlexHex("0F0F0F0");
-            Assert.AreEqual(CssColorValue.FromRgb(0xf, 0xf0, 0x0), color);
+            Assert.That(color, Is.EqualTo(CssColorValue.FromRgb(0xf, 0xf0, 0x0)));
         }
 
         [Test]
         public void CssColorValueFlexHexFifteenLetters()
         {
             var color = CssColorValue.FromFlexHex("1234567890ABCDE");
-            Assert.AreEqual(CssColorValue.FromRgb(0x12, 0x67, 0xab), color);
+            Assert.That(color, Is.EqualTo(CssColorValue.FromRgb(0x12, 0x67, 0xab)));
         }
 
         [Test]
         public void CssColorValueFlexHexExtremelyLong()
         {
             var color = CssColorValue.FromFlexHex("1234567890ABCDE1234567890ABCDE");
-            Assert.AreEqual(CssColorValue.FromRgb(0x34, 0xcd, 0x89), color);
+            Assert.That(color, Is.EqualTo(CssColorValue.FromRgb(0x34, 0xcd, 0x89)));
         }
 
         [Test]
         public void CssColorValueFlexHexRandomString()
         {
             var color = CssColorValue.FromFlexHex("6db6ec49efd278cd0bc92d1e5e072d68");
-            Assert.AreEqual(CssColorValue.FromRgb(0x6e, 0xcd, 0xe0), color);
+            Assert.That(color, Is.EqualTo(CssColorValue.FromRgb(0x6e, 0xcd, 0xe0)));
         }
 
         [Test]
         public void CssColorValueFlexHexSixLettersInvalid()
         {
             var color = CssColorValue.FromFlexHex("zqbttv");
-            Assert.AreEqual(CssColorValue.FromRgb(0x0, 0xb0, 0x0), color);
+            Assert.That(color, Is.EqualTo(CssColorValue.FromRgb(0x0, 0xb0, 0x0)));
         }
 
         [Test]
         public void CssColorValueFromGraySimple()
         {
             var color = CssColorValue.FromGray(25);
-            Assert.AreEqual(CssColorValue.FromRgb(25, 25, 25), color);
+            Assert.That(color, Is.EqualTo(CssColorValue.FromRgb(25, 25, 25)));
         }
 
         [Test]
         public void CssColorValueFromGrayWithAlpha()
         {
             var color = CssColorValue.FromGray(25, 0.5f);
-            Assert.AreEqual(CssColorValue.FromRgba(25, 25, 25, 0.5f), color);
+            Assert.That(color, Is.EqualTo(CssColorValue.FromRgba(25, 25, 25, 0.5f)));
         }
 
         [Test]
         public void CssColorValueFromGrayPercent()
         {
             var color = CssColorValue.FromGray(0.5f, 0.5f);
-            Assert.AreEqual(CssColorValue.FromRgba(128, 128, 128, 0.5f), color);
+            Assert.That(color, Is.EqualTo(CssColorValue.FromRgba(128, 128, 128, 0.5f)));
         }
 
         [Test]
         public void CssColorValueFromHwbRed()
         {
             var color = CssColorValue.FromHwb(0f, 0.2f, 0.2f);
-            Assert.AreEqual(CssColorValue.FromRgb(204, 51, 51), color);
+            Assert.That(color, Is.EqualTo(CssColorValue.FromRgb(204, 51, 51)));
         }
 
         [Test]
         public void CssColorValueFromHwbGreen()
         {
             var color = CssColorValue.FromHwb(1f / 3f, 0.2f, 0.6f);
-            Assert.AreEqual(CssColorValue.FromRgb(51, 102, 51), color);
+            Assert.That(color, Is.EqualTo(CssColorValue.FromRgb(51, 102, 51)));
         }
 
         [Test]
         public void CssColorValueFromHwbMagentaTransparent()
         {
             var color = CssColorValue.FromHwba(5f / 6f, 0.4f, 0.2f, 0.5f);
-            Assert.AreEqual(CssColorValue.FromRgba(204, 102, 204, 0.5f), color);
+            Assert.That(color, Is.EqualTo(CssColorValue.FromRgba(204, 102, 204, 0.5f)));
         }
     }
 }

--- a/src/AngleSharp.Css.Tests/Values/ErrorHandling.cs
+++ b/src/AngleSharp.Css.Tests/Values/ErrorHandling.cs
@@ -20,9 +20,9 @@ namespace AngleSharp.Css.Tests.Values
                 IsIncludingUnknownRules = true
             });
             var div = document.QuerySelector<IHtmlElement>("div");
-            Assert.AreEqual(1, div.GetStyle().Length);
-            Assert.AreEqual("background-image", div.GetStyle()[0]);
-            Assert.AreEqual("url(\"javascript:alert(1)\")", div.GetStyle().GetBackgroundImage());
+            Assert.That(div.GetStyle().Length, Is.EqualTo(1));
+            Assert.That(div.GetStyle()[0], Is.EqualTo("background-image"));
+            Assert.That(div.GetStyle().GetBackgroundImage(), Is.EqualTo("url(\"javascript:alert(1)\")"));
         }
 
         [Test]
@@ -35,9 +35,9 @@ namespace AngleSharp.Css.Tests.Values
                 IsIncludingUnknownRules = true
             });
             var div = document.QuerySelector<IHtmlElement>("div");
-            Assert.AreEqual(10, div.GetStyle().Length);
+            Assert.That(div.GetStyle().Length, Is.EqualTo(10));
             div.GetStyle().RemoveProperty("background");
-            Assert.AreEqual(0, div.GetStyle().Length);
+            Assert.That(div.GetStyle().Length, Is.EqualTo(0));
         }
     }
 }

--- a/src/AngleSharp.Css.Tests/Values/Gradient.cs
+++ b/src/AngleSharp.Css.Tests/Values/Gradient.cs
@@ -33,20 +33,20 @@ namespace AngleSharp.Css.Tests.Values
             var blue = CssColorValue.Blue;
             var source = $"background-image: linear-gradient(135deg, {red.CssText}, {blue.CssText})";
             var property = ParseDeclaration(source);
-            Assert.IsTrue(property.HasValue);
-            Assert.IsFalse(property.IsInitial);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.IsInitial, Is.False);
             var value = property.RawValue as CssListValue;
             Assert.IsNotNull(value);
-            Assert.AreEqual(1, value.Items.Length);
+            Assert.That(value.Items.Length, Is.EqualTo(1));
             var gradient = value.Items[0] as CssLinearGradientValue;
             Assert.IsNotNull(gradient);
-            Assert.IsFalse(gradient.IsRepeating);
-            Assert.AreEqual(CssAngleValue.TripleHalfQuarter, gradient.Angle);
-            Assert.AreEqual(2, gradient.Stops.Length);
-            Assert.AreEqual(red, gradient.Stops.OfType<CssGradientStopValue>().First().Color);
-            Assert.AreEqual(blue, gradient.Stops.OfType<CssGradientStopValue>().Last().Color);
+            Assert.That(gradient.IsRepeating, Is.False);
+            Assert.That(gradient.Angle, Is.EqualTo(CssAngleValue.TripleHalfQuarter));
+            Assert.That(gradient.Stops.Length, Is.EqualTo(2));
+            Assert.That(gradient.Stops.OfType<CssGradientStopValue>().First().Color, Is.EqualTo(red));
+            Assert.That(gradient.Stops.OfType<CssGradientStopValue>().Last().Color, Is.EqualTo(blue));
 
-            Assert.AreEqual(source, property.CssText);
+            Assert.That(property.CssText, Is.EqualTo(source));
         }
 
         [Test]
@@ -54,23 +54,23 @@ namespace AngleSharp.Css.Tests.Values
         {
             var source = "background-image: linear-gradient(to right, red, orange, yellow, green, blue, indigo, violet)";
             var property = ParseDeclaration(source);
-            Assert.IsTrue(property.HasValue);
-            Assert.IsFalse(property.IsInitial);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.IsInitial, Is.False);
             var value = property.RawValue as CssListValue;
             Assert.IsNotNull(value);
-            Assert.AreEqual(1, value.Items.Length);
+            Assert.That(value.Items.Length, Is.EqualTo(1));
             var gradient = value.Items[0] as CssLinearGradientValue;
-            Assert.IsFalse(gradient.IsRepeating);
-            Assert.AreEqual(CssAngleValue.Quarter, gradient.Angle);
+            Assert.That(gradient.IsRepeating, Is.False);
+            Assert.That(gradient.Angle, Is.EqualTo(CssAngleValue.Quarter));
             var stops = gradient.Stops.ToArray();
-            Assert.AreEqual(7, stops.Length);
-            Assert.AreEqual(CssColors.GetColor("red").Value, ((CssGradientStopValue)stops[0]).Color);
-            Assert.AreEqual(CssColors.GetColor("orange").Value, ((CssGradientStopValue)stops[1]).Color);
-            Assert.AreEqual(CssColors.GetColor("yellow").Value, ((CssGradientStopValue)stops[2]).Color);
-            Assert.AreEqual(CssColors.GetColor("green").Value, ((CssGradientStopValue)stops[3]).Color);
-            Assert.AreEqual(CssColors.GetColor("blue").Value, ((CssGradientStopValue)stops[4]).Color);
-            Assert.AreEqual(CssColors.GetColor("indigo").Value, ((CssGradientStopValue)stops[5]).Color);
-            Assert.AreEqual(CssColors.GetColor("violet").Value, ((CssGradientStopValue)stops[6]).Color);
+            Assert.That(stops.Length, Is.EqualTo(7));
+            Assert.That(((CssGradientStopValue)stops[0]).Color, Is.EqualTo(CssColors.GetColor("red").Value));
+            Assert.That(((CssGradientStopValue)stops[1]).Color, Is.EqualTo(CssColors.GetColor("orange").Value));
+            Assert.That(((CssGradientStopValue)stops[2]).Color, Is.EqualTo(CssColors.GetColor("yellow").Value));
+            Assert.That(((CssGradientStopValue)stops[3]).Color, Is.EqualTo(CssColors.GetColor("green").Value));
+            Assert.That(((CssGradientStopValue)stops[4]).Color, Is.EqualTo(CssColors.GetColor("blue").Value));
+            Assert.That(((CssGradientStopValue)stops[5]).Color, Is.EqualTo(CssColors.GetColor("indigo").Value));
+            Assert.That(((CssGradientStopValue)stops[6]).Color, Is.EqualTo(CssColors.GetColor("violet").Value));
         }
 
         [Test]
@@ -78,17 +78,17 @@ namespace AngleSharp.Css.Tests.Values
         {
             var source = "background-image: linear-gradient(to bottom right, red, rgba(255,0,0,0))";
             var property = ParseDeclaration(source);
-            Assert.IsTrue(property.HasValue);
-            Assert.IsFalse(property.IsInitial);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.IsInitial, Is.False);
             var value = property.RawValue as CssListValue;
             Assert.IsNotNull(value);
-            Assert.AreEqual(1, value.Items.Length);
+            Assert.That(value.Items.Length, Is.EqualTo(1));
             var gradient = value.Items[0] as CssLinearGradientValue;
-            Assert.IsFalse(gradient.IsRepeating);
-            Assert.AreEqual(CssAngleValue.TripleHalfQuarter, gradient.Angle);
-            Assert.AreEqual(2, gradient.Stops.Count());
-            Assert.AreEqual(CssColorValue.Red, gradient.Stops.OfType<CssGradientStopValue>().First().Color);
-            Assert.AreEqual(CssColorValue.FromRgba(255, 0, 0, 0), gradient.Stops.OfType<CssGradientStopValue>().Last().Color);
+            Assert.That(gradient.IsRepeating, Is.False);
+            Assert.That(gradient.Angle, Is.EqualTo(CssAngleValue.TripleHalfQuarter));
+            Assert.That(gradient.Stops.Count(), Is.EqualTo(2));
+            Assert.That(gradient.Stops.OfType<CssGradientStopValue>().First().Color, Is.EqualTo(CssColorValue.Red));
+            Assert.That(gradient.Stops.OfType<CssGradientStopValue>().Last().Color, Is.EqualTo(CssColorValue.FromRgba(255, 0, 0, 0)));
         }
 
         [Test]
@@ -96,17 +96,17 @@ namespace AngleSharp.Css.Tests.Values
         {
             var source = "background-image: linear-gradient(to bottom, hsl(0, 80%, 70%), #bada55)";
             var property = ParseDeclaration(source);
-            Assert.IsTrue(property.HasValue);
-            Assert.IsFalse(property.IsInitial);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.IsInitial, Is.False);
             var value = property.RawValue as CssListValue;
             Assert.IsNotNull(value);
-            Assert.AreEqual(1, value.Items.Length);
+            Assert.That(value.Items.Length, Is.EqualTo(1));
             var gradient = value.Items[0] as CssLinearGradientValue;
-            Assert.IsFalse(gradient.IsRepeating);
-            Assert.AreEqual(CssAngleValue.Half, gradient.Angle);
-            Assert.AreEqual(2, gradient.Stops.Count());
-            Assert.AreEqual(CssColorValue.FromHsl(0f, 0.8f, 0.7f), gradient.Stops.OfType<CssGradientStopValue>().First().Color);
-            Assert.AreEqual(CssColorValue.FromHex("bada55"), gradient.Stops.OfType<CssGradientStopValue>().Last().Color);
+            Assert.That(gradient.IsRepeating, Is.False);
+            Assert.That(gradient.Angle, Is.EqualTo(CssAngleValue.Half));
+            Assert.That(gradient.Stops.Count(), Is.EqualTo(2));
+            Assert.That(gradient.Stops.OfType<CssGradientStopValue>().First().Color, Is.EqualTo(CssColorValue.FromHsl(0f, 0.8f, 0.7f)));
+            Assert.That(gradient.Stops.OfType<CssGradientStopValue>().Last().Color, Is.EqualTo(CssColorValue.FromHex("bada55")));
         }
 
         [Test]
@@ -114,18 +114,18 @@ namespace AngleSharp.Css.Tests.Values
         {
             var source = "background-image: linear-gradient(yellow, blue 20%, #0f0)";
             var property = ParseDeclaration(source);
-            Assert.IsTrue(property.HasValue);
-            Assert.IsFalse(property.IsInitial);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.IsInitial, Is.False);
             var value = property.RawValue as CssListValue;
             Assert.IsNotNull(value);
-            Assert.AreEqual(1, value.Items.Length);
+            Assert.That(value.Items.Length, Is.EqualTo(1));
             var gradient = value.Items[0] as CssLinearGradientValue;
-            Assert.IsFalse(gradient.IsRepeating);
-            Assert.AreEqual(CssAngleValue.Half, gradient.Angle);
-            Assert.AreEqual(3, gradient.Stops.Count());
-            Assert.AreEqual(CssColors.GetColor("yellow").Value, gradient.Stops.OfType<CssGradientStopValue>().First().Color);
-            Assert.AreEqual(CssColors.GetColor("blue").Value, gradient.Stops.OfType<CssGradientStopValue>().Skip(1).First().Color);
-            Assert.AreEqual(CssColorValue.FromRgb(0, 255, 0), gradient.Stops.OfType<CssGradientStopValue>().Skip(2).First().Color);
+            Assert.That(gradient.IsRepeating, Is.False);
+            Assert.That(gradient.Angle, Is.EqualTo(CssAngleValue.Half));
+            Assert.That(gradient.Stops.Count(), Is.EqualTo(3));
+            Assert.That(gradient.Stops.OfType<CssGradientStopValue>().First().Color, Is.EqualTo(CssColors.GetColor("yellow").Value));
+            Assert.That(gradient.Stops.OfType<CssGradientStopValue>().Skip(1).First().Color, Is.EqualTo(CssColors.GetColor("blue").Value));
+            Assert.That(gradient.Stops.OfType<CssGradientStopValue>().Skip(2).First().Color, Is.EqualTo(CssColorValue.FromRgb(0, 255, 0)));
         }
 
         [Test]
@@ -133,22 +133,22 @@ namespace AngleSharp.Css.Tests.Values
         {
             var source = "background-image: radial-gradient(circle farthest-corner at 45px 45px , #00FFFF 0%, rgba(0, 0, 255, 0) 50%, #0000FF 95%)";
             var property = ParseDeclaration(source);
-            Assert.IsTrue(property.HasValue);
-            Assert.IsFalse(property.IsInitial);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.IsInitial, Is.False);
             var value = property.RawValue as CssListValue;
             Assert.IsNotNull(value);
-            Assert.AreEqual(1, value.Items.Length);
+            Assert.That(value.Items.Length, Is.EqualTo(1));
             var gradient = value.Items[0] as CssRadialGradientValue;
-            Assert.IsFalse(gradient.IsRepeating);
-            Assert.AreEqual(new CssLengthValue(45, CssLengthValue.Unit.Px), gradient.Position.X);
-            Assert.AreEqual(new CssLengthValue(45, CssLengthValue.Unit.Px), gradient.Position.Y);
-            Assert.AreEqual(true, gradient.IsCircle);
-            Assert.AreEqual(CssRadialGradientValue.SizeMode.FarthestCorner, gradient.Mode);
+            Assert.That(gradient.IsRepeating, Is.False);
+            Assert.That(gradient.Position.X, Is.EqualTo(new CssLengthValue(45, CssLengthValue.Unit.Px)));
+            Assert.That(gradient.Position.Y, Is.EqualTo(new CssLengthValue(45, CssLengthValue.Unit.Px)));
+            Assert.That(gradient.IsCircle, Is.EqualTo(true));
+            Assert.That(gradient.Mode, Is.EqualTo(CssRadialGradientValue.SizeMode.FarthestCorner));
             var stops = gradient.Stops.ToArray();
-            Assert.AreEqual(3, stops.Length);
-            Assert.AreEqual(CssColorValue.FromRgb(0, 255, 255), ((CssGradientStopValue)stops[0]).Color);
-            Assert.AreEqual(CssColorValue.FromRgba(0, 0, 255, 0), ((CssGradientStopValue)stops[1]).Color);
-            Assert.AreEqual(CssColorValue.FromRgb(0, 0, 255), ((CssGradientStopValue)stops[2]).Color);
+            Assert.That(stops.Length, Is.EqualTo(3));
+            Assert.That(((CssGradientStopValue)stops[0]).Color, Is.EqualTo(CssColorValue.FromRgb(0, 255, 255)));
+            Assert.That(((CssGradientStopValue)stops[1]).Color, Is.EqualTo(CssColorValue.FromRgba(0, 0, 255, 0)));
+            Assert.That(((CssGradientStopValue)stops[2]).Color, Is.EqualTo(CssColorValue.FromRgb(0, 0, 255)));
         }
 
         [Test]
@@ -156,22 +156,22 @@ namespace AngleSharp.Css.Tests.Values
         {
             var source = "background-image: radial-gradient(ellipse farthest-corner at 470px 47px , #FFFF80 20%, rgba(204, 153, 153, 0.4) 30%, #E6E6FF 60%)";
             var property = ParseDeclaration(source);
-            Assert.IsTrue(property.HasValue);
-            Assert.IsFalse(property.IsInitial);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.IsInitial, Is.False);
             var value = property.RawValue as CssListValue;
             Assert.IsNotNull(value);
-            Assert.AreEqual(1, value.Items.Length);
+            Assert.That(value.Items.Length, Is.EqualTo(1));
             var gradient = value.Items[0] as CssRadialGradientValue;
-            Assert.IsFalse(gradient.IsRepeating);
-            Assert.AreEqual(new CssLengthValue(470, CssLengthValue.Unit.Px), gradient.Position.X);
-            Assert.AreEqual(new CssLengthValue(47, CssLengthValue.Unit.Px), gradient.Position.Y);
-            Assert.AreEqual(false, gradient.IsCircle);
-            Assert.AreEqual(CssRadialGradientValue.SizeMode.FarthestCorner, gradient.Mode);
+            Assert.That(gradient.IsRepeating, Is.False);
+            Assert.That(gradient.Position.X, Is.EqualTo(new CssLengthValue(470, CssLengthValue.Unit.Px)));
+            Assert.That(gradient.Position.Y, Is.EqualTo(new CssLengthValue(47, CssLengthValue.Unit.Px)));
+            Assert.That(gradient.IsCircle, Is.EqualTo(false));
+            Assert.That(gradient.Mode, Is.EqualTo(CssRadialGradientValue.SizeMode.FarthestCorner));
             var stops = gradient.Stops.ToArray();
-            Assert.AreEqual(3, stops.Length);
-            Assert.AreEqual(CssColorValue.FromRgb(0xFF, 0xFF, 0x80), ((CssGradientStopValue)stops[0]).Color);
-            Assert.AreEqual(CssColorValue.FromRgba(204, 153, 153, 0.4f), ((CssGradientStopValue)stops[1]).Color);
-            Assert.AreEqual(CssColorValue.FromRgb(0xE6, 0xE6, 0xFF), ((CssGradientStopValue)stops[2]).Color);
+            Assert.That(stops.Length, Is.EqualTo(3));
+            Assert.That(((CssGradientStopValue)stops[0]).Color, Is.EqualTo(CssColorValue.FromRgb(0xFF, 0xFF, 0x80)));
+            Assert.That(((CssGradientStopValue)stops[1]).Color, Is.EqualTo(CssColorValue.FromRgba(204, 153, 153, 0.4f)));
+            Assert.That(((CssGradientStopValue)stops[2]).Color, Is.EqualTo(CssColorValue.FromRgb(0xE6, 0xE6, 0xFF)));
         }
 
         [Test]
@@ -179,21 +179,21 @@ namespace AngleSharp.Css.Tests.Values
         {
             var source = "background-image: radial-gradient(farthest-corner at 45px 45px , #FF0000 0%, #0000FF 100%)";
             var property = ParseDeclaration(source);
-            Assert.IsTrue(property.HasValue);
-            Assert.IsFalse(property.IsInitial);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.IsInitial, Is.False);
             var value = property.RawValue as CssListValue;
             Assert.IsNotNull(value);
-            Assert.AreEqual(1, value.Items.Length);
+            Assert.That(value.Items.Length, Is.EqualTo(1));
             var gradient = value.Items[0] as CssRadialGradientValue;
-            Assert.IsFalse(gradient.IsRepeating);
-            Assert.AreEqual(new CssLengthValue(45, CssLengthValue.Unit.Px), gradient.Position.X);
-            Assert.AreEqual(new CssLengthValue(45, CssLengthValue.Unit.Px), gradient.Position.Y);
-            Assert.AreEqual(false, gradient.IsCircle);
-            Assert.AreEqual(CssRadialGradientValue.SizeMode.FarthestCorner, gradient.Mode);
+            Assert.That(gradient.IsRepeating, Is.False);
+            Assert.That(gradient.Position.X, Is.EqualTo(new CssLengthValue(45, CssLengthValue.Unit.Px)));
+            Assert.That(gradient.Position.Y, Is.EqualTo(new CssLengthValue(45, CssLengthValue.Unit.Px)));
+            Assert.That(gradient.IsCircle, Is.EqualTo(false));
+            Assert.That(gradient.Mode, Is.EqualTo(CssRadialGradientValue.SizeMode.FarthestCorner));
             var stops = gradient.Stops.ToArray();
-            Assert.AreEqual(2, stops.Length);
-            Assert.AreEqual(CssColorValue.FromRgb(255, 0, 0), ((CssGradientStopValue)stops[0]).Color);
-            Assert.AreEqual(CssColorValue.FromRgb(0, 0, 255), ((CssGradientStopValue)stops[1]).Color);
+            Assert.That(stops.Length, Is.EqualTo(2));
+            Assert.That(((CssGradientStopValue)stops[0]).Color, Is.EqualTo(CssColorValue.FromRgb(255, 0, 0)));
+            Assert.That(((CssGradientStopValue)stops[1]).Color, Is.EqualTo(CssColorValue.FromRgb(0, 0, 255)));
         }
 
         [Test]
@@ -201,25 +201,25 @@ namespace AngleSharp.Css.Tests.Values
         {
             var source = "background-image: radial-gradient(16px at 60px 50% , #000000 0%, #000000 14px, rgba(0, 0, 0, 0.3) 18px, rgba(0, 0, 0, 0) 19px)";
             var property = ParseDeclaration(source);
-            Assert.IsTrue(property.HasValue);
-            Assert.IsFalse(property.IsInitial);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.IsInitial, Is.False);
             var value = property.RawValue as CssListValue;
             Assert.IsNotNull(value);
-            Assert.AreEqual(1, value.Items.Length);
+            Assert.That(value.Items.Length, Is.EqualTo(1));
             var gradient = value.Items[0] as CssRadialGradientValue;
-            Assert.IsFalse(gradient.IsRepeating);
-            Assert.AreEqual(new CssLengthValue(60f, CssLengthValue.Unit.Px), gradient.Position.X);
-            Assert.AreEqual(CssLengthValue.Half, gradient.Position.Y);
-            Assert.AreEqual(true, gradient.IsCircle);
-            Assert.AreEqual(CssRadialGradientValue.SizeMode.None, gradient.Mode);
-            Assert.AreEqual(new CssLengthValue(16f, CssLengthValue.Unit.Px), gradient.MajorRadius);
-            Assert.AreEqual(CssLengthValue.Full, gradient.MinorRadius);
+            Assert.That(gradient.IsRepeating, Is.False);
+            Assert.That(gradient.Position.X, Is.EqualTo(new CssLengthValue(60f, CssLengthValue.Unit.Px)));
+            Assert.That(gradient.Position.Y, Is.EqualTo(CssLengthValue.Half));
+            Assert.That(gradient.IsCircle, Is.EqualTo(true));
+            Assert.That(gradient.Mode, Is.EqualTo(CssRadialGradientValue.SizeMode.None));
+            Assert.That(gradient.MajorRadius, Is.EqualTo(new CssLengthValue(16f, CssLengthValue.Unit.Px)));
+            Assert.That(gradient.MinorRadius, Is.EqualTo(CssLengthValue.Full));
             var stops = gradient.Stops.ToArray();
-            Assert.AreEqual(4, stops.Length);
-            Assert.AreEqual(CssColorValue.FromRgb(0, 0, 0), ((CssGradientStopValue)stops[0]).Color);
-            Assert.AreEqual(CssColorValue.FromRgb(0, 0, 0), ((CssGradientStopValue)stops[1]).Color);
-            Assert.AreEqual(CssColorValue.FromRgba(0, 0, 0, 0.3), ((CssGradientStopValue)stops[2]).Color);
-            Assert.AreEqual(CssColorValue.Transparent, ((CssGradientStopValue)stops[3]).Color);
+            Assert.That(stops.Length, Is.EqualTo(4));
+            Assert.That(((CssGradientStopValue)stops[0]).Color, Is.EqualTo(CssColorValue.FromRgb(0, 0, 0)));
+            Assert.That(((CssGradientStopValue)stops[1]).Color, Is.EqualTo(CssColorValue.FromRgb(0, 0, 0)));
+            Assert.That(((CssGradientStopValue)stops[2]).Color, Is.EqualTo(CssColorValue.FromRgba(0, 0, 0, 0.3)));
+            Assert.That(((CssGradientStopValue)stops[3]).Color, Is.EqualTo(CssColorValue.Transparent));
         }
 
         [Test]
@@ -227,21 +227,21 @@ namespace AngleSharp.Css.Tests.Values
         {
             var source = "background-image: radial-gradient(circle, yellow, green)";
             var property = ParseDeclaration(source);
-            Assert.IsTrue(property.HasValue);
-            Assert.IsFalse(property.IsInitial);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.IsInitial, Is.False);
             var value = property.RawValue as CssListValue;
             Assert.IsNotNull(value);
-            Assert.AreEqual(1, value.Items.Length);
+            Assert.That(value.Items.Length, Is.EqualTo(1));
             var gradient = value.Items[0] as CssRadialGradientValue;
-            Assert.IsFalse(gradient.IsRepeating);
-            Assert.AreEqual(CssLengthValue.Half, gradient.Position.X);
-            Assert.AreEqual(CssLengthValue.Half, gradient.Position.Y);
-            Assert.AreEqual(true, gradient.IsCircle);
-            Assert.AreEqual(CssRadialGradientValue.SizeMode.None, gradient.Mode);
+            Assert.That(gradient.IsRepeating, Is.False);
+            Assert.That(gradient.Position.X, Is.EqualTo(CssLengthValue.Half));
+            Assert.That(gradient.Position.Y, Is.EqualTo(CssLengthValue.Half));
+            Assert.That(gradient.IsCircle, Is.EqualTo(true));
+            Assert.That(gradient.Mode, Is.EqualTo(CssRadialGradientValue.SizeMode.None));
             var stops = gradient.Stops.ToArray();
-            Assert.AreEqual(2, stops.Length);
-            Assert.AreEqual(CssColorValue.FromName("yellow").Value, ((CssGradientStopValue)stops[0]).Color);
-            Assert.AreEqual(CssColorValue.FromName("green").Value, ((CssGradientStopValue)stops[1]).Color);
+            Assert.That(stops.Length, Is.EqualTo(2));
+            Assert.That(((CssGradientStopValue)stops[0]).Color, Is.EqualTo(CssColorValue.FromName("yellow").Value));
+            Assert.That(((CssGradientStopValue)stops[1]).Color, Is.EqualTo(CssColorValue.FromName("green").Value));
         }
 
         [Test]
@@ -249,21 +249,21 @@ namespace AngleSharp.Css.Tests.Values
         {
             var source = "background-image: radial-gradient(yellow, green)";
             var property = ParseDeclaration(source);
-            Assert.IsTrue(property.HasValue);
-            Assert.IsFalse(property.IsInitial);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.IsInitial, Is.False);
             var value = property.RawValue as CssListValue;
             Assert.IsNotNull(value);
-            Assert.AreEqual(1, value.Items.Length);
+            Assert.That(value.Items.Length, Is.EqualTo(1));
             var gradient = value.Items[0] as CssRadialGradientValue;
-            Assert.IsFalse(gradient.IsRepeating);
-            Assert.AreEqual(CssLengthValue.Half, gradient.Position.X);
-            Assert.AreEqual(CssLengthValue.Half, gradient.Position.Y);
-            Assert.AreEqual(false, gradient.IsCircle);
-            Assert.AreEqual(CssRadialGradientValue.SizeMode.None, gradient.Mode);
+            Assert.That(gradient.IsRepeating, Is.False);
+            Assert.That(gradient.Position.X, Is.EqualTo(CssLengthValue.Half));
+            Assert.That(gradient.Position.Y, Is.EqualTo(CssLengthValue.Half));
+            Assert.That(gradient.IsCircle, Is.EqualTo(false));
+            Assert.That(gradient.Mode, Is.EqualTo(CssRadialGradientValue.SizeMode.None));
             var stops = gradient.Stops.ToArray();
-            Assert.AreEqual(2, stops.Length);
-            Assert.AreEqual(CssColorValue.FromName("yellow").Value, ((CssGradientStopValue)stops[0]).Color);
-            Assert.AreEqual(CssColorValue.FromName("green").Value, ((CssGradientStopValue)stops[1]).Color);
+            Assert.That(stops.Length, Is.EqualTo(2));
+            Assert.That(((CssGradientStopValue)stops[0]).Color, Is.EqualTo(CssColorValue.FromName("yellow").Value));
+            Assert.That(((CssGradientStopValue)stops[1]).Color, Is.EqualTo(CssColorValue.FromName("green").Value));
         }
 
         [Test]
@@ -271,21 +271,21 @@ namespace AngleSharp.Css.Tests.Values
         {
             var source = "background-image: radial-gradient(ellipse at center, yellow 0%, green 100%)";
             var property = ParseDeclaration(source);
-            Assert.IsTrue(property.HasValue);
-            Assert.IsFalse(property.IsInitial);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.IsInitial, Is.False);
             var value = property.RawValue as CssListValue;
             Assert.IsNotNull(value);
-            Assert.AreEqual(1, value.Items.Length);
+            Assert.That(value.Items.Length, Is.EqualTo(1));
             var gradient = value.Items[0] as CssRadialGradientValue;
-            Assert.IsFalse(gradient.IsRepeating);
-            Assert.AreEqual(CssLengthValue.Half, gradient.Position.X);
-            Assert.AreEqual(CssLengthValue.Half, gradient.Position.Y);
-            Assert.AreEqual(false, gradient.IsCircle);
-            Assert.AreEqual(CssRadialGradientValue.SizeMode.None, gradient.Mode);
+            Assert.That(gradient.IsRepeating, Is.False);
+            Assert.That(gradient.Position.X, Is.EqualTo(CssLengthValue.Half));
+            Assert.That(gradient.Position.Y, Is.EqualTo(CssLengthValue.Half));
+            Assert.That(gradient.IsCircle, Is.EqualTo(false));
+            Assert.That(gradient.Mode, Is.EqualTo(CssRadialGradientValue.SizeMode.None));
             var stops = gradient.Stops.ToArray();
-            Assert.AreEqual(2, stops.Length);
-            Assert.AreEqual(CssColorValue.FromName("yellow").Value, ((CssGradientStopValue)stops[0]).Color);
-            Assert.AreEqual(CssColorValue.FromName("green").Value, ((CssGradientStopValue)stops[1]).Color);
+            Assert.That(stops.Length, Is.EqualTo(2));
+            Assert.That(((CssGradientStopValue)stops[0]).Color, Is.EqualTo(CssColorValue.FromName("yellow").Value));
+            Assert.That(((CssGradientStopValue)stops[1]).Color, Is.EqualTo(CssColorValue.FromName("green").Value));
         }
 
         [Test]
@@ -293,21 +293,21 @@ namespace AngleSharp.Css.Tests.Values
         {
             var source = "background-image: radial-gradient(farthest-corner, yellow, green)";
             var property = ParseDeclaration(source);
-            Assert.IsTrue(property.HasValue);
-            Assert.IsFalse(property.IsInitial);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.IsInitial, Is.False);
             var value = property.RawValue as CssListValue;
             Assert.IsNotNull(value);
-            Assert.AreEqual(1, value.Items.Length);
+            Assert.That(value.Items.Length, Is.EqualTo(1));
             var gradient = value.Items[0] as CssRadialGradientValue;
-            Assert.IsFalse(gradient.IsRepeating);
-            Assert.AreEqual(CssLengthValue.Half, gradient.Position.X);
-            Assert.AreEqual(CssLengthValue.Half, gradient.Position.Y);
-            Assert.AreEqual(false, gradient.IsCircle);
-            Assert.AreEqual(CssRadialGradientValue.SizeMode.FarthestCorner, gradient.Mode);
+            Assert.That(gradient.IsRepeating, Is.False);
+            Assert.That(gradient.Position.X, Is.EqualTo(CssLengthValue.Half));
+            Assert.That(gradient.Position.Y, Is.EqualTo(CssLengthValue.Half));
+            Assert.That(gradient.IsCircle, Is.EqualTo(false));
+            Assert.That(gradient.Mode, Is.EqualTo(CssRadialGradientValue.SizeMode.FarthestCorner));
             var stops = gradient.Stops.ToArray();
-            Assert.AreEqual(2, stops.Length);
-            Assert.AreEqual(CssColorValue.FromName("yellow").Value, ((CssGradientStopValue)stops[0]).Color);
-            Assert.AreEqual(CssColorValue.FromName("green").Value, ((CssGradientStopValue)stops[1]).Color);
+            Assert.That(stops.Length, Is.EqualTo(2));
+            Assert.That(((CssGradientStopValue)stops[0]).Color, Is.EqualTo(CssColorValue.FromName("yellow").Value));
+            Assert.That(((CssGradientStopValue)stops[1]).Color, Is.EqualTo(CssColorValue.FromName("green").Value));
         }
 
         [Test]
@@ -315,22 +315,22 @@ namespace AngleSharp.Css.Tests.Values
         {
             var source = "background-image: radial-gradient(closest-side at 20px 30px, red, yellow, green)";
             var property = ParseDeclaration(source);
-            Assert.IsTrue(property.HasValue);
-            Assert.IsFalse(property.IsInitial);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.IsInitial, Is.False);
             var value = property.RawValue as CssListValue;
             Assert.IsNotNull(value);
-            Assert.AreEqual(1, value.Items.Length);
+            Assert.That(value.Items.Length, Is.EqualTo(1));
             var gradient = value.Items[0] as CssRadialGradientValue;
-            Assert.IsFalse(gradient.IsRepeating);
-            Assert.AreEqual(new CssLengthValue(20f, CssLengthValue.Unit.Px), gradient.Position.X);
-            Assert.AreEqual(new CssLengthValue(30f, CssLengthValue.Unit.Px), gradient.Position.Y);
-            Assert.AreEqual(false, gradient.IsCircle);
-            Assert.AreEqual(CssRadialGradientValue.SizeMode.ClosestSide, gradient.Mode);
+            Assert.That(gradient.IsRepeating, Is.False);
+            Assert.That(gradient.Position.X, Is.EqualTo(new CssLengthValue(20f, CssLengthValue.Unit.Px)));
+            Assert.That(gradient.Position.Y, Is.EqualTo(new CssLengthValue(30f, CssLengthValue.Unit.Px)));
+            Assert.That(gradient.IsCircle, Is.EqualTo(false));
+            Assert.That(gradient.Mode, Is.EqualTo(CssRadialGradientValue.SizeMode.ClosestSide));
             var stops = gradient.Stops.ToArray();
-            Assert.AreEqual(3, stops.Length);
-            Assert.AreEqual(CssColorValue.FromName("red").Value, ((CssGradientStopValue)stops[0]).Color);
-            Assert.AreEqual(CssColorValue.FromName("yellow").Value, ((CssGradientStopValue)stops[1]).Color);
-            Assert.AreEqual(CssColorValue.FromName("green").Value, ((CssGradientStopValue)stops[2]).Color);
+            Assert.That(stops.Length, Is.EqualTo(3));
+            Assert.That(((CssGradientStopValue)stops[0]).Color, Is.EqualTo(CssColorValue.FromName("red").Value));
+            Assert.That(((CssGradientStopValue)stops[1]).Color, Is.EqualTo(CssColorValue.FromName("yellow").Value));
+            Assert.That(((CssGradientStopValue)stops[2]).Color, Is.EqualTo(CssColorValue.FromName("green").Value));
         }
 
         [Test]
@@ -338,24 +338,24 @@ namespace AngleSharp.Css.Tests.Values
         {
             var source = "background-image: radial-gradient(20px 30px at 20px 30px, red, yellow, green)";
             var property = ParseDeclaration(source);
-            Assert.IsTrue(property.HasValue);
-            Assert.IsFalse(property.IsInitial);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.IsInitial, Is.False);
             var value = property.RawValue as CssListValue;
             Assert.IsNotNull(value);
-            Assert.AreEqual(1, value.Items.Length);
+            Assert.That(value.Items.Length, Is.EqualTo(1));
             var gradient = value.Items[0] as CssRadialGradientValue;
-            Assert.IsFalse(gradient.IsRepeating);
-            Assert.AreEqual(new CssLengthValue(20f, CssLengthValue.Unit.Px), gradient.Position.X);
-            Assert.AreEqual(new CssLengthValue(30f, CssLengthValue.Unit.Px), gradient.Position.Y);
-            Assert.AreEqual(false, gradient.IsCircle);
-            Assert.AreEqual(CssRadialGradientValue.SizeMode.None, gradient.Mode);
-            Assert.AreEqual(new CssLengthValue(20f, CssLengthValue.Unit.Px), gradient.MajorRadius);
-            Assert.AreEqual(new CssLengthValue(30f, CssLengthValue.Unit.Px), gradient.MinorRadius);
+            Assert.That(gradient.IsRepeating, Is.False);
+            Assert.That(gradient.Position.X, Is.EqualTo(new CssLengthValue(20f, CssLengthValue.Unit.Px)));
+            Assert.That(gradient.Position.Y, Is.EqualTo(new CssLengthValue(30f, CssLengthValue.Unit.Px)));
+            Assert.That(gradient.IsCircle, Is.EqualTo(false));
+            Assert.That(gradient.Mode, Is.EqualTo(CssRadialGradientValue.SizeMode.None));
+            Assert.That(gradient.MajorRadius, Is.EqualTo(new CssLengthValue(20f, CssLengthValue.Unit.Px)));
+            Assert.That(gradient.MinorRadius, Is.EqualTo(new CssLengthValue(30f, CssLengthValue.Unit.Px)));
             var stops = gradient.Stops.ToArray();
-            Assert.AreEqual(3, stops.Length);
-            Assert.AreEqual(CssColorValue.FromName("red").Value, ((CssGradientStopValue)stops[0]).Color);
-            Assert.AreEqual(CssColorValue.FromName("yellow").Value, ((CssGradientStopValue)stops[1]).Color);
-            Assert.AreEqual(CssColorValue.FromName("green").Value, ((CssGradientStopValue)stops[2]).Color);
+            Assert.That(stops.Length, Is.EqualTo(3));
+            Assert.That(((CssGradientStopValue)stops[0]).Color, Is.EqualTo(CssColorValue.FromName("red").Value));
+            Assert.That(((CssGradientStopValue)stops[1]).Color, Is.EqualTo(CssColorValue.FromName("yellow").Value));
+            Assert.That(((CssGradientStopValue)stops[2]).Color, Is.EqualTo(CssColorValue.FromName("green").Value));
         }
 
         [Test]
@@ -363,22 +363,22 @@ namespace AngleSharp.Css.Tests.Values
         {
             var source = "background-image: radial-gradient(closest-side circle at 20px 30px, red, yellow, green)";
             var property = ParseDeclaration(source);
-            Assert.IsTrue(property.HasValue);
-            Assert.IsFalse(property.IsInitial);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.IsInitial, Is.False);
             var value = property.RawValue as CssListValue;
             Assert.IsNotNull(value);
-            Assert.AreEqual(1, value.Items.Length);
+            Assert.That(value.Items.Length, Is.EqualTo(1));
             var gradient = value.Items[0] as CssRadialGradientValue;
-            Assert.IsFalse(gradient.IsRepeating);
-            Assert.AreEqual(new CssLengthValue(20f, CssLengthValue.Unit.Px), gradient.Position.X);
-            Assert.AreEqual(new CssLengthValue(30f, CssLengthValue.Unit.Px), gradient.Position.Y);
-            Assert.AreEqual(true, gradient.IsCircle);
-            Assert.AreEqual(CssRadialGradientValue.SizeMode.ClosestSide, gradient.Mode);
+            Assert.That(gradient.IsRepeating, Is.False);
+            Assert.That(gradient.Position.X, Is.EqualTo(new CssLengthValue(20f, CssLengthValue.Unit.Px)));
+            Assert.That(gradient.Position.Y, Is.EqualTo(new CssLengthValue(30f, CssLengthValue.Unit.Px)));
+            Assert.That(gradient.IsCircle, Is.EqualTo(true));
+            Assert.That(gradient.Mode, Is.EqualTo(CssRadialGradientValue.SizeMode.ClosestSide));
             var stops = gradient.Stops.ToArray();
-            Assert.AreEqual(3, stops.Length);
-            Assert.AreEqual(CssColorValue.FromName("red").Value, ((CssGradientStopValue)stops[0]).Color);
-            Assert.AreEqual(CssColorValue.FromName("yellow").Value, ((CssGradientStopValue)stops[1]).Color);
-            Assert.AreEqual(CssColorValue.FromName("green").Value, ((CssGradientStopValue)stops[2]).Color);
+            Assert.That(stops.Length, Is.EqualTo(3));
+            Assert.That(((CssGradientStopValue)stops[0]).Color, Is.EqualTo(CssColorValue.FromName("red").Value));
+            Assert.That(((CssGradientStopValue)stops[1]).Color, Is.EqualTo(CssColorValue.FromName("yellow").Value));
+            Assert.That(((CssGradientStopValue)stops[2]).Color, Is.EqualTo(CssColorValue.FromName("green").Value));
         }
 
         [Test]
@@ -386,22 +386,22 @@ namespace AngleSharp.Css.Tests.Values
         {
             var source = "background-image: radial-gradient(farthest-side at left bottom, red, yellow 50px, green);";
             var property = ParseDeclaration(source);
-            Assert.IsTrue(property.HasValue);
-            Assert.IsFalse(property.IsInitial);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.IsInitial, Is.False);
             var value = property.RawValue as CssListValue;
             Assert.IsNotNull(value);
-            Assert.AreEqual(1, value.Items.Length);
+            Assert.That(value.Items.Length, Is.EqualTo(1));
             var gradient = value.Items[0] as CssRadialGradientValue;
-            Assert.IsFalse(gradient.IsRepeating);
-            Assert.AreEqual(CssLengthValue.Zero, gradient.Position.X);
-            Assert.AreEqual(CssLengthValue.Full, gradient.Position.Y);
-            Assert.AreEqual(false, gradient.IsCircle);
-            Assert.AreEqual(CssRadialGradientValue.SizeMode.FarthestSide, gradient.Mode);
+            Assert.That(gradient.IsRepeating, Is.False);
+            Assert.That(gradient.Position.X, Is.EqualTo(CssLengthValue.Zero));
+            Assert.That(gradient.Position.Y, Is.EqualTo(CssLengthValue.Full));
+            Assert.That(gradient.IsCircle, Is.EqualTo(false));
+            Assert.That(gradient.Mode, Is.EqualTo(CssRadialGradientValue.SizeMode.FarthestSide));
             var stops = gradient.Stops.ToArray();
-            Assert.AreEqual(3, stops.Length);
-            Assert.AreEqual(CssColorValue.FromName("red").Value, ((CssGradientStopValue)stops[0]).Color);
-            Assert.AreEqual(CssColorValue.FromName("yellow").Value, ((CssGradientStopValue)stops[1]).Color);
-            Assert.AreEqual(CssColorValue.FromName("green").Value, ((CssGradientStopValue)stops[2]).Color);
+            Assert.That(stops.Length, Is.EqualTo(3));
+            Assert.That(((CssGradientStopValue)stops[0]).Color, Is.EqualTo(CssColorValue.FromName("red").Value));
+            Assert.That(((CssGradientStopValue)stops[1]).Color, Is.EqualTo(CssColorValue.FromName("yellow").Value));
+            Assert.That(((CssGradientStopValue)stops[2]).Color, Is.EqualTo(CssColorValue.FromName("green").Value));
         }
 
         [Test]
@@ -409,18 +409,18 @@ namespace AngleSharp.Css.Tests.Values
         {
             var source = "background-image: repeating-linear-gradient(red, blue 20px, red 40px)";
             var property = ParseDeclaration(source);
-            Assert.IsTrue(property.HasValue);
-            Assert.IsFalse(property.IsInitial);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.IsInitial, Is.False);
             var value = property.RawValue as CssListValue;
             Assert.IsNotNull(value);
-            Assert.AreEqual(1, value.Items.Length);
+            Assert.That(value.Items.Length, Is.EqualTo(1));
             var gradient = value.Items[0] as CssLinearGradientValue;
-            Assert.IsTrue(gradient.IsRepeating);
+            Assert.That(gradient.IsRepeating, Is.True);
             var stops = gradient.Stops.ToArray();
-            Assert.AreEqual(3, stops.Length);
-            Assert.AreEqual(CssColorValue.FromName("red").Value, ((CssGradientStopValue)stops[0]).Color);
-            Assert.AreEqual(CssColorValue.FromName("blue").Value, ((CssGradientStopValue)stops[1]).Color);
-            Assert.AreEqual(CssColorValue.FromName("red").Value, ((CssGradientStopValue)stops[2]).Color);
+            Assert.That(stops.Length, Is.EqualTo(3));
+            Assert.That(((CssGradientStopValue)stops[0]).Color, Is.EqualTo(CssColorValue.FromName("red").Value));
+            Assert.That(((CssGradientStopValue)stops[1]).Color, Is.EqualTo(CssColorValue.FromName("blue").Value));
+            Assert.That(((CssGradientStopValue)stops[2]).Color, Is.EqualTo(CssColorValue.FromName("red").Value));
         }
 
         [Test]
@@ -428,22 +428,22 @@ namespace AngleSharp.Css.Tests.Values
         {
             var source = "background-image: repeating-radial-gradient(red, blue 20px, red 40px)";
             var property = ParseDeclaration(source);
-            Assert.IsTrue(property.HasValue);
-            Assert.IsFalse(property.IsInitial);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.IsInitial, Is.False);
             var value = property.RawValue as CssListValue;
             Assert.IsNotNull(value);
-            Assert.AreEqual(1, value.Items.Length);
+            Assert.That(value.Items.Length, Is.EqualTo(1));
             var gradient = value.Items[0] as CssRadialGradientValue;
-            Assert.IsTrue(gradient.IsRepeating);
-            Assert.AreEqual(CssLengthValue.Half, gradient.Position.X);
-            Assert.AreEqual(CssLengthValue.Half, gradient.Position.Y);
-            Assert.AreEqual(false, gradient.IsCircle);
-            Assert.AreEqual(CssRadialGradientValue.SizeMode.None, gradient.Mode);
+            Assert.That(gradient.IsRepeating, Is.True);
+            Assert.That(gradient.Position.X, Is.EqualTo(CssLengthValue.Half));
+            Assert.That(gradient.Position.Y, Is.EqualTo(CssLengthValue.Half));
+            Assert.That(gradient.IsCircle, Is.EqualTo(false));
+            Assert.That(gradient.Mode, Is.EqualTo(CssRadialGradientValue.SizeMode.None));
             var stops = gradient.Stops.ToArray();
-            Assert.AreEqual(3, stops.Length);
-            Assert.AreEqual(CssColorValue.FromName("red").Value, ((CssGradientStopValue)stops[0]).Color);
-            Assert.AreEqual(CssColorValue.FromName("blue").Value, ((CssGradientStopValue)stops[1]).Color);
-            Assert.AreEqual(CssColorValue.FromName("red").Value, ((CssGradientStopValue)stops[2]).Color);
+            Assert.That(stops.Length, Is.EqualTo(3));
+            Assert.That(((CssGradientStopValue)stops[0]).Color, Is.EqualTo(CssColorValue.FromName("red").Value));
+            Assert.That(((CssGradientStopValue)stops[1]).Color, Is.EqualTo(CssColorValue.FromName("blue").Value));
+            Assert.That(((CssGradientStopValue)stops[2]).Color, Is.EqualTo(CssColorValue.FromName("red").Value));
         }
 
         [Test]
@@ -451,24 +451,24 @@ namespace AngleSharp.Css.Tests.Values
         {
             var source = "background-image: repeating-radial-gradient(circle closest-side at 20px 30px, red, yellow, green 100%, yellow 150%, red 200%)";
             var property = ParseDeclaration(source);
-            Assert.IsTrue(property.HasValue);
-            Assert.IsFalse(property.IsInitial);
+            Assert.That(property.HasValue, Is.True);
+            Assert.That(property.IsInitial, Is.False);
             var value = property.RawValue as CssListValue;
             Assert.IsNotNull(value);
-            Assert.AreEqual(1, value.Items.Length);
+            Assert.That(value.Items.Length, Is.EqualTo(1));
             var gradient = value.Items[0] as CssRadialGradientValue;
-            Assert.IsTrue(gradient.IsRepeating);
-            Assert.AreEqual(new CssLengthValue(20f, CssLengthValue.Unit.Px), gradient.Position.X);
-            Assert.AreEqual(new CssLengthValue(30f, CssLengthValue.Unit.Px), gradient.Position.Y);
-            Assert.AreEqual(true, gradient.IsCircle);
-            Assert.AreEqual(CssRadialGradientValue.SizeMode.ClosestSide, gradient.Mode);
+            Assert.That(gradient.IsRepeating, Is.True);
+            Assert.That(gradient.Position.X, Is.EqualTo(new CssLengthValue(20f, CssLengthValue.Unit.Px)));
+            Assert.That(gradient.Position.Y, Is.EqualTo(new CssLengthValue(30f, CssLengthValue.Unit.Px)));
+            Assert.That(gradient.IsCircle, Is.EqualTo(true));
+            Assert.That(gradient.Mode, Is.EqualTo(CssRadialGradientValue.SizeMode.ClosestSide));
             var stops = gradient.Stops.ToArray();
-            Assert.AreEqual(5, stops.Length);
-            Assert.AreEqual(CssColorValue.FromName("red").Value, ((CssGradientStopValue)stops[0]).Color);
-            Assert.AreEqual(CssColorValue.FromName("yellow").Value, ((CssGradientStopValue)stops[1]).Color);
-            Assert.AreEqual(CssColorValue.FromName("green").Value, ((CssGradientStopValue)stops[2]).Color);
-            Assert.AreEqual(CssColorValue.FromName("yellow").Value, ((CssGradientStopValue)stops[3]).Color);
-            Assert.AreEqual(CssColorValue.FromName("red").Value, ((CssGradientStopValue)stops[4]).Color);
+            Assert.That(stops.Length, Is.EqualTo(5));
+            Assert.That(((CssGradientStopValue)stops[0]).Color, Is.EqualTo(CssColorValue.FromName("red").Value));
+            Assert.That(((CssGradientStopValue)stops[1]).Color, Is.EqualTo(CssColorValue.FromName("yellow").Value));
+            Assert.That(((CssGradientStopValue)stops[2]).Color, Is.EqualTo(CssColorValue.FromName("green").Value));
+            Assert.That(((CssGradientStopValue)stops[3]).Color, Is.EqualTo(CssColorValue.FromName("yellow").Value));
+            Assert.That(((CssGradientStopValue)stops[4]).Color, Is.EqualTo(CssColorValue.FromName("red").Value));
         }
     }
 }

--- a/src/AngleSharp.Css.Tests/Values/UnitConversion.cs
+++ b/src/AngleSharp.Css.Tests/Values/UnitConversion.cs
@@ -13,9 +13,9 @@ namespace AngleSharp.Css.Tests.Values
             var s = "12px";
             var v = default(CssLengthValue);
             var r = CssLengthValue.TryParse(s, out v);
-            Assert.IsTrue(r);
-            Assert.AreEqual(12f, v.Value);
-            Assert.AreEqual(CssLengthValue.Unit.Px, v.Type);
+            Assert.That(r, Is.True);
+            Assert.That(v.Value, Is.EqualTo(12f));
+            Assert.That(v.Type, Is.EqualTo(CssLengthValue.Unit.Px));
         }
 
         [Test]
@@ -24,7 +24,7 @@ namespace AngleSharp.Css.Tests.Values
             var s = "123.5";
             var v = default(CssLengthValue);
             var r = CssLengthValue.TryParse(s, out v);
-            Assert.IsFalse(r);
+            Assert.That(r, Is.False);
         }
 
         [Test]
@@ -33,9 +33,9 @@ namespace AngleSharp.Css.Tests.Values
             var s = "12.2vw";
             var v = default(CssLengthValue);
             var r = CssLengthValue.TryParse(s, out v);
-            Assert.IsTrue(r);
-            Assert.AreEqual(12.2, v.Value);
-            Assert.AreEqual(CssLengthValue.Unit.Vw, v.Type);
+            Assert.That(r, Is.True);
+            Assert.That(v.Value, Is.EqualTo(12.2));
+            Assert.That(v.Type, Is.EqualTo(CssLengthValue.Unit.Vw));
         }
 
         [Test]
@@ -61,7 +61,7 @@ namespace AngleSharp.Css.Tests.Values
         {
             var l = new CssLengthValue(50, CssLengthValue.Unit.Percent);
             var renderDevice = new DefaultRenderDevice {ViewPortWidth = 500};
-            Assert.AreEqual(250, l.ToPixel(renderDevice, RenderMode.Horizontal));
+            Assert.That(l.ToPixel(renderDevice, RenderMode.Horizontal), Is.EqualTo(250));
         }
 
         [Test]
@@ -69,7 +69,7 @@ namespace AngleSharp.Css.Tests.Values
         {
             var l = new CssLengthValue(25, CssLengthValue.Unit.Percent);
             var renderDevice = new DefaultRenderDevice {ViewPortHeight = 600};
-            Assert.AreEqual(150, l.ToPixel(renderDevice, RenderMode.Vertical));
+            Assert.That(l.ToPixel(renderDevice, RenderMode.Vertical), Is.EqualTo(150));
         }
 
         [Test]
@@ -77,7 +77,7 @@ namespace AngleSharp.Css.Tests.Values
         {
             var l = new CssLengthValue(25, CssLengthValue.Unit.Rem);
             var renderDevice = new DefaultRenderDevice {FontSize = 10};
-            Assert.AreEqual(250, l.ToPixel(renderDevice, RenderMode.Undefined));
+            Assert.That(l.ToPixel(renderDevice, RenderMode.Undefined), Is.EqualTo(250));
         }
 
         [Test]
@@ -85,7 +85,7 @@ namespace AngleSharp.Css.Tests.Values
         {
             var l = new CssLengthValue(10, CssLengthValue.Unit.Em);
             var renderDevice = new DefaultRenderDevice {FontSize = 10};
-            Assert.AreEqual(100, l.ToPixel(renderDevice, RenderMode.Undefined));
+            Assert.That(l.ToPixel(renderDevice, RenderMode.Undefined), Is.EqualTo(100));
         }
 
         [Test]
@@ -93,7 +93,7 @@ namespace AngleSharp.Css.Tests.Values
         {
             var l = new CssLengthValue(10, CssLengthValue.Unit.Vh);
             var renderDevice = new DefaultRenderDevice {ViewPortHeight = 1000};
-            Assert.AreEqual(100, l.ToPixel(renderDevice, RenderMode.Undefined));
+            Assert.That(l.ToPixel(renderDevice, RenderMode.Undefined), Is.EqualTo(100));
         }
 
         [Test]
@@ -101,7 +101,7 @@ namespace AngleSharp.Css.Tests.Values
         {
             var l = new CssLengthValue(20, CssLengthValue.Unit.Vw);
             var renderDevice = new DefaultRenderDevice {ViewPortWidth = 1000};
-            Assert.AreEqual(200, l.ToPixel(renderDevice, RenderMode.Undefined));
+            Assert.That(l.ToPixel(renderDevice, RenderMode.Undefined), Is.EqualTo(200));
         }
 
         [Test]
@@ -113,7 +113,7 @@ namespace AngleSharp.Css.Tests.Values
                 ViewPortHeight = 1000,
                 ViewPortWidth = 500
             };
-            Assert.AreEqual(200, l.ToPixel(renderDevice, RenderMode.Undefined));
+            Assert.That(l.ToPixel(renderDevice, RenderMode.Undefined), Is.EqualTo(200));
         }
 
         [Test]
@@ -125,7 +125,7 @@ namespace AngleSharp.Css.Tests.Values
                 ViewPortHeight = 1000,
                 ViewPortWidth = 500
             };
-            Assert.AreEqual(100, l.ToPixel(renderDevice, RenderMode.Undefined));
+            Assert.That(l.ToPixel(renderDevice, RenderMode.Undefined), Is.EqualTo(100));
         }
 
         [Test]
@@ -133,7 +133,7 @@ namespace AngleSharp.Css.Tests.Values
         {
             var l = new CssLengthValue(100, CssLengthValue.Unit.Px);
             var renderDevice = new DefaultRenderDevice {ViewPortWidth = 500};
-            Assert.AreEqual(20, l.To(CssLengthValue.Unit.Percent, renderDevice, RenderMode.Horizontal));
+            Assert.That(l.To(CssLengthValue.Unit.Percent, renderDevice, RenderMode.Horizontal), Is.EqualTo(20));
         }
 
         [Test]
@@ -141,7 +141,7 @@ namespace AngleSharp.Css.Tests.Values
         {
             var l = new CssLengthValue(100, CssLengthValue.Unit.Px);
             var renderDevice = new DefaultRenderDevice {ViewPortHeight = 1000};
-            Assert.AreEqual(10, l.To(CssLengthValue.Unit.Percent, renderDevice, RenderMode.Vertical));
+            Assert.That(l.To(CssLengthValue.Unit.Percent, renderDevice, RenderMode.Vertical), Is.EqualTo(10));
         }
 
         [Test]
@@ -149,7 +149,7 @@ namespace AngleSharp.Css.Tests.Values
         {
             var l = new CssLengthValue(100, CssLengthValue.Unit.Px);
             var renderDevice = new DefaultRenderDevice {FontSize = 16};
-            Assert.AreEqual(6.25d, l.To(CssLengthValue.Unit.Rem, renderDevice, RenderMode.Undefined));
+            Assert.That(l.To(CssLengthValue.Unit.Rem, renderDevice, RenderMode.Undefined), Is.EqualTo(6.25d));
         }
 
         [Test]
@@ -157,7 +157,7 @@ namespace AngleSharp.Css.Tests.Values
         {
             var l = new CssLengthValue(1600, CssLengthValue.Unit.Px);
             var renderDevice = new DefaultRenderDevice {FontSize = 16};
-            Assert.AreEqual(100, l.To(CssLengthValue.Unit.Em, renderDevice, RenderMode.Undefined));
+            Assert.That(l.To(CssLengthValue.Unit.Em, renderDevice, RenderMode.Undefined), Is.EqualTo(100));
         }
 
         [Test]
@@ -165,7 +165,7 @@ namespace AngleSharp.Css.Tests.Values
         {
             var l = new CssLengthValue(100, CssLengthValue.Unit.Px);
             var renderDevice = new DefaultRenderDevice {ViewPortHeight = 1000};
-            Assert.AreEqual(10, l.To(CssLengthValue.Unit.Vh, renderDevice, RenderMode.Undefined));
+            Assert.That(l.To(CssLengthValue.Unit.Vh, renderDevice, RenderMode.Undefined), Is.EqualTo(10));
         }
 
         [Test]
@@ -173,7 +173,7 @@ namespace AngleSharp.Css.Tests.Values
         {
             var l = new CssLengthValue(50, CssLengthValue.Unit.Px);
             var renderDevice = new DefaultRenderDevice {ViewPortWidth = 1000};
-            Assert.AreEqual(5, l.To(CssLengthValue.Unit.Vw, renderDevice, RenderMode.Undefined));
+            Assert.That(l.To(CssLengthValue.Unit.Vw, renderDevice, RenderMode.Undefined), Is.EqualTo(5));
         }
 
         [Test]
@@ -185,7 +185,7 @@ namespace AngleSharp.Css.Tests.Values
                 ViewPortWidth = 1000,
                 ViewPortHeight = 500
             };
-            Assert.AreEqual(5, l.To(CssLengthValue.Unit.Vmax, renderDevice, RenderMode.Undefined));
+            Assert.That(l.To(CssLengthValue.Unit.Vmax, renderDevice, RenderMode.Undefined), Is.EqualTo(5));
         }
 
         [Test]
@@ -197,7 +197,7 @@ namespace AngleSharp.Css.Tests.Values
                 ViewPortWidth = 1000,
                 ViewPortHeight = 500
             };
-            Assert.AreEqual(10, l.To(CssLengthValue.Unit.Vmin, renderDevice, RenderMode.Undefined));
+            Assert.That(l.To(CssLengthValue.Unit.Vmin, renderDevice, RenderMode.Undefined), Is.EqualTo(10));
         }
 
         [Test]
@@ -206,9 +206,9 @@ namespace AngleSharp.Css.Tests.Values
             var s = "1.35e2deg";
             var v = default(CssAngleValue);
             var r = CssAngleValue.TryParse(s, out v);
-            Assert.IsTrue(r);
-            Assert.AreEqual(135f, v.Value);
-            Assert.AreEqual(CssAngleValue.Unit.Deg, v.Type);
+            Assert.That(r, Is.True);
+            Assert.That(v.Value, Is.EqualTo(135f));
+            Assert.That(v.Type, Is.EqualTo(CssAngleValue.Unit.Deg));
         }
 
         [Test]
@@ -217,9 +217,9 @@ namespace AngleSharp.Css.Tests.Values
             var s = "-24.0dpi";
             var v = default(CssResolutionValue);
             var r = CssResolutionValue.TryParse(s, out v);
-            Assert.IsTrue(r);
-            Assert.AreEqual(-24f, v.Value);
-            Assert.AreEqual(CssResolutionValue.Unit.Dpi, v.Type);
+            Assert.That(r, Is.True);
+            Assert.That(v.Value, Is.EqualTo(-24f));
+            Assert.That(v.Type, Is.EqualTo(CssResolutionValue.Unit.Dpi));
         }
 
         [Test]
@@ -228,9 +228,9 @@ namespace AngleSharp.Css.Tests.Values
             var s = "17.123khz";
             var v = default(CssFrequencyValue);
             var r = CssFrequencyValue.TryParse(s, out v);
-            Assert.IsTrue(r);
-            Assert.AreEqual(17.123, v.Value);
-            Assert.AreEqual(CssFrequencyValue.Unit.Khz, v.Type);
+            Assert.That(r, Is.True);
+            Assert.That(v.Value, Is.EqualTo(17.123));
+            Assert.That(v.Type, Is.EqualTo(CssFrequencyValue.Unit.Khz));
         }
 
         [Test]
@@ -239,9 +239,9 @@ namespace AngleSharp.Css.Tests.Values
             var s = "0s";
             var v = default(CssTimeValue);
             var r = CssTimeValue.TryParse(s, out v);
-            Assert.IsTrue(r);
-            Assert.AreEqual(0f, v.Value);
-            Assert.AreEqual(CssTimeValue.Unit.S, v.Type);
+            Assert.That(r, Is.True);
+            Assert.That(v.Value, Is.EqualTo(0f));
+            Assert.That(v.Type, Is.EqualTo(CssTimeValue.Unit.S));
         }
 
         [Test]
@@ -250,7 +250,7 @@ namespace AngleSharp.Css.Tests.Values
             var s = "123.deg";
             var v = default(CssAngleValue);
             var r = CssAngleValue.TryParse(s, out v);
-            Assert.IsFalse(r);
+            Assert.That(r, Is.False);
         }
     }
 }

--- a/src/AngleSharp.Css.Tests/Values/W3CSelector.cs
+++ b/src/AngleSharp.Css.Tests/Values/W3CSelector.cs
@@ -1,4 +1,4 @@
-﻿namespace AngleSharp.Css.Tests.Values
+namespace AngleSharp.Css.Tests.Values
 {
     using NUnit.Framework;
     using static CssConstructionFunctions;
@@ -24,11 +24,11 @@
             var document = ParseDocument(source);
 
             var selector1 = document.QuerySelectorAll("div.stub p");
-            Assert.AreEqual(1, selector1.Length);
+            Assert.That(selector1.Length, Is.EqualTo(1));
             var selector2 = document.QuerySelectorAll("div.stub > a|*");
-            Assert.AreEqual(2, selector2.Length);
+            Assert.That(selector2.Length, Is.EqualTo(2));
             var selector3 = document.QuerySelectorAll("div.stub *|*:not([test='1'])");
-            Assert.AreEqual(4, selector3.Length);
+            Assert.That(selector3.Length, Is.EqualTo(4));
         }
 
         /// <summary>
@@ -47,9 +47,9 @@
             var document = ParseDocument(source);
 
             var selector1 = document.QuerySelectorAll("a|*");
-            Assert.AreEqual(2, selector1.Length);
+            Assert.That(selector1.Length, Is.EqualTo(2));
             var selector2 = document.QuerySelectorAll("div.stub *|*:not([test])");
-            Assert.AreEqual(2, selector2.Length);
+            Assert.That(selector2.Length, Is.EqualTo(2));
         }
 
         /// <summary>
@@ -72,15 +72,15 @@
             var document = ParseDocument(source);
 
             var selector1 = document.QuerySelectorAll("div.stub p");
-            Assert.AreEqual(1, selector1.Length);
+            Assert.That(selector1.Length, Is.EqualTo(1));
             var selector2 = document.QuerySelectorAll("div.stub > a|*, div.stub > b|*");
-            Assert.AreEqual(4, selector2.Length);
+            Assert.That(selector2.Length, Is.EqualTo(4));
             var selector3 = document.QuerySelectorAll("div.stub *|*:not([test~='foo'])");
-            Assert.AreEqual(6, selector3.Length);
+            Assert.That(selector3.Length, Is.EqualTo(6));
             var selector4 = document.QuerySelectorAll("div.stub *|p:not([class~='foo'])");
-            Assert.AreEqual(1, selector4.Length);
+            Assert.That(selector4.Length, Is.EqualTo(1));
             var selector5 = document.QuerySelectorAll("div.stub b|*[test~='foo2']");
-            Assert.AreEqual(1, selector5.Length);
+            Assert.That(selector5.Length, Is.EqualTo(1));
         }
 
         /// <summary>
@@ -103,15 +103,15 @@
             var document = ParseDocument(source);
 
             var selector1 = document.QuerySelectorAll("div.stub p");
-            Assert.AreEqual(1, selector1.Length);
+            Assert.That(selector1.Length, Is.EqualTo(1));
             var selector2 = document.QuerySelectorAll("div.stub > a|*, div.stub > b|*");
-            Assert.AreEqual(4, selector2.Length);
+            Assert.That(selector2.Length, Is.EqualTo(4));
             var selector3 = document.QuerySelectorAll("div.stub *|*:not([test|='foo-bar'])");
-            Assert.AreEqual(6, selector3.Length);
+            Assert.That(selector3.Length, Is.EqualTo(6));
             var selector4 = document.QuerySelectorAll("div.stub *|p:not([lang|='en-us'])");
-            Assert.AreEqual(1, selector4.Length);
+            Assert.That(selector4.Length, Is.EqualTo(1));
             var selector5 = document.QuerySelectorAll("div.stub b|*[test|='foo2-bar']");
-            Assert.AreEqual(1, selector5.Length);
+            Assert.That(selector5.Length, Is.EqualTo(1));
         }
 
         /// <summary>
@@ -125,9 +125,9 @@
             var document = ParseDocument(source);
 
             var selector1 = document.QuerySelectorAll("testa");
-            Assert.AreEqual(1, selector1.Length);
+            Assert.That(selector1.Length, Is.EqualTo(1));
             var selector2 = document.QuerySelectorAll("test|testa");
-            Assert.AreEqual(1, selector2.Length);
+            Assert.That(selector2.Length, Is.EqualTo(1));
         }
 
         /// <summary>
@@ -145,9 +145,9 @@
             var document = ParseDocument(source);
 
             var selector1 = document.QuerySelectorAll("p,q");
-            Assert.AreEqual(5, selector1.Length);
+            Assert.That(selector1.Length, Is.EqualTo(5));
             var selector2 = document.QuerySelectorAll("b|*");
-            Assert.AreEqual(3, selector2.Length);
+            Assert.That(selector2.Length, Is.EqualTo(3));
         }
 
         /// <summary>
@@ -165,11 +165,11 @@
             var document = ParseDocument(source);
 
             var selector1 = document.QuerySelectorAll("p,q");
-            Assert.AreEqual(5, selector1.Length);
+            Assert.That(selector1.Length, Is.EqualTo(5));
             var selector2 = document.QuerySelectorAll("b|*");
-            Assert.AreEqual(3, selector2.Length);
+            Assert.That(selector2.Length, Is.EqualTo(3));
             var selector3 = document.QuerySelectorAll("[test]");
-            Assert.AreEqual(3, selector3.Length);
+            Assert.That(selector3.Length, Is.EqualTo(3));
         }
     }
 }


### PR DESCRIPTION
# Types of Changes

## Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

## Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [x] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## Description

- Update NUnit from 3.13.2 to 4.5.1
- Update NUnit3TestAdapter from 4.2.0 to 6.2.0
- Set test project LangVersion to latest (required by NUnit 4's C# 14 extension types)
- Convert Assert.IsTrue(x) to Assert.That(x, Is.True) (784 occurrences)
- Convert Assert.AreEqual(expected, actual) to Assert.That(actual, Is.EqualTo(expected)) (2724 occurrences)

