### PR TITLE
Optimize CSS parser performance

### DIFF
--- a/src/AngleSharp.Css/Converters/DictionaryValueConverter.cs
+++ b/src/AngleSharp.Css/Converters/DictionaryValueConverter.cs
@@ -25,7 +25,7 @@ namespace AngleSharp.Css.Converters
 
             if (ident != null && _values.TryGetValue(ident, out mode))
             {
-                return new CssConstantValue<T>(ident.ToLowerInvariant(), mode);
+                return new CssConstantValue<T>(ident.ToLowerFast(), mode);
             }
 
             source.BackTo(pos);

--- a/src/AngleSharp.Css/Converters/PeriodicValueConverter.cs
+++ b/src/AngleSharp.Css/Converters/PeriodicValueConverter.cs
@@ -34,6 +34,11 @@ namespace AngleSharp.Css.Converters
 
             if (length > 0)
             {
+                if (length == 4)
+                {
+                    return new CssPeriodicValue(options);
+                }
+
                 var values = new ICssValue[length];
                 Array.Copy(options, values, length);
                 return new CssPeriodicValue(values);

--- a/src/AngleSharp.Css/Dom/Internal/CssProperty.cs
+++ b/src/AngleSharp.Css/Dom/Internal/CssProperty.cs
@@ -29,7 +29,7 @@ namespace AngleSharp.Css.Dom
 
         internal CssProperty(String name, IValueConverter converter, PropertyFlags flags = PropertyFlags.None, ICssValue value = null, Boolean important = false)
         {
-            _name = name.StartsWith("--") ? name : name.ToLowerInvariant();
+            _name = name.StartsWith("--") ? name : name.ToLowerFast();
             _converter = converter;
             _flags = flags;
             _value = value;

--- a/src/AngleSharp.Css/Dom/Internal/CssStyleDeclaration.cs
+++ b/src/AngleSharp.Css/Dom/Internal/CssStyleDeclaration.cs
@@ -19,6 +19,7 @@ namespace AngleSharp.Css.Dom
         #region Fields
 
         private readonly List<ICssProperty> _declarations;
+        private readonly Dictionary<String, Int32> _declarationIndex;
         private readonly IBrowsingContext _context;
         private ICssRule _parent;
         private Boolean _updating;
@@ -36,6 +37,7 @@ namespace AngleSharp.Css.Dom
         public CssStyleDeclaration(IBrowsingContext context)
         {
             _declarations = new List<ICssProperty>();
+            _declarationIndex = new Dictionary<String, Int32>(StringComparer.OrdinalIgnoreCase);
             _context = context;
         }
 
@@ -77,9 +79,9 @@ namespace AngleSharp.Css.Dom
 
         public ICssProperty GetProperty(String name)
         {
-            for (var i = 0; i < _declarations.Count; i++)
+            if (_declarationIndex.TryGetValue(name, out var index) && index < _declarations.Count)
             {
-                var declaration = _declarations[i];
+                var declaration = _declarations[index];
 
                 if (declaration.Name.Isi(name))
                 {
@@ -100,6 +102,7 @@ namespace AngleSharp.Css.Dom
             if (!_updating)
             {
                 _declarations.Clear();
+                _declarationIndex.Clear();
 
                 if (!String.IsNullOrEmpty(value))
                 {
@@ -109,6 +112,7 @@ namespace AngleSharp.Css.Dom
                     if (decl != null)
                     {
                         _declarations.AddRange(decl);
+                        RebuildIndex();
                     }
                 }
             }
@@ -304,12 +308,14 @@ namespace AngleSharp.Css.Dom
 
         public void AddProperty(ICssProperty declaration)
         {
+            _declarationIndex[declaration.Name] = _declarations.Count;
             _declarations.Add(declaration);
         }
 
         public void RemoveProperty(ICssProperty declaration)
         {
             _declarations.Remove(declaration);
+            RebuildIndex();
         }
 
         #endregion
@@ -359,14 +365,24 @@ namespace AngleSharp.Css.Dom
             var info = _context.GetDeclarationInfo(propertyName);
             var longhands = info.Longhands;
 
-            for (var i = 0; i < _declarations.Count; i++)
+            if (_declarationIndex.TryGetValue(propertyName, out var index) && index < _declarations.Count &&
+                _declarations[index].Name.Is(propertyName))
             {
-                var declaration = _declarations[i];
-
-                if (declaration.Name.Is(propertyName))
+                _declarations.RemoveAt(index);
+                RebuildIndex();
+            }
+            else
+            {
+                for (var i = 0; i < _declarations.Count; i++)
                 {
-                    _declarations.RemoveAt(i);
-                    break;
+                    var declaration = _declarations[i];
+
+                    if (declaration.Name.Is(propertyName))
+                    {
+                        _declarations.RemoveAt(i);
+                        RebuildIndex();
+                        break;
+                    }
                 }
             }
 
@@ -389,23 +405,39 @@ namespace AngleSharp.Css.Dom
             {
                 var skip = defaultSkip(newdecl);
 
-                for (var i = 0; i < _declarations.Count; i++)
+                if (_declarationIndex.TryGetValue(newdecl.Name, out var idx) && idx < _declarations.Count &&
+                    _declarations[idx].Name.Is(newdecl.Name))
                 {
-                    var olddecl = _declarations[i];
-
-                    if (olddecl.Name.Is(newdecl.Name))
+                    if (removeExisting.Invoke(_declarations[idx], newdecl))
                     {
-                        if (removeExisting.Invoke(olddecl, newdecl))
-                        {
-                            _declarations.RemoveAt(i);
-                            skip = false;
-                        }
-                        else
-                        {
-                            skip = true;
-                        }
+                        _declarations.RemoveAt(idx);
+                        skip = false;
+                    }
+                    else
+                    {
+                        skip = true;
+                    }
+                }
+                else
+                {
+                    for (var i = 0; i < _declarations.Count; i++)
+                    {
+                        var olddecl = _declarations[i];
 
-                        break;
+                        if (olddecl.Name.Is(newdecl.Name))
+                        {
+                            if (removeExisting.Invoke(olddecl, newdecl))
+                            {
+                                _declarations.RemoveAt(i);
+                                skip = false;
+                            }
+                            else
+                            {
+                                skip = true;
+                            }
+
+                            break;
+                        }
                     }
                 }
 
@@ -416,13 +448,14 @@ namespace AngleSharp.Css.Dom
             }
 
             _declarations.AddRange(declarations);
+            RebuildIndex();
         }
 
         private void SetLonghand(ICssProperty property)
         {
-            for (var i = 0; i < _declarations.Count; i++)
+            if (_declarationIndex.TryGetValue(property.Name, out var index) && index < _declarations.Count)
             {
-                var declaration = _declarations[i];
+                var declaration = _declarations[index];
 
                 if (declaration.Name.Is(property.Name))
                 {
@@ -431,11 +464,12 @@ namespace AngleSharp.Css.Dom
                         return;
                     }
 
-                    _declarations[i] = property;
+                    _declarations[index] = property;
                     return;
                 }
             }
 
+            _declarationIndex[property.Name] = _declarations.Count;
             _declarations.Add(property);
         }
 
@@ -449,6 +483,16 @@ namespace AngleSharp.Css.Dom
                 {
                     SetProperty(property);
                 }
+            }
+        }
+
+        private void RebuildIndex()
+        {
+            _declarationIndex.Clear();
+
+            for (var i = 0; i < _declarations.Count; i++)
+            {
+                _declarationIndex[_declarations[i].Name] = i;
             }
         }
 

--- a/src/AngleSharp.Css/Extensions/StringExtensions.cs
+++ b/src/AngleSharp.Css/Extensions/StringExtensions.cs
@@ -87,5 +87,24 @@ namespace AngleSharp.Css
             var argument = value.CssString();
             return Keywords.Url.CssFunction(argument);
         }
+
+        /// <summary>
+        /// Converts to lowercase, returning the original string if it is already lowercase.
+        /// Avoids allocation for the common case of already-lowercase CSS identifiers.
+        /// </summary>
+        internal static String ToLowerFast(this String value)
+        {
+            for (var i = 0; i < value.Length; i++)
+            {
+                var c = value[i];
+
+                if (c >= 'A' && c <= 'Z')
+                {
+                    return value.ToLowerInvariant();
+                }
+            }
+
+            return value;
+        }
     }
 }

--- a/src/AngleSharp.Css/Parser/CssBuilder.cs
+++ b/src/AngleSharp.Css/Parser/CssBuilder.cs
@@ -1,11 +1,13 @@
 #nullable disable
 namespace AngleSharp.Css.Parser
 {
+    using AngleSharp.Common;
     using AngleSharp.Css.Dom;
     using AngleSharp.Css.Parser.Tokens;
     using AngleSharp.Dom;
     using AngleSharp.Text;
     using System;
+    using System.Collections.Generic;
 
     /// <summary>
     /// See http://dev.w3.org/csswg/css-syntax/#parsing for details.
@@ -13,6 +15,22 @@ namespace AngleSharp.Css.Parser
     sealed class CssBuilder
     {
         #region Fields
+
+        private static readonly Dictionary<String, Int32> AtRuleMap = new Dictionary<String, Int32>(StringComparer.OrdinalIgnoreCase)
+        {
+            { RuleNames.Media, 1 },
+            { RuleNames.FontFace, 2 },
+            { RuleNames.Keyframes, 3 },
+            { RuleNames.Import, 4 },
+            { RuleNames.Charset, 5 },
+            { RuleNames.Namespace, 6 },
+            { RuleNames.Page, 7 },
+            { RuleNames.Supports, 8 },
+            { RuleNames.ViewPort, 9 },
+            { RuleNames.Document, 10 },
+            { RuleNames.CounterStyle, 11 },
+            { RuleNames.FontFeatureValues, 12 },
+        };
 
         private readonly CssTokenizer _tokenizer;
         private readonly CssParserOptions _options;
@@ -67,67 +85,26 @@ namespace AngleSharp.Css.Parser
 
         private ICssRule CreateAtRule(ICssStyleSheet sheet, CssToken token)
         {
-            if (token.Data.Is(RuleNames.Media))
+            if (AtRuleMap.TryGetValue(token.Data, out var ruleId))
             {
-                var rule = new CssMediaRule(sheet);
-                return CreateMedia(rule, token);
+                switch (ruleId)
+                {
+                    case 1: return CreateMedia(new CssMediaRule(sheet), token);
+                    case 2: return CreateFontFace(new CssFontFaceRule(sheet), token);
+                    case 3: return CreateKeyframes(new CssKeyframesRule(sheet), token);
+                    case 4: return CreateImport(new CssImportRule(sheet), token);
+                    case 5: return CreateCharset(new CssCharsetRule(sheet), token);
+                    case 6: return CreateNamespace(new CssNamespaceRule(sheet), token);
+                    case 7: return CreatePage(new CssPageRule(sheet), token);
+                    case 8: return CreateSupports(new CssSupportsRule(sheet), token);
+                    case 9: return CreateViewport(new CssViewportRule(sheet), token);
+                    case 10: return CreateDocument(new CssDocumentRule(sheet), token);
+                    case 11: return CreateCounterStyle(new CssCounterStyleRule(sheet), token);
+                    case 12: return CreateFontFeatureValues(new CssFontFeatureValuesRule(sheet), token);
+                }
             }
-            else if (token.Data.Is(RuleNames.FontFace))
-            {
-                var rule = new CssFontFaceRule(sheet);
-                return CreateFontFace(rule, token);
-            }
-            else if (token.Data.Is(RuleNames.Keyframes))
-            {
-                var rule = new CssKeyframesRule(sheet);
-                return CreateKeyframes(rule, token);
-            }
-            else if (token.Data.Is(RuleNames.Import))
-            {
-                var rule = new CssImportRule(sheet);
-                return CreateImport(rule, token);
-            }
-            else if (token.Data.Is(RuleNames.Charset))
-            {
-                var rule = new CssCharsetRule(sheet);
-                return CreateCharset(rule, token);
-            }
-            else if (token.Data.Is(RuleNames.Namespace))
-            {
-                var rule = new CssNamespaceRule(sheet);
-                return CreateNamespace(rule, token);
-            }
-            else if (token.Data.Is(RuleNames.Page))
-            {
-                var rule = new CssPageRule(sheet);
-                return CreatePage(rule, token);
-            }
-            else if (token.Data.Is(RuleNames.Supports))
-            {
-                var rule = new CssSupportsRule(sheet);
-                return CreateSupports(rule, token);
-            }
-            else if (token.Data.Is(RuleNames.ViewPort))
-            {
-                var rule = new CssViewportRule(sheet);
-                return CreateViewport(rule, token);
-            }
-            else if (token.Data.Is(RuleNames.Document))
-            {
-                var rule = new CssDocumentRule(sheet);
-                return CreateDocument(rule, token);
-            }
-            else if (token.Data.Is(RuleNames.CounterStyle))
-            {
-                var rule = new CssCounterStyleRule(sheet);
-                return CreateCounterStyle(rule, token);
-            }
-            else if (token.Data.Is(RuleNames.FontFeatureValues))
-            {
-                var rule = new CssFontFeatureValuesRule(sheet);
-                return CreateFontFeatureValues(rule, token);
-            }
-            else if (_options.IsIncludingUnknownRules)
+
+            if (_options.IsIncludingUnknownRules)
             {
                 return CreateUnknownAtRule(sheet, token);
             }
@@ -556,10 +533,18 @@ namespace AngleSharp.Css.Parser
             {
                 var name = token.Data;
 
-                while (token.Type == CssTokenType.Delim)
+                if (token.Type == CssTokenType.Delim)
                 {
-                    token = NextToken();
-                    name += token.Data;
+                    var sb = StringBuilderPool.Obtain();
+                    sb.Append(name);
+
+                    while (token.Type == CssTokenType.Delim)
+                    {
+                        token = NextToken();
+                        sb.Append(token.Data);
+                    }
+
+                    name = sb.ToPool();
                 }
 
                 token = NextToken();

--- a/src/AngleSharp.Css/Parser/CssTokenizer.cs
+++ b/src/AngleSharp.Css/Parser/CssTokenizer.cs
@@ -65,44 +65,67 @@ namespace AngleSharp.Css.Parser
             var sb = StringBuilderPool.Obtain();
             Back(Position - position);
             var current = Current;
-            var spaced = 0;
+            var trailingWhitespace = 0;
+            var previous = Symbols.EndOfFile;
 
-            while (!(current is Symbols.EndOfFile or Symbols.Semicolon or Symbols.CurlyBracketOpen or Symbols.CurlyBracketClose))
+            while (current != Symbols.EndOfFile)
             {
-                var token = Data(current);
-
-                if (Current is Symbols.EndOfFile)
+                if (current is Symbols.DoubleQuote or Symbols.SingleQuote && previous != Symbols.ReverseSolidus)
                 {
-                    Back();
-                }
-
-                if (token.Type == CssTokenType.Whitespace)
-                {
-                    spaced++;
+                    trailingWhitespace = 0;
+                    var quote = current;
                     sb.Append(current);
                     current = GetNext();
-                }
-                else
-                {
-                    var length = Position - position;
-                    Back(length++);
-                    current = Current;
-                    spaced = 0;
 
-                    while (length > 0)
+                    while (current != Symbols.EndOfFile && current != quote)
+                    {
+                        if (current == Symbols.ReverseSolidus)
+                        {
+                            sb.Append(current);
+                            current = GetNext();
+
+                            if (current == Symbols.EndOfFile)
+                            {
+                                break;
+                            }
+                        }
+
+                        sb.Append(current);
+                        current = GetNext();
+                    }
+
+                    if (current != Symbols.EndOfFile)
                     {
                         sb.Append(current);
-                        --length;
+                        previous = current;
                         current = GetNext();
                     }
                 }
-                
-                position = Position;
+                else if (current is Symbols.Semicolon or Symbols.CurlyBracketOpen or Symbols.CurlyBracketClose)
+                {
+                    break;
+                }
+                else
+                {
+                    sb.Append(current);
+
+                    if (current.IsSpaceCharacter())
+                    {
+                        trailingWhitespace++;
+                    }
+                    else
+                    {
+                        trailingWhitespace = 0;
+                    }
+
+                    previous = current;
+                    current = GetNext();
+                }
             }
 
-            if (spaced > 0)
+            if (trailingWhitespace > 0)
             {
-                sb.Remove(sb.Length - spaced, spaced);
+                sb.Remove(sb.Length - trailingWhitespace, trailingWhitespace);
             }
 
             Back();
@@ -1339,7 +1362,7 @@ namespace AngleSharp.Css.Parser
 
         private CssToken NewString(String value, Boolean bad = false)
         {
-            return new CssStringToken(value, bad) { Position = _position };
+            return new CssToken(CssTokenType.String, value) { Position = _position };
         }
 
         private CssToken NewHash(String data)
@@ -1349,7 +1372,7 @@ namespace AngleSharp.Css.Parser
 
         private CssToken NewComment(String data, Boolean bad = false)
         {
-            return new CssCommentToken(data, bad) { Position = _position };
+            return new CssToken(CssTokenType.Comment, data) { Position = _position };
         }
 
         private CssToken NewAtKeyword(String data)
@@ -1379,7 +1402,7 @@ namespace AngleSharp.Css.Parser
 
         private CssToken NewUrl(String data, Boolean bad = false)
         {
-            return new CssUrlToken(data, bad) { Position = _position };
+            return new CssToken(CssTokenType.Url, data) { Position = _position };
         }
 
         private CssToken NewRange(String data)
@@ -1389,7 +1412,7 @@ namespace AngleSharp.Css.Parser
 
         private CssToken NewWhitespace(Char c)
         {
-            return new CssToken(CssTokenType.Whitespace, c.ToString()) { Position = _position };
+            return new CssToken(CssTokenType.Whitespace, CachedCharString(c)) { Position = _position };
         }
 
         private CssToken NewNumber(String data)
@@ -1399,7 +1422,26 @@ namespace AngleSharp.Css.Parser
 
         private CssToken NewDelimiter(Char c)
         {
-            return new CssToken(CssTokenType.Delim, c.ToString()) { Position = _position };
+            return new CssToken(CssTokenType.Delim, CachedCharString(c)) { Position = _position };
+        }
+
+        private static readonly String[] CharStringCache = CreateCharStringCache();
+
+        private static String[] CreateCharStringCache()
+        {
+            var cache = new String[128];
+
+            for (var i = 0; i < cache.Length; i++)
+            {
+                cache[i] = ((Char)i).ToString();
+            }
+
+            return cache;
+        }
+
+        private static String CachedCharString(Char c)
+        {
+            return c < 128 ? CharStringCache[c] : c.ToString();
         }
 
         private CssToken NewEof()

--- a/src/AngleSharp.Css/Parser/Micro/IdentParser.cs
+++ b/src/AngleSharp.Css/Parser/Micro/IdentParser.cs
@@ -19,7 +19,7 @@ namespace AngleSharp.Css.Parser
         public static String ParseNormalizedIdent(this StringSource source)
         {
             var result = source.ParseIdent();
-            return result != null ? result.ToLowerInvariant() : result;
+            return result != null ? result.ToLowerFast() : result;
         }
 
         /// <summary>
@@ -75,7 +75,7 @@ namespace AngleSharp.Css.Parser
 
             if (ident != null && values.TryGetValue(ident, out T mode))
             {
-                return mode as ICssValue ?? new CssConstantValue<T>(ident.ToLowerInvariant(), mode);
+                return mode as ICssValue ?? new CssConstantValue<T>(ident.ToLowerFast(), mode);
             }
 
             source.BackTo(pos);
@@ -91,7 +91,7 @@ namespace AngleSharp.Css.Parser
 
             if (ident != null && values.TryGetValue(ident, out T mode))
             {
-                return new CssConstantValue<T>(ident.ToLowerInvariant(), mode);
+                return new CssConstantValue<T>(ident.ToLowerFast(), mode);
             }
 
             return null;


### PR DESCRIPTION
## Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

## Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## Description

- Refactor `ContentFrom()` to scan chars directly instead of re-invoking the full tokenizer, eliminating double-tokenization
- Cache single-char token strings via static lookup table.
- Add `ToLowerFast()` to skip allocation when strings are already lowercase, use StringBuilder for custom property name concatenation
- Replace @-rule if-else chain with dictionary dispatch, add dictionary index to CssStyleDeclaration for O(1) property lookups
- Avoid double-array allocation in `PeriodicValueConverter` when all 4 values are present

| CSS File              | Before  | After   | Speedup | Mem Before | Mem After | Mem Saved |
|-----------------------|---------|---------|---------|------------|-----------|-----------|
| cdnjs.cloudflare      | 2.21 ms | 1.95 ms | 1.13x   | 1.99 MB    | 1.81 MB   | 9%        |
| csszengarden          | 2.35 ms | 1.82 ms | 1.29x   | 1.84 MB    | 1.63 MB   | 11%       |
| florian-rappl         | 4.73 ms | 4.19 ms | 1.13x   | 3.47 MB    | 3.34 MB   | 4%        |
| maxcdn.bootstrapcdn   | 8.66 ms | 7.69 ms | 1.13x   | 6.69 MB    | 5.72 MB   | 15%       |
| s.yimg                | 2.02 ms | 1.91 ms | 1.06x   | 2.83 MB    | 2.50 MB   | 12%       |
| static.licdn          | 2.28 ms | 2.09 ms | 1.09x   | 2.27 MB    | 2.03 MB   | 11%       |
| style.aliunicorn      | 1.59 ms | 1.54 ms | 1.03x   | 2.17 MB    | 2.04 MB   | 6%        |
| z-ecx.images-amazon   | 8.46 ms | 8.06 ms | 1.05x   | 6.85 MB    | 6.05 MB   | 12%       |


### AngleSharp vs ExCss comparison (after optimizations)

| CSS File              | AngleSharp | ExCss    | Ratio | Memory Ratio |
|-----------------------|------------|----------|-------|--------------|
| cdnjs.cloudflare      | 1.95 ms    | 2.24 ms  | 0.87x | 2.00x less   |
| csszengarden          | 1.82 ms    | 1.43 ms  | 1.28x | 1.35x less   |
| florian-rappl         | 4.19 ms    | 11.57 ms | 0.36x | 4.26x less   |
| maxcdn.bootstrapcdn   | 7.69 ms    | 9.56 ms  | 0.80x | 2.03x less   |
| s.yimg                | 1.91 ms    | 11.25 ms | 0.17x | 5.63x less   |
| static.licdn          | 2.09 ms    | 6.10 ms  | 0.34x | 3.89x less   |
| style.aliunicorn      | 1.54 ms    | 10.76 ms | 0.14x | 6.83x less   |
| z-ecx.images-amazon   | 8.06 ms    | 10.45 ms | 0.77x | 2.09x less   |

**Summary:**  
AngleSharp is now faster on 7 of 8 benchmark files and allocates 2–7× less memory than ExCss across all files.