### PR TITLE
Fix GetInnerText skipping table tabs/newlines when HTML has whitespace between elements

### DIFF
--- a/src/AngleSharp.Css.Tests/Extensions/InnerText.cs
+++ b/src/AngleSharp.Css.Tests/Extensions/InnerText.cs
@@ -47,6 +47,7 @@ namespace AngleSharp.Css.Tests.Extensions
         [TestCase("test1<br>test2<br>test3", "test1\ntest2\ntest3")]
         // table
         [TestCase("<table><tr><td>1</td><td>2</td></tr><tr><td>3</td><td>4</td></tr></table>", "1\t2\n3\t4")]
+        [TestCase("<table><tr><td>1</td> <td>2</td></tr> <tr><td>3</td> <td>4</td></tr></table>", "1\t2\n3\t4")]
         [TestCase("<table><tr><td>1</td><td>2</td></tr><tr><td><table><tr><td>3</td><td>4</td></tr></table></td><td>5</td></tr></table>", "1\t2\n\n3\t4\n\t5")]
         // select
         [TestCase("<select><option>test1</option><option>test2</option></select>", "test1\ntest2")]

--- a/src/AngleSharp.Css/Extensions/ElementExtensions.cs
+++ b/src/AngleSharp.Css/Extensions/ElementExtensions.cs
@@ -204,7 +204,7 @@ namespace AngleSharp.Dom
                 }
                 else if (elementStyle is not null && ((node is IHtmlTableCellElement && String.IsNullOrEmpty(elementStyle.GetDisplay())) || elementStyle.GetDisplay() == CssKeywords.TableCell))
                 {
-                    if (node.NextSibling is IElement nextSibling)
+                    if (((IElement)node).NextElementSibling is IElement nextSibling)
                     {
                         var nextSiblingCss = nextSibling.ComputeCurrentStyle();
 
@@ -216,7 +216,7 @@ namespace AngleSharp.Dom
                 }
                 else if (elementStyle is not null && ((node is IHtmlTableRowElement && String.IsNullOrEmpty(elementStyle.GetDisplay())) || elementStyle.GetDisplay() == CssKeywords.TableRow))
                 {
-                    if (node.NextSibling is IElement nextSibling)
+                    if (((IElement)node).NextElementSibling is IElement nextSibling)
                     {
                         var nextSiblingCss = nextSibling.ComputeCurrentStyle();
 


### PR DESCRIPTION

# Types of Changes

## Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

## Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## Description

Use NextElementSibling instead of NextSibling for table cell and row sibling checks, so whitespace text nodes between elements don't prevent tab/newline insertion.

Without fix: `Test\nTitel: Herr Vorname: Horst Nachname: Hammer`
With fix: `Test\n\nTitel:\tHerr\nVorname:\tHorst\nNachname:\tHammer`

Resolves #174 