### PR TITLE
Fix performance benchmark TFM compatibility. Update to latest ExCSS ver

### DIFF
--- a/src/AngleSharp.Performance.Css/AngleSharp.Performance.Css.csproj
+++ b/src/AngleSharp.Performance.Css/AngleSharp.Performance.Css.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFrameworks>net472;net10.0</TargetFrameworks>
     <ApplicationIcon />
     <OutputType>Exe</OutputType>
     <StartupObject />
@@ -26,8 +26,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Alba.CsCss" version="1.0.1.0" />
     <PackageReference Include="AngleSharp" Version="1.4.0" />
-    <PackageReference Include="ExCSS" version="2.0.6" />
+    <PackageReference Include="ExCSS" version="4.3.1" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
+    <PackageReference Include="Alba.CsCss" version="1.0.1.0" />
   </ItemGroup>
 </Project>

--- a/src/AngleSharp.Performance.Css/CsCssParser.cs
+++ b/src/AngleSharp.Performance.Css/CsCssParser.cs
@@ -1,4 +1,5 @@
-﻿namespace AngleSharp.Performance.Css
+﻿#if NET472
+namespace AngleSharp.Performance.Css
 {
     using Alba.CsCss.Style;
     using System;
@@ -24,3 +25,4 @@
         }
     }
 }
+#endif

--- a/src/AngleSharp.Performance.Css/ExCssParser.cs
+++ b/src/AngleSharp.Performance.Css/ExCssParser.cs
@@ -7,11 +7,11 @@
     {
         public String Name => "ExCSS";
 
-        public Type Library => typeof(Parser);
+        public Type Library => typeof(StylesheetParser);
 
         public void Run(String source)
         {
-            var parser = new Parser();
+            var parser = new StylesheetParser();
             parser.Parse(source);
         }
     }

--- a/src/AngleSharp.Performance.Css/Program.cs
+++ b/src/AngleSharp.Performance.Css/Program.cs
@@ -16,7 +16,9 @@ namespace AngleSharp.Performance.Css
             {
                 new AngleSharpParser(),
                 new ExCssParser(),
+#if NET472
                 new CsCssParser(),
+#endif
             };
 
             var testsuite = new TestSuite(parsers, stylesheets.Tests, new Output(), new Warmup())


### PR DESCRIPTION
# Types of Changes

## Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

## Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## Description

Multi-target AngleSharp.Performance.Css to net472;net10.0 so that Alba.CsCss (which only supports net462/net472) is excluded from the net10.0 build. Update ExCSS from 2.0.6 to 4.3.1 and adapt to its renamed StylesheetParser API.

This removes the NU1701 warnings on build.


