### PR TITLE
Fix/css inherit shorthand resolution

### DIFF
--- a/src/AngleSharp.Css.Tests/Declarations/CssBorderProperty.cs
+++ b/src/AngleSharp.Css.Tests/Declarations/CssBorderProperty.cs
@@ -586,5 +586,130 @@ namespace AngleSharp.Css.Tests.Declarations
             style.SetBorderColor("black");
             Assert.AreEqual(expectedCss, style.CssText);
         }
+
+        [Test]
+        public void CssBorderInheritShouldResolveToParentValues()
+        {
+            var source = @"<!DOCTYPE html>
+<html>
+<head><style>
+table { border: 3px solid; }
+table * { border: inherit; }
+</style></head>
+<body>
+<table><tr><td>Cell</td></tr></table>
+</body>
+</html>";
+            var document = source.ToHtmlDocument(Configuration.Default.WithCss());
+            var td = document.QuerySelector("td");
+            var style = td.ComputeCurrentStyle();
+            Assert.AreEqual("solid", style.GetBorderTopStyle());
+            Assert.AreEqual("3px", style.GetBorderTopWidth());
+        }
+
+        [Test]
+        public void CssBorderInheritShouldResolveAllSides()
+        {
+            var source = @"<!DOCTYPE html>
+<html>
+<head><style>
+div.parent { border: 2px dashed; }
+div.child { border: inherit; }
+</style></head>
+<body>
+<div class='parent'><div class='child'>Content</div></div>
+</body>
+</html>";
+            var document = source.ToHtmlDocument(Configuration.Default.WithCss());
+            var child = document.QuerySelector("div.child");
+            var style = child.ComputeCurrentStyle();
+            Assert.AreEqual("dashed", style.GetBorderTopStyle());
+            Assert.AreEqual("dashed", style.GetBorderBottomStyle());
+            Assert.AreEqual("dashed", style.GetBorderLeftStyle());
+            Assert.AreEqual("dashed", style.GetBorderRightStyle());
+            Assert.AreEqual("2px", style.GetBorderTopWidth());
+            Assert.AreEqual("2px", style.GetBorderBottomWidth());
+        }
+
+        [Test]
+        public void CssBorderStyleInheritShouldResolveToParentValues()
+        {
+            var source = @"<!DOCTYPE html>
+<html>
+<head><style>
+div.parent { border-style: dotted; }
+div.child { border-style: inherit; }
+</style></head>
+<body>
+<div class='parent'><div class='child'>Content</div></div>
+</body>
+</html>";
+            var document = source.ToHtmlDocument(Configuration.Default.WithCss());
+            var child = document.QuerySelector("div.child");
+            var style = child.ComputeCurrentStyle();
+            Assert.AreEqual("dotted", style.GetBorderTopStyle());
+            Assert.AreEqual("dotted", style.GetBorderRightStyle());
+        }
+
+        [Test]
+        public void CssBorderWidthInheritShouldResolveToParentValues()
+        {
+            var source = @"<!DOCTYPE html>
+<html>
+<head><style>
+div.parent { border-width: 5px; }
+div.child { border-width: inherit; }
+</style></head>
+<body>
+<div class='parent'><div class='child'>Content</div></div>
+</body>
+</html>";
+            var document = source.ToHtmlDocument(Configuration.Default.WithCss());
+            var child = document.QuerySelector("div.child");
+            var style = child.ComputeCurrentStyle();
+            Assert.AreEqual("5px", style.GetBorderTopWidth());
+            Assert.AreEqual("5px", style.GetBorderLeftWidth());
+        }
+
+        [Test]
+        public void CssBorderInheritThroughMultipleLevels()
+        {
+            var source = @"<!DOCTYPE html>
+<html>
+<head><style>
+div.root { border: 4px solid; }
+div.root * { border: inherit; }
+</style></head>
+<body>
+<div class='root'><div class='mid'><div class='inner'>Deep</div></div></div>
+</body>
+</html>";
+            var document = source.ToHtmlDocument(Configuration.Default.WithCss());
+            var inner = document.QuerySelector("div.inner");
+            var style = inner.ComputeCurrentStyle();
+            Assert.AreEqual("solid", style.GetBorderTopStyle());
+            Assert.AreEqual("4px", style.GetBorderTopWidth());
+        }
+
+        [Test]
+        public void CssBorderInheritWithExplicitChildOverride()
+        {
+            var source = @"<!DOCTYPE html>
+<html>
+<head><style>
+div.parent { border: 3px solid; }
+div.child { border: inherit; border-top-style: dotted; }
+</style></head>
+<body>
+<div class='parent'><div class='child'>Content</div></div>
+</body>
+</html>";
+            var document = source.ToHtmlDocument(Configuration.Default.WithCss());
+            var child = document.QuerySelector("div.child");
+            var style = child.ComputeCurrentStyle();
+            Assert.AreEqual("dotted", style.GetBorderTopStyle());
+            Assert.AreEqual("solid", style.GetBorderBottomStyle());
+            Assert.AreEqual("3px", style.GetBorderTopWidth());
+        }
     }
 }

--- a/src/AngleSharp.Css.Tests/Library/ComputedStyle.cs
+++ b/src/AngleSharp.Css.Tests/Library/ComputedStyle.cs
@@ -1,9 +1,11 @@
 namespace AngleSharp.Css.Tests.Library
 {
+    using AngleSharp.Css.Dom;
     using AngleSharp.Dom;
     using AngleSharp.Html.Dom;
     using NUnit.Framework;
     using System.Threading.Tasks;
+    using static CssConstructionFunctions;
 
     [TestFixture]
     public class ComputedStyleTests
@@ -24,6 +26,83 @@ namespace AngleSharp.Css.Tests.Library
             var fontSize = span.ComputeCurrentStyle().GetProperty("font-size");
 
             Assert.AreEqual("24px", fontSize.Value);
+        }
+
+        [Test]
+        public void MarginInheritShouldResolveToParentValues()
+        {
+            var source = @"<!DOCTYPE html>
+<html>
+<head><style>
+div.parent { margin: 10px 20px; }
+div.child { margin: inherit; }
+</style></head>
+<body>
+<div class='parent'><div class='child'>Content</div></div>
+</body>
+</html>";
+            var document = ParseDocument(source);
+            var child = document.QuerySelector("div.child");
+            var style = child.ComputeCurrentStyle();
+            Assert.AreEqual("10px", style.GetMarginTop());
+            Assert.AreEqual("20px", style.GetMarginRight());
+            Assert.AreEqual("10px", style.GetMarginBottom());
+            Assert.AreEqual("20px", style.GetMarginLeft());
+        }
+
+        [Test]
+        public void PaddingInheritShouldResolveToParentValues()
+        {
+            var source = @"<!DOCTYPE html>
+<html>
+<head><style>
+div.parent { padding: 5px 15px 10px; }
+div.child { padding: inherit; }
+</style></head>
+<body>
+<div class='parent'><div class='child'>Content</div></div>
+</body>
+</html>";
+            var document = ParseDocument(source);
+            var child = document.QuerySelector("div.child");
+            var style = child.ComputeCurrentStyle();
+            Assert.AreEqual("5px", style.GetPaddingTop());
+            Assert.AreEqual("15px", style.GetPaddingRight());
+            Assert.AreEqual("10px", style.GetPaddingBottom());
+            Assert.AreEqual("15px", style.GetPaddingLeft());
+        }
+
+        [Test]
+        public void InheritOnNonInheritablePropertyShouldResolveFromParent()
+        {
+            var source = @"<!DOCTYPE html>
+<html>
+<head><style>
+div.parent { border: 1px solid; padding: 8px; }
+div.child { border: inherit; padding: inherit; }
+</style></head>
+<body>
+<div class='parent'><div class='child'>Content</div></div>
+</body>
+</html>";
+            var document = ParseDocument(source);
+            var child = document.QuerySelector("div.child");
+            var style = child.ComputeCurrentStyle();
+            Assert.AreEqual("solid", style.GetBorderTopStyle());
+            Assert.AreEqual("1px", style.GetBorderTopWidth());
+            Assert.AreEqual("8px", style.GetPaddingTop());
+        }
+
+        [Test]
+        public void BorderInheritShouldSerializeCorrectly()
+        {
+            var html = @"<style>div { border: inherit }</style>";
+            var dom = ParseDocument(html);
+            var styleSheet = dom.StyleSheets[0] as ICssStyleSheet;
+            var rule = styleSheet.Rules[0] as ICssStyleRule;
+            Assert.AreEqual("inherit", rule.Style.GetPropertyValue("border-top-style"));
+            Assert.AreEqual("inherit", rule.Style.GetPropertyValue("border-top-width"));
+            Assert.AreEqual("inherit", rule.Style.GetPropertyValue("border-top-color"));
         }
     }
 }

--- a/src/AngleSharp.Css/DeclarationInfo.cs
+++ b/src/AngleSharp.Css/DeclarationInfo.cs
@@ -21,7 +21,7 @@ namespace AngleSharp.Css
         public DeclarationInfo(String name, IValueConverter converter, PropertyFlags flags = PropertyFlags.None, ICssValue initialValue = null, String[] shorthands = null, String[] longhands = null)
         {
             Name = name;
-            Converter = initialValue != null ? Or(converter, AssignInitial(initialValue)) : converter;
+            Converter = initialValue != null || longhands?.Length > 0 ? Or(AssignInitial(initialValue), converter) : converter;
             Aggregator = converter as IValueAggregator;
             Flags = flags;
             InitialValue = initialValue;

--- a/src/AngleSharp.Css/Dom/Internal/CssStyleDeclaration.cs
+++ b/src/AngleSharp.Css/Dom/Internal/CssStyleDeclaration.cs
@@ -397,6 +397,7 @@ namespace AngleSharp.Css.Dom
                         if (removeExisting.Invoke(olddecl, newdecl))
                         {
                             _declarations.RemoveAt(i);
+                            skip = false;
                         }
                         else
                         {

--- a/src/AngleSharp.Css/Extensions/DeclarationInfoExtensions.cs
+++ b/src/AngleSharp.Css/Extensions/DeclarationInfoExtensions.cs
@@ -16,12 +16,14 @@ namespace AngleSharp.Css
             var initial = true;
             var unset = true;
             var child = true;
+            var inherit = true;
 
             foreach (var longhand in longhands)
             {
                 initial = initial && longhand is CssInitialValue;
                 unset = unset && longhand is CssUnsetValue;
                 child = child && longhand is CssChildValue;
+                inherit = inherit && longhand is CssInheritValue;
             }
 
             if (initial)
@@ -31,6 +33,10 @@ namespace AngleSharp.Css
             else if (unset)
             {
                 return new CssUnsetValue(info.InitialValue);
+            }
+            else if (inherit)
+            {
+                return CssInheritValue.Instance;
             }
             else if (child)
             {
@@ -55,6 +61,19 @@ namespace AngleSharp.Css
             {
                 return longhands
                     .Select(name => new CssInitialValue(factory.Create(name)?.InitialValue))
+                    .OfType<ICssValue>()
+                    .ToArray();
+            }
+            else if (value is CssInheritValue)
+            {
+                return Enumerable
+                    .Repeat(value, longhands.Length)
+                    .ToArray();
+            }
+            else if (value is CssUnsetValue)
+            {
+                return longhands
+                    .Select(name => new CssUnsetValue(factory.Create(name)?.InitialValue))
                     .OfType<ICssValue>()
                     .ToArray();
             }


### PR DESCRIPTION
# Types of Changes

## Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

## Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## Description

Fix CSS inherit keyword not resolving on shorthand properties

The `inherit` keyword on shorthand properties like `border`, `margin`,
and `padding` was not correctly resolved to parent values. Three
independent bugs contributed:

1. DeclarationInfo: shorthand converters with null InitialValue were
   not wrapped with StandardValueConverter, so CSS-wide keywords like
   `inherit` were either ignored or partially mis-parsed by the
   property-specific converter. Fixed by always wrapping with
   StandardValueConverter first.

2. DeclarationInfoExtensions.Expand: CssInheritValue and CssUnsetValue
   were not handled when expanding shorthand properties to longhands,
   causing them to fall through to the aggregator Split which returned
   null. Added explicit handling for both value types.

3. DeclarationInfoExtensions.Collapse: CssInheritValue was not tracked
   for round-trip serialization of shorthand properties. Added inherit
   tracking alongside initial, unset, and child.

4. CssStyleDeclaration.ChangeDeclarations: when UpdateDeclarations
   found a child property with explicit `inherit` value, it removed it
   but did not allow the parent value to replace it because the skip
   flag was not reset. Fixed by setting skip to false when the old
   declaration is removed.

fixes #184 