### PR TITLE
Enable nullable reference types solution-wide (but #nullable disabled marked for existing code)

### DIFF
--- a/src/AngleSharp.Css.Tests/CssConstructionFunctions.cs
+++ b/src/AngleSharp.Css.Tests/CssConstructionFunctions.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Tests
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css.Tests/Declarations/CssFontProperty.cs
+++ b/src/AngleSharp.Css.Tests/Declarations/CssFontProperty.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Tests.Declarations
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css.Tests/Declarations/CssVariables.cs
+++ b/src/AngleSharp.Css.Tests/Declarations/CssVariables.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Tests.Declarations
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css.Tests/Extensions/AnalysisWindow.cs
+++ b/src/AngleSharp.Css.Tests/Extensions/AnalysisWindow.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Tests.Extensions
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css.Tests/Extensions/AsyncParsing.cs
+++ b/src/AngleSharp.Css.Tests/Extensions/AsyncParsing.cs
@@ -1,3 +1,4 @@
+#nullable disable
 ﻿namespace AngleSharp.Css.Tests.Extensions
 {
     using AngleSharp.Css.Parser;

--- a/src/AngleSharp.Css.Tests/Extensions/InnerText.cs
+++ b/src/AngleSharp.Css.Tests/Extensions/InnerText.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Tests.Extensions
 {
     using AngleSharp.Dom;

--- a/src/AngleSharp.Css.Tests/Functions/CssDocumentFunction.cs
+++ b/src/AngleSharp.Css.Tests/Functions/CssDocumentFunction.cs
@@ -1,3 +1,4 @@
+#nullable disable
 ﻿namespace AngleSharp.Css.Tests.Functions
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css.Tests/Library/ComputedStyle.cs
+++ b/src/AngleSharp.Css.Tests/Library/ComputedStyle.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Tests.Library
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css.Tests/Library/ExtractInfos.cs
+++ b/src/AngleSharp.Css.Tests/Library/ExtractInfos.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Tests.Library
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css.Tests/Library/StringRepresentation.cs
+++ b/src/AngleSharp.Css.Tests/Library/StringRepresentation.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Tests.Library
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css.Tests/Mocks/MockRequester.cs
+++ b/src/AngleSharp.Css.Tests/Mocks/MockRequester.cs
@@ -1,3 +1,4 @@
+#nullable disable
 ﻿namespace AngleSharp.Css.Tests.Mocks
 {
     using AngleSharp.Io;

--- a/src/AngleSharp.Css.Tests/Mocks/MockScriptEngine.cs
+++ b/src/AngleSharp.Css.Tests/Mocks/MockScriptEngine.cs
@@ -1,3 +1,4 @@
+#nullable disable
 ﻿namespace AngleSharp.Css.Tests.Mocks
 {
     using AngleSharp.Io;

--- a/src/AngleSharp.Css.Tests/Mocks/PageRequester.cs
+++ b/src/AngleSharp.Css.Tests/Mocks/PageRequester.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Tests.Mocks
 {
     using AngleSharp.Dom;

--- a/src/AngleSharp.Css.Tests/Mocks/SiteMapping.cs
+++ b/src/AngleSharp.Css.Tests/Mocks/SiteMapping.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Tests.Mocks
 {
     using AngleSharp.Dom;

--- a/src/AngleSharp.Css.Tests/Mocks/TestServerRequester.cs
+++ b/src/AngleSharp.Css.Tests/Mocks/TestServerRequester.cs
@@ -1,3 +1,4 @@
+#nullable disable
 ﻿namespace AngleSharp.Css.Tests.Mocks
 {
     using AngleSharp.Io;

--- a/src/AngleSharp.Css.Tests/Parsing/LargeValues.cs
+++ b/src/AngleSharp.Css.Tests/Parsing/LargeValues.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Tests.Parsing
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css.Tests/Rules/CssMediaList.cs
+++ b/src/AngleSharp.Css.Tests/Rules/CssMediaList.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Tests.Rules
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css.Tests/Rules/CssSupports.cs
+++ b/src/AngleSharp.Css.Tests/Rules/CssSupports.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Tests.Rules
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css.Tests/Styling/BasicStyling.cs
+++ b/src/AngleSharp.Css.Tests/Styling/BasicStyling.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Tests.Styling
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css.Tests/Styling/ContextLoading.cs
+++ b/src/AngleSharp.Css.Tests/Styling/ContextLoading.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Tests.Styling
 {
     using AngleSharp.Css.Tests.Mocks;

--- a/src/AngleSharp.Css.Tests/Styling/CssCases.cs
+++ b/src/AngleSharp.Css.Tests/Styling/CssCases.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Tests.Styling
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css.Tests/Styling/CssSheet.cs
+++ b/src/AngleSharp.Css.Tests/Styling/CssSheet.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Tests.Styling
 {
     using AngleSharp.Css.Converters;

--- a/src/AngleSharp.Css.Tests/Styling/HtmlCssIntegration.cs
+++ b/src/AngleSharp.Css.Tests/Styling/HtmlCssIntegration.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Tests.Styling
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css.Tests/TestExtensions.cs
+++ b/src/AngleSharp.Css.Tests/TestExtensions.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Tests
 {
     using AngleSharp.Css.Tests.Mocks;

--- a/src/AngleSharp.Css.Tests/Values/Gradient.cs
+++ b/src/AngleSharp.Css.Tests/Values/Gradient.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Tests.Values
 {
     using AngleSharp.Css.Converters;

--- a/src/AngleSharp.Css/BrowsingContextExtensions.cs
+++ b/src/AngleSharp.Css/BrowsingContextExtensions.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Constants/InitialValues.cs
+++ b/src/AngleSharp.Css/Constants/InitialValues.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Converters/CounterValueConverter.cs
+++ b/src/AngleSharp.Css/Converters/CounterValueConverter.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Converters
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Converters/DictionaryValueConverter.cs
+++ b/src/AngleSharp.Css/Converters/DictionaryValueConverter.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Converters
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Converters/FlowRelativeValueConverter.cs
+++ b/src/AngleSharp.Css/Converters/FlowRelativeValueConverter.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Converters
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Converters/IdentifierValueConverter.cs
+++ b/src/AngleSharp.Css/Converters/IdentifierValueConverter.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Converters
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Converters/ListValueConverter.cs
+++ b/src/AngleSharp.Css/Converters/ListValueConverter.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Converters
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Converters/OneOrMoreValueConverter.cs
+++ b/src/AngleSharp.Css/Converters/OneOrMoreValueConverter.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Converters
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Converters/OrValueConverter.cs
+++ b/src/AngleSharp.Css/Converters/OrValueConverter.cs
@@ -1,3 +1,4 @@
+#nullable disable
 ﻿namespace AngleSharp.Css.Converters
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Converters/PeriodicValueConverter.cs
+++ b/src/AngleSharp.Css/Converters/PeriodicValueConverter.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Converters
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Converters/RadiusValueConverter.cs
+++ b/src/AngleSharp.Css/Converters/RadiusValueConverter.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Converters
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Converters/SeparatedEnumsConverter.cs
+++ b/src/AngleSharp.Css/Converters/SeparatedEnumsConverter.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Converters
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Converters/SeparatorConverter.cs
+++ b/src/AngleSharp.Css/Converters/SeparatorConverter.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Converters
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Converters/StandardValueConverter.cs
+++ b/src/AngleSharp.Css/Converters/StandardValueConverter.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Converters
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Converters/StructValueConverter.cs
+++ b/src/AngleSharp.Css/Converters/StructValueConverter.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Converters
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/CssConfigurationExtensions.cs
+++ b/src/AngleSharp.Css/CssConfigurationExtensions.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp
 {
     using AngleSharp.Css;

--- a/src/AngleSharp.Css/CssDefaultStyleSheetProvider.cs
+++ b/src/AngleSharp.Css/CssDefaultStyleSheetProvider.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/CssStylingService.cs
+++ b/src/AngleSharp.Css/CssStylingService.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/DeclarationInfo.cs
+++ b/src/AngleSharp.Css/DeclarationInfo.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Declarations/AnimationDeclaration.cs
+++ b/src/AngleSharp.Css/Declarations/AnimationDeclaration.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Declarations
 {
     using AngleSharp.Css.Converters;

--- a/src/AngleSharp.Css/Declarations/BackgroundDeclaration.cs
+++ b/src/AngleSharp.Css/Declarations/BackgroundDeclaration.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Declarations
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Declarations/BackgroundPositionDeclaration.cs
+++ b/src/AngleSharp.Css/Declarations/BackgroundPositionDeclaration.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Declarations
 {
     using AngleSharp.Css.Converters;

--- a/src/AngleSharp.Css/Declarations/BackgroundRepeatDeclaration.cs
+++ b/src/AngleSharp.Css/Declarations/BackgroundRepeatDeclaration.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Declarations
 {
     using AngleSharp.Css.Converters;

--- a/src/AngleSharp.Css/Declarations/BorderBottomDeclaration.cs
+++ b/src/AngleSharp.Css/Declarations/BorderBottomDeclaration.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Declarations
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Declarations/BorderColorDeclaration.cs
+++ b/src/AngleSharp.Css/Declarations/BorderColorDeclaration.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Declarations
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Declarations/BorderDeclaration.cs
+++ b/src/AngleSharp.Css/Declarations/BorderDeclaration.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Declarations
 {
     using AngleSharp.Css.Converters;

--- a/src/AngleSharp.Css/Declarations/BorderImageDeclaration.cs
+++ b/src/AngleSharp.Css/Declarations/BorderImageDeclaration.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Declarations
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Declarations/BorderLeftDeclaration.cs
+++ b/src/AngleSharp.Css/Declarations/BorderLeftDeclaration.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Declarations
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Declarations/BorderRadiusDeclaration.cs
+++ b/src/AngleSharp.Css/Declarations/BorderRadiusDeclaration.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Declarations
 {
     using AngleSharp.Css.Converters;

--- a/src/AngleSharp.Css/Declarations/BorderRightDeclaration.cs
+++ b/src/AngleSharp.Css/Declarations/BorderRightDeclaration.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Declarations
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Declarations/BorderStyleDeclaration.cs
+++ b/src/AngleSharp.Css/Declarations/BorderStyleDeclaration.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Declarations
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Declarations/BorderTopDeclaration.cs
+++ b/src/AngleSharp.Css/Declarations/BorderTopDeclaration.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Declarations
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Declarations/BorderWidthDeclaration.cs
+++ b/src/AngleSharp.Css/Declarations/BorderWidthDeclaration.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Declarations
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Declarations/ColumnRuleDeclaration.cs
+++ b/src/AngleSharp.Css/Declarations/ColumnRuleDeclaration.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Declarations
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Declarations/ColumnsDeclaration.cs
+++ b/src/AngleSharp.Css/Declarations/ColumnsDeclaration.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Declarations
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Declarations/ContentDeclaration.cs
+++ b/src/AngleSharp.Css/Declarations/ContentDeclaration.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Declarations
 {
     using AngleSharp.Css.Converters;

--- a/src/AngleSharp.Css/Declarations/CursorDeclaration.cs
+++ b/src/AngleSharp.Css/Declarations/CursorDeclaration.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Declarations
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Declarations/FlexDeclaration.cs
+++ b/src/AngleSharp.Css/Declarations/FlexDeclaration.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Declarations
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Declarations/FlexFlowDeclaration.cs
+++ b/src/AngleSharp.Css/Declarations/FlexFlowDeclaration.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Declarations
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Declarations/FontDeclaration.cs
+++ b/src/AngleSharp.Css/Declarations/FontDeclaration.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Declarations
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Declarations/GapDeclaration.cs
+++ b/src/AngleSharp.Css/Declarations/GapDeclaration.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Declarations
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Declarations/GridAreaDeclaration.cs
+++ b/src/AngleSharp.Css/Declarations/GridAreaDeclaration.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Declarations
 {
     using AngleSharp.Css.Converters;

--- a/src/AngleSharp.Css/Declarations/GridColumnDeclaration.cs
+++ b/src/AngleSharp.Css/Declarations/GridColumnDeclaration.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Declarations
 {
     using AngleSharp.Css.Converters;

--- a/src/AngleSharp.Css/Declarations/GridColumnEndDeclaration.cs
+++ b/src/AngleSharp.Css/Declarations/GridColumnEndDeclaration.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Declarations
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Declarations/GridColumnStartDeclaration.cs
+++ b/src/AngleSharp.Css/Declarations/GridColumnStartDeclaration.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Declarations
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Declarations/GridDeclaration.cs
+++ b/src/AngleSharp.Css/Declarations/GridDeclaration.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Declarations
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Declarations/GridGapDeclaration.cs
+++ b/src/AngleSharp.Css/Declarations/GridGapDeclaration.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Declarations
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Declarations/GridRowDeclaration.cs
+++ b/src/AngleSharp.Css/Declarations/GridRowDeclaration.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Declarations
 {
     using AngleSharp.Css.Converters;

--- a/src/AngleSharp.Css/Declarations/GridRowEndDeclaration.cs
+++ b/src/AngleSharp.Css/Declarations/GridRowEndDeclaration.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Declarations
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Declarations/GridRowStartDeclaration.cs
+++ b/src/AngleSharp.Css/Declarations/GridRowStartDeclaration.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Declarations
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Declarations/GridTemplateDeclaration.cs
+++ b/src/AngleSharp.Css/Declarations/GridTemplateDeclaration.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Declarations
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Declarations/ListStyleDeclaration.cs
+++ b/src/AngleSharp.Css/Declarations/ListStyleDeclaration.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Declarations
 {
     using AngleSharp.Css.Converters;

--- a/src/AngleSharp.Css/Declarations/MarginBlockDeclaration.cs
+++ b/src/AngleSharp.Css/Declarations/MarginBlockDeclaration.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Declarations
 {
     using AngleSharp.Css.Converters;

--- a/src/AngleSharp.Css/Declarations/MarginDeclaration.cs
+++ b/src/AngleSharp.Css/Declarations/MarginDeclaration.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Declarations
 {
     using AngleSharp.Css.Converters;

--- a/src/AngleSharp.Css/Declarations/MarginInlineDeclaration.cs
+++ b/src/AngleSharp.Css/Declarations/MarginInlineDeclaration.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Declarations
 {
     using AngleSharp.Css.Converters;

--- a/src/AngleSharp.Css/Declarations/OrderDeclaration.cs
+++ b/src/AngleSharp.Css/Declarations/OrderDeclaration.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Declarations
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Declarations/OutlineDeclaration.cs
+++ b/src/AngleSharp.Css/Declarations/OutlineDeclaration.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Declarations
 {
     using AngleSharp.Css.Converters;

--- a/src/AngleSharp.Css/Declarations/PaddingBlockDeclaration.cs
+++ b/src/AngleSharp.Css/Declarations/PaddingBlockDeclaration.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Declarations
 {
     using AngleSharp.Css.Converters;

--- a/src/AngleSharp.Css/Declarations/PaddingDeclaration.cs
+++ b/src/AngleSharp.Css/Declarations/PaddingDeclaration.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Declarations
 {
     using AngleSharp.Css.Converters;

--- a/src/AngleSharp.Css/Declarations/PaddingInlineDeclaration.cs
+++ b/src/AngleSharp.Css/Declarations/PaddingInlineDeclaration.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Declarations
 {
     using AngleSharp.Css.Converters;

--- a/src/AngleSharp.Css/Declarations/SrcDeclaration.cs
+++ b/src/AngleSharp.Css/Declarations/SrcDeclaration.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Declarations
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Declarations/StrokeDeclaration.cs
+++ b/src/AngleSharp.Css/Declarations/StrokeDeclaration.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Declarations
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Declarations/TextDecorationDeclaration.cs
+++ b/src/AngleSharp.Css/Declarations/TextDecorationDeclaration.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Declarations
 {
     using AngleSharp.Css.Converters;

--- a/src/AngleSharp.Css/Declarations/TransitionDeclaration.cs
+++ b/src/AngleSharp.Css/Declarations/TransitionDeclaration.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Declarations
 {
     using AngleSharp.Css.Converters;

--- a/src/AngleSharp.Css/Declarations/UnicodeRangeDeclaration.cs
+++ b/src/AngleSharp.Css/Declarations/UnicodeRangeDeclaration.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Declarations
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Dom/CssHelpers.cs
+++ b/src/AngleSharp.Css/Dom/CssHelpers.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Dom
 {
     using AngleSharp.Attributes;

--- a/src/AngleSharp.Css/Dom/ElementCssInlineStyleExtensions.cs
+++ b/src/AngleSharp.Css/Dom/ElementCssInlineStyleExtensions.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Dom
 {
     using AngleSharp.Attributes;

--- a/src/AngleSharp.Css/Dom/Events/MediaQueryListEvent.cs
+++ b/src/AngleSharp.Css/Dom/Events/MediaQueryListEvent.cs
@@ -1,3 +1,4 @@
+#nullable disable
 ﻿namespace AngleSharp.Css.Dom.Events
 {
     using AngleSharp.Attributes;

--- a/src/AngleSharp.Css/Dom/ICssProperties .cs
+++ b/src/AngleSharp.Css/Dom/ICssProperties .cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Dom
 {
     using AngleSharp.Attributes;

--- a/src/AngleSharp.Css/Dom/Internal/CssMedium.cs
+++ b/src/AngleSharp.Css/Dom/Internal/CssMedium.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Dom
 {
     using AngleSharp.Text;

--- a/src/AngleSharp.Css/Dom/Internal/CssProperty.cs
+++ b/src/AngleSharp.Css/Dom/Internal/CssProperty.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Dom
 {
     using AngleSharp.Css;

--- a/src/AngleSharp.Css/Dom/Internal/CssPseudoElement.cs
+++ b/src/AngleSharp.Css/Dom/Internal/CssPseudoElement.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Dom
 {
     using AngleSharp.Dom;

--- a/src/AngleSharp.Css/Dom/Internal/CssPseudoElementList.cs
+++ b/src/AngleSharp.Css/Dom/Internal/CssPseudoElementList.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Dom
 {
     using System;

--- a/src/AngleSharp.Css/Dom/Internal/CssRule.cs
+++ b/src/AngleSharp.Css/Dom/Internal/CssRule.cs
@@ -1,3 +1,4 @@
+#nullable disable
 ﻿namespace AngleSharp.Css.Dom
 {
     using AngleSharp.Css.Parser;

--- a/src/AngleSharp.Css/Dom/Internal/CssStyleDeclaration.cs
+++ b/src/AngleSharp.Css/Dom/Internal/CssStyleDeclaration.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Dom
 {
     using AngleSharp.Css;

--- a/src/AngleSharp.Css/Dom/Internal/CssStyleSheet.cs
+++ b/src/AngleSharp.Css/Dom/Internal/CssStyleSheet.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Dom
 {
     using AngleSharp.Css.Parser;

--- a/src/AngleSharp.Css/Dom/Internal/MediaFeature.cs
+++ b/src/AngleSharp.Css/Dom/Internal/MediaFeature.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Dom
 {
     using AngleSharp.Css.Values;

--- a/src/AngleSharp.Css/Dom/Internal/MediaList.cs
+++ b/src/AngleSharp.Css/Dom/Internal/MediaList.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Dom
 {
     using AngleSharp.Css.Parser;

--- a/src/AngleSharp.Css/Dom/Internal/PseudoElement.cs
+++ b/src/AngleSharp.Css/Dom/Internal/PseudoElement.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Dom
 {
     using AngleSharp.Dom;

--- a/src/AngleSharp.Css/Dom/Internal/ReferencedNestedSelector.cs
+++ b/src/AngleSharp.Css/Dom/Internal/ReferencedNestedSelector.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Dom
 {
     using AngleSharp.Dom;

--- a/src/AngleSharp.Css/Dom/Internal/Rules/CssCounterStyleRule.cs
+++ b/src/AngleSharp.Css/Dom/Internal/Rules/CssCounterStyleRule.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Dom
 {
     using AngleSharp.Css;

--- a/src/AngleSharp.Css/Dom/Internal/Rules/CssDeclarationRule.cs
+++ b/src/AngleSharp.Css/Dom/Internal/Rules/CssDeclarationRule.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Dom
 {
     using AngleSharp.Css.Parser;

--- a/src/AngleSharp.Css/Dom/Internal/Rules/CssDocumentRule.cs
+++ b/src/AngleSharp.Css/Dom/Internal/Rules/CssDocumentRule.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Dom
 {
     using AngleSharp.Css.Parser;

--- a/src/AngleSharp.Css/Dom/Internal/Rules/CssFontFeatureValuesRule.cs
+++ b/src/AngleSharp.Css/Dom/Internal/Rules/CssFontFeatureValuesRule.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Dom
 {
     using AngleSharp.Css;

--- a/src/AngleSharp.Css/Dom/Internal/Rules/CssGroupingRule.cs
+++ b/src/AngleSharp.Css/Dom/Internal/Rules/CssGroupingRule.cs
@@ -1,3 +1,4 @@
+#nullable disable
 ﻿namespace AngleSharp.Css.Dom
 {
     using System;

--- a/src/AngleSharp.Css/Dom/Internal/Rules/CssImportRule.cs
+++ b/src/AngleSharp.Css/Dom/Internal/Rules/CssImportRule.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Dom
 {
     using System;

--- a/src/AngleSharp.Css/Dom/Internal/Rules/CssKeyframeRule.cs
+++ b/src/AngleSharp.Css/Dom/Internal/Rules/CssKeyframeRule.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Dom
 {
     using AngleSharp.Css.Parser;

--- a/src/AngleSharp.Css/Dom/Internal/Rules/CssKeyframesRule.cs
+++ b/src/AngleSharp.Css/Dom/Internal/Rules/CssKeyframesRule.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Dom
 {
     using AngleSharp.Text;

--- a/src/AngleSharp.Css/Dom/Internal/Rules/CssPageRule.cs
+++ b/src/AngleSharp.Css/Dom/Internal/Rules/CssPageRule.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Dom
 {
     using AngleSharp.Dom;

--- a/src/AngleSharp.Css/Dom/Internal/Rules/CssStyleRule.cs
+++ b/src/AngleSharp.Css/Dom/Internal/Rules/CssStyleRule.cs
@@ -1,3 +1,5 @@
+#nullable enable annotations
+#nullable disable warnings
 namespace AngleSharp.Css.Dom
 {
     using AngleSharp.Css;

--- a/src/AngleSharp.Css/Dom/Internal/Rules/CssSupportsRule.cs
+++ b/src/AngleSharp.Css/Dom/Internal/Rules/CssSupportsRule.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Dom
 {
     using AngleSharp.Css.Parser;

--- a/src/AngleSharp.Css/Dom/StyleUtilityExtensions.cs
+++ b/src/AngleSharp.Css/Dom/StyleUtilityExtensions.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Dom
 {
     using AngleSharp.Attributes;

--- a/src/AngleSharp.Css/Extensions/CssApiExtensions.cs
+++ b/src/AngleSharp.Css/Extensions/CssApiExtensions.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Dom
 {
     using AngleSharp.Common;

--- a/src/AngleSharp.Css/Extensions/CssOmExtensions.cs
+++ b/src/AngleSharp.Css/Extensions/CssOmExtensions.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Dom
 {
     using AngleSharp.Css.Parser;

--- a/src/AngleSharp.Css/Extensions/CssValueExtensions.cs
+++ b/src/AngleSharp.Css/Extensions/CssValueExtensions.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Dom
 {
     using AngleSharp.Css.Values;

--- a/src/AngleSharp.Css/Extensions/DeclarationInfoExtensions.cs
+++ b/src/AngleSharp.Css/Extensions/DeclarationInfoExtensions.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Extensions/ElementExtensions.cs
+++ b/src/AngleSharp.Css/Extensions/ElementExtensions.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Dom
 {
     using AngleSharp.Attributes;

--- a/src/AngleSharp.Css/Extensions/RenderNodeExtensions.cs
+++ b/src/AngleSharp.Css/Extensions/RenderNodeExtensions.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.RenderTree
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Extensions/StringExtensions.cs
+++ b/src/AngleSharp.Css/Extensions/StringExtensions.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css
 {
     using AngleSharp.Common;

--- a/src/AngleSharp.Css/Extensions/StyleCollectionExtensions.cs
+++ b/src/AngleSharp.Css/Extensions/StyleCollectionExtensions.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Extensions/StyleSheetExtensions.cs
+++ b/src/AngleSharp.Css/Extensions/StyleSheetExtensions.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Dom
 {
     using AngleSharp.Css;

--- a/src/AngleSharp.Css/Extensions/ValueConverterExtensions.cs
+++ b/src/AngleSharp.Css/Extensions/ValueConverterExtensions.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Converters
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Extensions/WindowExtensions.cs
+++ b/src/AngleSharp.Css/Extensions/WindowExtensions.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Dom
 {
     using AngleSharp.Attributes;

--- a/src/AngleSharp.Css/Factories/DefaultDeclarationFactory.cs
+++ b/src/AngleSharp.Css/Factories/DefaultDeclarationFactory.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css
 {
     using AngleSharp.Css.Declarations;

--- a/src/AngleSharp.Css/Factories/DefaultDocumentFunctionFactory.cs
+++ b/src/AngleSharp.Css/Factories/DefaultDocumentFunctionFactory.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Factories/DefaultFeatureValidatorFactory.cs
+++ b/src/AngleSharp.Css/Factories/DefaultFeatureValidatorFactory.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css
 {
     using AngleSharp.Css.FeatureValidators;

--- a/src/AngleSharp.Css/Factories/DefaultPseudoElementFactory.cs
+++ b/src/AngleSharp.Css/Factories/DefaultPseudoElementFactory.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Factories/StyleAttributeObserver.cs
+++ b/src/AngleSharp.Css/Factories/StyleAttributeObserver.cs
@@ -1,3 +1,4 @@
+#nullable disable
 ﻿namespace AngleSharp.Css
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Parser/CssBuilder.cs
+++ b/src/AngleSharp.Css/Parser/CssBuilder.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Parser
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Parser/CssParser.cs
+++ b/src/AngleSharp.Css/Parser/CssParser.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Parser
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Parser/CssTokenizer.cs
+++ b/src/AngleSharp.Css/Parser/CssTokenizer.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Parser
 {
     using AngleSharp.Common;

--- a/src/AngleSharp.Css/Parser/Micro/CalcParser.cs
+++ b/src/AngleSharp.Css/Parser/Micro/CalcParser.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Parser
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Parser/Micro/ColorParser.cs
+++ b/src/AngleSharp.Css/Parser/Micro/ColorParser.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Parser
 {
     using AngleSharp.Css.Values;

--- a/src/AngleSharp.Css/Parser/Micro/CompoundParser.cs
+++ b/src/AngleSharp.Css/Parser/Micro/CompoundParser.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Parser
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Parser/Micro/ConditionParser.cs
+++ b/src/AngleSharp.Css/Parser/Micro/ConditionParser.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Parser
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Parser/Micro/CssUriParser.cs
+++ b/src/AngleSharp.Css/Parser/Micro/CssUriParser.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Parser
 {
     using AngleSharp.Css.Values;

--- a/src/AngleSharp.Css/Parser/Micro/DocumentFunctionParser.cs
+++ b/src/AngleSharp.Css/Parser/Micro/DocumentFunctionParser.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Parser
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Parser/Micro/FunctionParser.cs
+++ b/src/AngleSharp.Css/Parser/Micro/FunctionParser.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Parser
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Parser/Micro/GradientParser.cs
+++ b/src/AngleSharp.Css/Parser/Micro/GradientParser.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Parser
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Parser/Micro/GridParser.cs
+++ b/src/AngleSharp.Css/Parser/Micro/GridParser.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Parser
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Parser/Micro/IdentParser.cs
+++ b/src/AngleSharp.Css/Parser/Micro/IdentParser.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Parser
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Parser/Micro/KeyframeParser.cs
+++ b/src/AngleSharp.Css/Parser/Micro/KeyframeParser.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Parser
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Parser/Micro/MediaParser.cs
+++ b/src/AngleSharp.Css/Parser/Micro/MediaParser.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Parser
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Parser/Micro/MediumParser.cs
+++ b/src/AngleSharp.Css/Parser/Micro/MediumParser.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Parser
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Parser/Micro/PointParser.cs
+++ b/src/AngleSharp.Css/Parser/Micro/PointParser.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Parser
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Parser/Micro/ShadowParser.cs
+++ b/src/AngleSharp.Css/Parser/Micro/ShadowParser.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Parser
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Parser/Micro/ShapeParser.cs
+++ b/src/AngleSharp.Css/Parser/Micro/ShapeParser.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Parser
 {
     using AngleSharp.Css.Values;

--- a/src/AngleSharp.Css/Parser/Micro/StringParser.cs
+++ b/src/AngleSharp.Css/Parser/Micro/StringParser.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Parser
 {
     using AngleSharp.Text;

--- a/src/AngleSharp.Css/Parser/Micro/SymbolsParser.cs
+++ b/src/AngleSharp.Css/Parser/Micro/SymbolsParser.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Parser
 {
     using AngleSharp.Css.Values;

--- a/src/AngleSharp.Css/Parser/Micro/TimingFunctionParser.cs
+++ b/src/AngleSharp.Css/Parser/Micro/TimingFunctionParser.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Parser
 {
     using AngleSharp.Css.Values;

--- a/src/AngleSharp.Css/Parser/Micro/TransformParser.cs
+++ b/src/AngleSharp.Css/Parser/Micro/TransformParser.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Parser
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Parser/Micro/UnitParser.cs
+++ b/src/AngleSharp.Css/Parser/Micro/UnitParser.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Parser
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/RenderTree/RenderTreeBuilder.cs
+++ b/src/AngleSharp.Css/RenderTree/RenderTreeBuilder.cs
@@ -1,3 +1,5 @@
+#nullable enable annotations
+#nullable disable warnings
 namespace AngleSharp.Css.RenderTree
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/ValueConverters.cs
+++ b/src/AngleSharp.Css/ValueConverters.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css
 {
     using AngleSharp.Css.Converters;

--- a/src/AngleSharp.Css/Values/Composites/CssBackgroundLayerValue.cs
+++ b/src/AngleSharp.Css/Values/Composites/CssBackgroundLayerValue.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Values
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Values/Composites/CssBackgroundSizeValue.cs
+++ b/src/AngleSharp.Css/Values/Composites/CssBackgroundSizeValue.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Values
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Values/Composites/CssBackgroundValue.cs
+++ b/src/AngleSharp.Css/Values/Composites/CssBackgroundValue.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Values
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Values/Composites/CssBorderImageSliceValue.cs
+++ b/src/AngleSharp.Css/Values/Composites/CssBorderImageSliceValue.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Values
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Values/Composites/CssBorderImageValue.cs
+++ b/src/AngleSharp.Css/Values/Composites/CssBorderImageValue.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Values
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Values/Composites/CssBorderRadiusValue.cs
+++ b/src/AngleSharp.Css/Values/Composites/CssBorderRadiusValue.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Values
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Values/Composites/CssCursorValue.cs
+++ b/src/AngleSharp.Css/Values/Composites/CssCursorValue.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Values
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Values/Composites/CssCustomCursorValue.cs
+++ b/src/AngleSharp.Css/Values/Composites/CssCustomCursorValue.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Values
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Values/Composites/CssFontValue.cs
+++ b/src/AngleSharp.Css/Values/Composites/CssFontValue.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Values
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Values/Composites/CssGradientStopValue.cs
+++ b/src/AngleSharp.Css/Values/Composites/CssGradientStopValue.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Values
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Values/Composites/CssGridTemplateValue.cs
+++ b/src/AngleSharp.Css/Values/Composites/CssGridTemplateValue.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Values
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Values/Composites/CssGridValue.cs
+++ b/src/AngleSharp.Css/Values/Composites/CssGridValue.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Values
 {
     using AngleSharp.Css.Converters;

--- a/src/AngleSharp.Css/Values/Composites/CssImageRepeatsValue.cs
+++ b/src/AngleSharp.Css/Values/Composites/CssImageRepeatsValue.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Values
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Values/Composites/CssOriginValue.cs
+++ b/src/AngleSharp.Css/Values/Composites/CssOriginValue.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Values
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Values/Composites/CssPoint2D.cs
+++ b/src/AngleSharp.Css/Values/Composites/CssPoint2D.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Values
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Values/Composites/CssRatioValue.cs
+++ b/src/AngleSharp.Css/Values/Composites/CssRatioValue.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Values
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Values/Composites/CssShadowValue.cs
+++ b/src/AngleSharp.Css/Values/Composites/CssShadowValue.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Values
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Values/CssChildValue.cs
+++ b/src/AngleSharp.Css/Values/CssChildValue.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Values
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Values/CssColors.cs
+++ b/src/AngleSharp.Css/Values/CssColors.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Values
 {
     using System;

--- a/src/AngleSharp.Css/Values/Expressions/CssCalcAddExpression.cs
+++ b/src/AngleSharp.Css/Values/Expressions/CssCalcAddExpression.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Values
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Values/Expressions/CssCalcBracketExpression.cs
+++ b/src/AngleSharp.Css/Values/Expressions/CssCalcBracketExpression.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Values
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Values/Expressions/CssCalcDivExpression.cs
+++ b/src/AngleSharp.Css/Values/Expressions/CssCalcDivExpression.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Values
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Values/Expressions/CssCalcMulExpression.cs
+++ b/src/AngleSharp.Css/Values/Expressions/CssCalcMulExpression.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Values
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Values/Expressions/CssCalcSubExpression.cs
+++ b/src/AngleSharp.Css/Values/Expressions/CssCalcSubExpression.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Values
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Values/Functions/CssAttrValue.cs
+++ b/src/AngleSharp.Css/Values/Functions/CssAttrValue.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Values
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Values/Functions/CssCalcValue.cs
+++ b/src/AngleSharp.Css/Values/Functions/CssCalcValue.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Values
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Values/Functions/CssConicGradientValue.cs
+++ b/src/AngleSharp.Css/Values/Functions/CssConicGradientValue.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Values
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Values/Functions/CssContentValue.cs
+++ b/src/AngleSharp.Css/Values/Functions/CssContentValue.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Values
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Values/Functions/CssCubicBezierValue.cs
+++ b/src/AngleSharp.Css/Values/Functions/CssCubicBezierValue.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Values
 {
     using AngleSharp.Css.Converters;

--- a/src/AngleSharp.Css/Values/Functions/CssFitContentValue.cs
+++ b/src/AngleSharp.Css/Values/Functions/CssFitContentValue.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Values
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Values/Functions/CssFontFormatValue.cs
+++ b/src/AngleSharp.Css/Values/Functions/CssFontFormatValue.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Values
 {
     using AngleSharp.Css.Converters;

--- a/src/AngleSharp.Css/Values/Functions/CssLinearGradientValue.cs
+++ b/src/AngleSharp.Css/Values/Functions/CssLinearGradientValue.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Values
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Values/Functions/CssLocalFontValue.cs
+++ b/src/AngleSharp.Css/Values/Functions/CssLocalFontValue.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Values
 {
     using AngleSharp.Css.Converters;

--- a/src/AngleSharp.Css/Values/Functions/CssMatrixValue.cs
+++ b/src/AngleSharp.Css/Values/Functions/CssMatrixValue.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Values
 {
     using AngleSharp.Css.Converters;

--- a/src/AngleSharp.Css/Values/Functions/CssMinMaxValue.cs
+++ b/src/AngleSharp.Css/Values/Functions/CssMinMaxValue.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Values
 {
     using AngleSharp.Css.Converters;

--- a/src/AngleSharp.Css/Values/Functions/CssNoneValue.cs
+++ b/src/AngleSharp.Css/Values/Functions/CssNoneValue.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Values
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Values/Functions/CssPerspectiveValue.cs
+++ b/src/AngleSharp.Css/Values/Functions/CssPerspectiveValue.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Values
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Values/Functions/CssRadialGradientValue.cs
+++ b/src/AngleSharp.Css/Values/Functions/CssRadialGradientValue.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Values
 {
     using AngleSharp.Css.Converters;

--- a/src/AngleSharp.Css/Values/Functions/CssRepeatValue.cs
+++ b/src/AngleSharp.Css/Values/Functions/CssRepeatValue.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Values
 {
     using AngleSharp.Css.Converters;

--- a/src/AngleSharp.Css/Values/Functions/CssRotateValue.cs
+++ b/src/AngleSharp.Css/Values/Functions/CssRotateValue.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Values
 {
     using AngleSharp.Css.Converters;

--- a/src/AngleSharp.Css/Values/Functions/CssRunningValue.cs
+++ b/src/AngleSharp.Css/Values/Functions/CssRunningValue.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Values
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Values/Functions/CssScaleValue.cs
+++ b/src/AngleSharp.Css/Values/Functions/CssScaleValue.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Values
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Values/Functions/CssShapeValue.cs
+++ b/src/AngleSharp.Css/Values/Functions/CssShapeValue.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Values
 {
     using AngleSharp.Css.Converters;

--- a/src/AngleSharp.Css/Values/Functions/CssSkewValue.cs
+++ b/src/AngleSharp.Css/Values/Functions/CssSkewValue.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Values
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Values/Functions/CssStepsValue.cs
+++ b/src/AngleSharp.Css/Values/Functions/CssStepsValue.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Values
 {
     using AngleSharp.Css.Converters;

--- a/src/AngleSharp.Css/Values/Functions/CssSymbolsValue.cs
+++ b/src/AngleSharp.Css/Values/Functions/CssSymbolsValue.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Values
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Values/Functions/CssTranslateValue.cs
+++ b/src/AngleSharp.Css/Values/Functions/CssTranslateValue.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Values
 {
     using AngleSharp.Css.Converters;

--- a/src/AngleSharp.Css/Values/Functions/CssUrlValue.cs
+++ b/src/AngleSharp.Css/Values/Functions/CssUrlValue.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Values
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Values/Functions/CssVarValue.cs
+++ b/src/AngleSharp.Css/Values/Functions/CssVarValue.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Values
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Values/Multiples/CssFlowRelativeValue.cs
+++ b/src/AngleSharp.Css/Values/Multiples/CssFlowRelativeValue.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Values
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Values/Multiples/CssListValue.cs
+++ b/src/AngleSharp.Css/Values/Multiples/CssListValue.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Values
 {
     using AngleSharp.Css.Converters;

--- a/src/AngleSharp.Css/Values/Multiples/CssPeriodicValue.cs
+++ b/src/AngleSharp.Css/Values/Multiples/CssPeriodicValue.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Values
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Values/Multiples/CssRadiusValue.cs
+++ b/src/AngleSharp.Css/Values/Multiples/CssRadiusValue.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Values
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Values/Multiples/CssTupleValue.cs
+++ b/src/AngleSharp.Css/Values/Multiples/CssTupleValue.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Values
 {
     using AngleSharp.Css.Converters;

--- a/src/AngleSharp.Css/Values/Primitives/CssAngleValue.cs
+++ b/src/AngleSharp.Css/Values/Primitives/CssAngleValue.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Values
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Values/Primitives/CssColorValue.cs
+++ b/src/AngleSharp.Css/Values/Primitives/CssColorValue.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Values
 {
     using AngleSharp.Css;

--- a/src/AngleSharp.Css/Values/Primitives/CssConstantValue.cs
+++ b/src/AngleSharp.Css/Values/Primitives/CssConstantValue.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Values
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Values/Primitives/CssCounterDefinitionValue.cs
+++ b/src/AngleSharp.Css/Values/Primitives/CssCounterDefinitionValue.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Values
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Values/Primitives/CssCounterValue.cs
+++ b/src/AngleSharp.Css/Values/Primitives/CssCounterValue.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Values
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Values/Primitives/CssFractionValue.cs
+++ b/src/AngleSharp.Css/Values/Primitives/CssFractionValue.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Values
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Values/Primitives/CssFrequencyValue.cs
+++ b/src/AngleSharp.Css/Values/Primitives/CssFrequencyValue.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Values
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Values/Primitives/CssIdentifierValue.cs
+++ b/src/AngleSharp.Css/Values/Primitives/CssIdentifierValue.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Values
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Values/Primitives/CssIntegerValue.cs
+++ b/src/AngleSharp.Css/Values/Primitives/CssIntegerValue.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Values
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Values/Primitives/CssLengthValue.cs
+++ b/src/AngleSharp.Css/Values/Primitives/CssLengthValue.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Values
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Values/Primitives/CssLineNamesValue.cs
+++ b/src/AngleSharp.Css/Values/Primitives/CssLineNamesValue.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Values
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Values/Primitives/CssNumberValue.cs
+++ b/src/AngleSharp.Css/Values/Primitives/CssNumberValue.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Values
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Values/Primitives/CssPercentageValue.cs
+++ b/src/AngleSharp.Css/Values/Primitives/CssPercentageValue.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Values
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Values/Primitives/CssQuoteValue.cs
+++ b/src/AngleSharp.Css/Values/Primitives/CssQuoteValue.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Values
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Values/Primitives/CssResolutionValue.cs
+++ b/src/AngleSharp.Css/Values/Primitives/CssResolutionValue.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Values
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Values/Primitives/CssStringValue.cs
+++ b/src/AngleSharp.Css/Values/Primitives/CssStringValue.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Values
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Values/Primitives/CssTimeValue.cs
+++ b/src/AngleSharp.Css/Values/Primitives/CssTimeValue.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Values
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Values/Raws/CssAnyValue.cs
+++ b/src/AngleSharp.Css/Values/Raws/CssAnyValue.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Values
 {
     using AngleSharp.Css.Converters;

--- a/src/AngleSharp.Css/Values/Raws/CssInheritValue.cs
+++ b/src/AngleSharp.Css/Values/Raws/CssInheritValue.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Values
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Values/Raws/CssInitialValue.cs
+++ b/src/AngleSharp.Css/Values/Raws/CssInitialValue.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Values
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Values/Raws/CssReferenceValue.cs
+++ b/src/AngleSharp.Css/Values/Raws/CssReferenceValue.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Values
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Values/Raws/CssUnsetValue.cs
+++ b/src/AngleSharp.Css/Values/Raws/CssUnsetValue.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Values
 {
     using AngleSharp.Css.Dom;

--- a/src/AngleSharp.Css/Values/TransformMatrix.cs
+++ b/src/AngleSharp.Css/Values/TransformMatrix.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace AngleSharp.Css.Values
 {
     using System;

--- a/src/AngleSharp.Performance.Common/TestSuite.cs
+++ b/src/AngleSharp.Performance.Common/TestSuite.cs
@@ -1,4 +1,5 @@
-﻿namespace AngleSharp.Performance
+﻿#nullable disable
+namespace AngleSharp.Performance
 {
     using System;
     using System.Collections.Generic;

--- a/src/AngleSharp.Performance.Utilities/UrlTest.cs
+++ b/src/AngleSharp.Performance.Utilities/UrlTest.cs
@@ -1,4 +1,5 @@
-﻿namespace AngleSharp.Performance
+﻿#nullable disable
+namespace AngleSharp.Performance
 {
     using System;
     using System.IO;

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,5 +3,6 @@
     <Description>Extends the CSSOM from the core AngleSharp library.</Description>
     <Product>AngleSharp.Css</Product>
     <Version>1.0.0</Version>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
# Types of Changes

## Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

## Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## Description

Files with non-trivial nullable warnings get #nullable disable to preserve current behavior.
Relates to https://github.com/AngleSharp/AngleSharp.Css/pull/157#issuecomment-3305590250

Aligns to approach seen in parent project to enable globally. and mark disable.

