### PR TITLE
Fix !important declarations being overridden by non-important duplicates

### DIFF
--- a/src/AngleSharp.Css.Tests/Declarations/CssPaddingProperty.cs
+++ b/src/AngleSharp.Css.Tests/Declarations/CssPaddingProperty.cs
@@ -1,5 +1,7 @@
 namespace AngleSharp.Css.Tests.Declarations
 {
+    using AngleSharp.Css.Dom;
+    using AngleSharp.Dom;
     using NUnit.Framework;
     using static CssConstructionFunctions;
 
@@ -138,6 +140,63 @@ namespace AngleSharp.Css.Tests.Declarations
             var result = ParseRule(snippet);
             var actual = result.CssText;
             Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void CssPaddingImportantShouldNotBeOverriddenByNonImportant()
+        {
+            var snippet = "padding: 20px !important; font-size: 20px; padding: 0";
+            var style = ParseDeclarations(snippet);
+            var padding = style.GetPropertyValue("padding");
+            Assert.AreEqual("20px", padding);
+            var paddingProp = style.GetProperty("padding");
+            Assert.IsNotNull(paddingProp);
+            Assert.IsTrue(paddingProp.IsImportant);
+            var fontSize = style.GetPropertyValue("font-size");
+            Assert.AreEqual("20px", fontSize);
+        }
+
+        [Test]
+        public void CssPaddingImportantShouldBeOverriddenByImportant()
+        {
+            var snippet = "padding: 20px !important; padding: 0 !important";
+            var style = ParseDeclarations(snippet);
+            var padding = style.GetPropertyValue("padding");
+            Assert.AreEqual("0", padding);
+            var paddingProp = style.GetProperty("padding");
+            Assert.IsNotNull(paddingProp);
+            Assert.IsTrue(paddingProp.IsImportant);
+        }
+
+        [Test]
+        public void CssPaddingNonImportantShouldBeOverriddenByNonImportant()
+        {
+            var snippet = "padding: 20px; padding: 0";
+            var style = ParseDeclarations(snippet);
+            var padding = style.GetPropertyValue("padding");
+            Assert.AreEqual("0", padding);
+        }
+
+        [Test]
+        public void CssPaddingNonImportantShouldBeOverriddenByImportant()
+        {
+            var snippet = "padding: 20px; padding: 0 !important";
+            var style = ParseDeclarations(snippet);
+            var padding = style.GetPropertyValue("padding");
+            Assert.AreEqual("0", padding);
+            var paddingProp = style.GetProperty("padding");
+            Assert.IsNotNull(paddingProp);
+            Assert.IsTrue(paddingProp.IsImportant);
+        }
+
+        [Test]
+        public void CssInlineStyleImportantPaddingShouldTakePrecedence()
+        {
+            var html = "<p style=\"padding: 20px !important; font-size: 20px; padding: 0;\">Test</p>";
+            var dom = ParseDocument(html);
+            var p = dom.QuerySelector("p");
+            var style = p.GetStyle();
+            Assert.AreEqual("padding: 20px !important; font-size: 20px", style.CssText);
         }
     }
 }

--- a/src/AngleSharp.Css/Dom/Internal/CssStyleDeclaration.cs
+++ b/src/AngleSharp.Css/Dom/Internal/CssStyleDeclaration.cs
@@ -424,6 +424,11 @@ namespace AngleSharp.Css.Dom
 
                 if (declaration.Name.Is(property.Name))
                 {
+                    if (declaration.IsImportant && !property.IsImportant)
+                    {
+                        return;
+                    }
+
                     _declarations[i] = property;
                     return;
                 }


### PR DESCRIPTION
# Types of Changes

## Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

## Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## Description

In SetLonghand, a later non-important declaration for the same property would unconditionally replace an earlier !important one. Now the existing declaration is preserved when it is !important and the incoming one is not.

Fixes the issue where parsing style="padding: 20px !important; padding: 0"
would incorrectly yield "padding: 0" instead of keeping the important value.

Fixes #193 