### PR TITLE
Fix 0% losing its percent unit during CSS serialization

### DIFF
--- a/src/AngleSharp.Css.Tests/Declarations/CssFlexProperty.cs
+++ b/src/AngleSharp.Css.Tests/Declarations/CssFlexProperty.cs
@@ -96,6 +96,36 @@ namespace AngleSharp.Css.Tests.Declarations
         }
 
         [Test]
+        public void CssFlexShorthandWithZeroPercentBasisLegal()
+        {
+            var snippet = "flex: 1 1 0%";
+            var property = ParseDeclaration(snippet);
+            Assert.AreEqual("flex", property.Name);
+            Assert.IsTrue(property.HasValue);
+            Assert.AreEqual("1 1 0%", property.Value);
+        }
+
+        [Test]
+        public void CssFlexBasisZeroPercentLegal()
+        {
+            var snippet = "flex-basis: 0%";
+            var property = ParseDeclaration(snippet);
+            Assert.AreEqual("flex-basis", property.Name);
+            Assert.IsTrue(property.HasValue);
+            Assert.AreEqual("0%", property.Value);
+        }
+
+        [Test]
+        public void CssFlexBasisZeroPxSerializesWithoutUnit()
+        {
+            var snippet = "flex-basis: 0px";
+            var property = ParseDeclaration(snippet);
+            Assert.AreEqual("flex-basis", property.Name);
+            Assert.IsTrue(property.HasValue);
+            Assert.AreEqual("0", property.Value);
+        }
+
+        [Test]
         public void CssFlexWrapLegal()
         {
             var snippet = "flex-wrap: wrap-reverse";

--- a/src/AngleSharp.Css.Tests/Declarations/CssObjectSizing.cs
+++ b/src/AngleSharp.Css.Tests/Declarations/CssObjectSizing.cs
@@ -131,7 +131,7 @@
             Assert.IsTrue(property.IsAnimatable);
             Assert.IsFalse(property.IsInherited);
             Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("0 30px", property.Value);
+            Assert.AreEqual("0% 30px", property.Value);
         }
     }
 }

--- a/src/AngleSharp.Css.Tests/Declarations/CssTransformProperty.cs
+++ b/src/AngleSharp.Css.Tests/Declarations/CssTransformProperty.cs
@@ -230,7 +230,7 @@
             Assert.IsFalse(property.IsImportant);
             Assert.IsFalse(property.IsInherited);
             Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("0 2px", property.Value);
+            Assert.AreEqual("0% 2px", property.Value);
         }
 
         [Test]
@@ -242,7 +242,7 @@
             Assert.IsFalse(property.IsImportant);
             Assert.IsFalse(property.IsInherited);
             Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("0 2px", property.Value);
+            Assert.AreEqual("0% 2px", property.Value);
         }
 
         [Test]
@@ -290,7 +290,7 @@
             Assert.IsFalse(property.IsImportant);
             Assert.IsFalse(property.IsInherited);
             Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("0 2px 10px", property.Value);
+            Assert.AreEqual("0% 2px 10px", property.Value);
         }
 
         [Test]
@@ -302,7 +302,7 @@
             Assert.IsFalse(property.IsImportant);
             Assert.IsFalse(property.IsInherited);
             Assert.IsTrue(property.HasValue);
-            Assert.AreEqual("0 5px -3px", property.Value);
+            Assert.AreEqual("0% 5px -3px", property.Value);
         }
 
         [Test]

--- a/src/AngleSharp.Css/Values/Primitives/CssLengthValue.cs
+++ b/src/AngleSharp.Css/Values/Primitives/CssLengthValue.cs
@@ -107,7 +107,9 @@ namespace AngleSharp.Css.Values
                 }
                 else
                 {
-                    var unit = _value == 0.0 ? String.Empty : UnitString;
+                    // Per CSS spec, 0 is valid without a unit for lengths,
+                    // but 0% is a percentage (relative to context) and must keep its unit.
+                    var unit = _value == 0.0 && _unit != Unit.Percent ? String.Empty : UnitString;
                     var val = _value.CssStringify();
                     return String.Concat(val, unit);
                 }


### PR DESCRIPTION

# Types of Changes

## Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

## Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## Description

Fix 0% losing its percent unit during CSS serialization

CssLengthValue.CssText unconditionally stripped all units when the
numeric value was zero. Per CSS spec, 0 is valid without a unit for
<length> values, but <percentage> values must always include the %
sign since 0% and 0 have different semantic meanings (e.g. flex-basis).

Resolves #172