### PR TITLE
Fix NullReferenceException in CssPeriodicValue

### DIFF
--- a/src/AngleSharp.Css.Tests/Styling/CssSheet.cs
+++ b/src/AngleSharp.Css.Tests/Styling/CssSheet.cs
@@ -90,6 +90,76 @@ h1 {
         }
 
         [Test]
+        public void CssSheetSerializeBorderSideThenBorderAll1()
+        {
+            var cssSrc = "#rule1 { border-top: none; border: 1px solid #BBCCEB }";
+            var expected = "#rule1 { border: 1px solid rgba(187, 204, 235, 1) }";
+            var stylesheet = ParseStyleSheet(cssSrc);
+            var cssText = stylesheet.ToCss();
+            Assert.AreEqual(expected, cssText);
+        }
+
+        [Test]
+        public void CssSheetSerializeBorderSideThenBorderAll2()
+        {
+            var cssSrc = "#rule1 { border-top: none !important; border: 1px solid #BBCCEB }";
+            var expected = "#rule1 { border-top: none !important; border-right: 1px solid rgba(187, 204, 235, 1); border-bottom: 1px solid rgba(187, 204, 235, 1); border-left: 1px solid rgba(187, 204, 235, 1) }";
+            var stylesheet = ParseStyleSheet(cssSrc);
+            var cssText = stylesheet.ToCss();
+            Assert.AreEqual(expected, cssText);
+        }
+
+        [Test]
+        public void CssSheetSerializeBorderSideThenBorderAll3()
+        {
+            var cssSrc = "#rule1 { border-top: none; border: 1px solid #BBCCEB !important }";
+            var expected = "#rule1 { border: 1px solid rgba(187, 204, 235, 1) !important }";
+            var stylesheet = ParseStyleSheet(cssSrc);
+            var cssText = stylesheet.ToCss();
+            Assert.AreEqual(expected, cssText);
+        }
+
+        [Test]
+        public void CssSheetSerializeBorderSideThenBorderAll4()
+        {
+            var cssSrc = "#rule1 { border-top: none !important; border: 1px solid #BBCCEB !important }";
+            var expected = "#rule1 { border: 1px solid rgba(187, 204, 235, 1) !important }";
+            var stylesheet = ParseStyleSheet(cssSrc);
+            var cssText = stylesheet.ToCss();
+            Assert.AreEqual(expected, cssText);
+        }
+
+        [Test]
+        public void CssSheetSerializeBorderAllThenBorderSide1()
+        {
+            var cssSrc = "#rule1 { border: 1px solid #BBCCEB !important; border-top: none }";
+            var expected = "#rule1 { border: 1px solid rgba(187, 204, 235, 1) !important }";
+            var stylesheet = ParseStyleSheet(cssSrc);
+            var cssText = stylesheet.ToCss();
+            Assert.AreEqual(expected, cssText);
+        }
+
+        [Test]
+        public void CssSheetSerializeBorderAllThenBorderSide2()
+        {
+            var cssSrc = "#rule1 { border: 1px solid #BBCCEB; border-top: none !important }";
+            var expected = "#rule1 { border-top: none !important; border-right: 1px solid rgba(187, 204, 235, 1); border-bottom: 1px solid rgba(187, 204, 235, 1); border-left: 1px solid rgba(187, 204, 235, 1) }";
+            var stylesheet = ParseStyleSheet(cssSrc);
+            var cssText = stylesheet.ToCss();
+            Assert.AreEqual(expected, cssText);
+        }
+
+        [Test]
+        public void CssSheetSerializeBorderAllThenBorderSide3()
+        {
+            var cssSrc = "#rule1 { border: 1px solid #BBCCEB !important; border-top: none !important }";
+            var expected = "#rule1 { border-top: none !important; border-right: 1px solid rgba(187, 204, 235, 1) !important; border-bottom: 1px solid rgba(187, 204, 235, 1) !important; border-left: 1px solid rgba(187, 204, 235, 1) !important }";
+            var stylesheet = ParseStyleSheet(cssSrc);
+            var cssText = stylesheet.ToCss();
+            Assert.AreEqual(expected, cssText);
+        }
+
+        [Test]
         public void CssSheetSerializeBackgroundWithUrlPositionRepeatX()
         {
             var cssSrc = "#rule2 { background:url(/_static/img/bx_tile.gif) top left repeat-x; }";

--- a/src/AngleSharp.Css/Values/Multiples/CssPeriodicValue.cs
+++ b/src/AngleSharp.Css/Values/Multiples/CssPeriodicValue.cs
@@ -61,7 +61,14 @@ namespace AngleSharp.Css.Values
 
                 for (var i = 0; i < l; i++)
                 {
-                    parts[i] = _values[i].CssText;
+                    var value = _values[i];
+
+                    if (value is null)
+                    {
+                        return String.Empty;
+                    }
+
+                    parts[i] = value.CssText;
                 }
 
                 if (l == 4 && parts[3].Is(parts[1]))


### PR DESCRIPTION
# Types of Changes

## Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

## Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## Description

`CssPeriodicValue.CssText` throws if any of the items in `_values` array is null. This change makes `CssText` getter return an empty string if a null value is found during the iteration.

Fixes #213