### PR TITLE
Optimize GetInnerText with style caching and incremental computation

### DIFF
--- a/src/AngleSharp.Css/Extensions/ElementExtensions.cs
+++ b/src/AngleSharp.Css/Extensions/ElementExtensions.cs
@@ -47,9 +47,17 @@ namespace AngleSharp.Dom
                 hidden = true;
             }
 
+            // Build the style collection once and cache computed styles for the
+            // entire traversal to avoid redundant stylesheet enumeration and
+            // repeated selector matching for the same elements.
+            var document = element.Owner;
+            var window = document?.DefaultView;
+            var styleCollection = window != null ? window.GetStyleCollection() : null;
+            var styleCache = new Dictionary<IElement, ICssStyleDeclaration>();
+
             if (!hidden.HasValue)
             {
-                var css = element.ComputeCurrentStyle();
+                var css = ComputeCachedStyle(element, styleCollection, styleCache);
 
                 if (!String.IsNullOrEmpty(css?.GetDisplay()))
                 {
@@ -67,7 +75,10 @@ namespace AngleSharp.Dom
                 var offset = 0;
                 var sb = StringBuilderPool.Obtain();
                 var requiredLineBreakCounts = new Dictionary<Int32, Int32>();
-                InnerTextCollection(element, sb, requiredLineBreakCounts, element.ParentElement?.ComputeCurrentStyle());
+                var parentStyle = element.ParentElement != null
+                    ? ComputeCachedStyle(element.ParentElement, styleCollection, styleCache)
+                    : null;
+                InnerTextCollection(element, sb, requiredLineBreakCounts, parentStyle, styleCollection, styleCache);
 
                 // Remove any runs of consecutive required line break count items at the start or end of results.
                 requiredLineBreakCounts.Remove(0);
@@ -85,6 +96,36 @@ namespace AngleSharp.Dom
             }
 
             return element.TextContent;
+        }
+
+        private static ICssStyleDeclaration ComputeCachedStyle(IElement element, IStyleCollection styleCollection, Dictionary<IElement, ICssStyleDeclaration> cache)
+        {
+            if (styleCollection == null)
+            {
+                return null;
+            }
+
+            if (cache.TryGetValue(element, out var cached))
+            {
+                return cached;
+            }
+
+            ICssStyleDeclaration style;
+            var parent = element.ParentElement;
+
+            if (parent != null && cache.TryGetValue(parent, out var parentStyle))
+            {
+                // Parent already computed — use incremental computation that
+                // skips the O(depth) ancestor walk.
+                style = styleCollection.ComputeDeclarationsWithParent(element, parentStyle);
+            }
+            else
+            {
+                style = styleCollection.ComputeDeclarations(element);
+            }
+
+            cache[element] = style;
+            return style;
         }
 
         /// <summary>
@@ -149,17 +190,17 @@ namespace AngleSharp.Dom
             }
         }
 
-        private static void InnerTextCollection(INode node, StringBuilder sb, Dictionary<Int32, Int32> requiredLineBreakCounts, ICssStyleDeclaration parentStyle)
+        private static void InnerTextCollection(INode node, StringBuilder sb, Dictionary<Int32, Int32> requiredLineBreakCounts, ICssStyleDeclaration parentStyle, IStyleCollection styleCollection, Dictionary<IElement, ICssStyleDeclaration> styleCache)
         {
             if (HasCssBox(node))
             {
                 var element = node as IElement;
-                var elementCss = element?.ComputeCurrentStyle();
-                ItcInCssBox(elementCss, parentStyle, node, sb, requiredLineBreakCounts);
+                var elementCss = element != null ? ComputeCachedStyle(element, styleCollection, styleCache) : null;
+                ItcInCssBox(elementCss, parentStyle, node, sb, requiredLineBreakCounts, styleCollection, styleCache);
             }
         }
 
-        private static void ItcInCssBox(ICssStyleDeclaration elementStyle, ICssStyleDeclaration parentStyle, INode node, StringBuilder sb, Dictionary<Int32, Int32> requiredLineBreakCounts)
+        private static void ItcInCssBox(ICssStyleDeclaration elementStyle, ICssStyleDeclaration parentStyle, INode node, StringBuilder sb, Dictionary<Int32, Int32> requiredLineBreakCounts, IStyleCollection styleCollection, Dictionary<IElement, ICssStyleDeclaration> styleCache)
         {
             var elementHidden = new Nullable<Boolean>();
 
@@ -188,7 +229,7 @@ namespace AngleSharp.Dom
 
                 foreach (var child in node.ChildNodes)
                 {
-                    InnerTextCollection(child, sb, requiredLineBreakCounts, elementStyle);
+                    InnerTextCollection(child, sb, requiredLineBreakCounts, elementStyle, styleCollection, styleCache);
                 }
 
                 if (node is IText textElement)
@@ -206,7 +247,7 @@ namespace AngleSharp.Dom
                 {
                     if (node.NextSibling is IElement nextSibling)
                     {
-                        var nextSiblingCss = nextSibling.ComputeCurrentStyle();
+                        var nextSiblingCss = ComputeCachedStyle(nextSibling, styleCollection, styleCache);
 
                         if (nextSibling is IHtmlTableCellElement && String.IsNullOrEmpty(nextSiblingCss.GetDisplay()) || nextSiblingCss.GetDisplay() == CssKeywords.TableCell)
                         {
@@ -218,7 +259,7 @@ namespace AngleSharp.Dom
                 {
                     if (node.NextSibling is IElement nextSibling)
                     {
-                        var nextSiblingCss = nextSibling.ComputeCurrentStyle();
+                        var nextSiblingCss = ComputeCachedStyle(nextSibling, styleCollection, styleCache);
 
                         if (nextSibling is IHtmlTableRowElement && String.IsNullOrEmpty(nextSiblingCss.GetDisplay()) || nextSiblingCss.GetDisplay() == CssKeywords.TableRow)
                         {

--- a/src/AngleSharp.Css/Extensions/StyleCollectionExtensions.cs
+++ b/src/AngleSharp.Css/Extensions/StyleCollectionExtensions.cs
@@ -118,6 +118,31 @@ namespace AngleSharp.Css
             return computedStyle;
         }
 
+        /// <summary>
+        /// Computes the declarations for the given element using a pre-computed
+        /// parent style for inheritance, avoiding the O(depth) ancestor walk.
+        /// </summary>
+        /// <param name="styles">The styles to use.</param>
+        /// <param name="element">The element that is questioned.</param>
+        /// <param name="parentComputedStyle">The parent's already-computed style.</param>
+        /// <returns>The style declaration containing all the declarations.</returns>
+        internal static ICssStyleDeclaration ComputeDeclarationsWithParent(this IStyleCollection styles, IElement element, ICssStyleDeclaration parentComputedStyle)
+        {
+            var ctx = element.Owner?.Context;
+            var computedStyle = new CssStyleDeclaration(ctx);
+
+            // Element's own cascaded style (CSS rule matching + inline style).
+            computedStyle.SetDeclarations(styles.ComputeCascadedStyle(element));
+
+            // Inherit from the parent's already-computed style instead of walking
+            // all ancestors individually. The parent style already includes the
+            // full ancestor inheritance chain.
+            computedStyle.UpdateDeclarations(parentComputedStyle);
+
+            var context = new CssComputeContext(styles.Device, ctx, computedStyle);
+            return computedStyle.Compute(context);
+        }
+
         #endregion
 
         #region Helpers


### PR DESCRIPTION
# Types of Changes

## Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

## Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## Description

- Cache computed styles in a dictionary across the entire traversal so the same element is never computed twice (hit as element, parent, and sibling).
- Hoist StyleCollection creation to the top of GetInnerText and reuse it throughout, eliminating repeated stylesheet enumeration and LINQ allocations.
- When the parent's computed style is already cached, use incremental computation (ComputeDeclarationsWithParent) that inherits from the cached parent instead of walking all ancestors - replacing the O(depth) ancestor loop with a single UpdateDeclarations call.

Related #55

Benchmark.net results from similar test to #55 

| Benchmark | Original | Total Speedup | Mem Original | Mem Now | Mem Reduction |
|-----------|----------|---------------|-------------|---------|---------------|
| SmallTable (10×5) | 10.6 ms | **7.7x** | 13 MB | 1.6 MB | **88%** |
| LargeTable (200×15) | 4,666 ms | **10.2x** | 742 MB | 76 MB | **90%** |
| LargeTableBody (200×15) | 7,558 ms | **16.7x** | 738 MB | 76 MB | **90%** |
| AllCells individually (3000) | 8,039 ms | **1.9x** | 1,309 MB | 676 MB | **48%** |