### PR TITLE
Speed up cascade resolution by ~4.5x

### DIFF
--- a/src/AngleSharp.Css/Dom/Internal/CssStyleDeclaration.cs
+++ b/src/AngleSharp.Css/Dom/Internal/CssStyleDeclaration.cs
@@ -126,7 +126,6 @@ namespace AngleSharp.Css.Dom
 
             if (requiredProperties.Length > 0)
             {
-                var longhands = Declarations.Where(m => !serialized.Contains(m.Name)).ToList();
                 var values = new ICssValue[requiredProperties.Length];
                 var important = 0;
                 var count = 0;
@@ -135,9 +134,9 @@ namespace AngleSharp.Css.Dom
                 {
                     var name = requiredProperties[i];
                     var propInfo = factory.Create(name);
-                    var property = propInfo.Longhands.Any() ?
+                    var property = propInfo.Longhands.Length > 0 ?
                         TryCreateShorthand(name, serialized, usedProperties, force) :
-                        longhands.Where(m => m.Name == name).FirstOrDefault();
+                        FindUnserializedLonghand(name, serialized);
 
                     if (property?.Value is not null)
                     {
@@ -339,6 +338,39 @@ namespace AngleSharp.Css.Dom
 
         private ICssProperty GetPropertyShorthand(String name) =>
             TryCreateShorthand(name, Enumerable.Empty<String>(), new List<String>(), true);
+
+        /// <summary>
+        /// Gets the first declaration with the given name, unless that name was
+        /// already serialized. Equivalent to filtering all declarations by the
+        /// serialized set first, since only declarations with exactly this name
+        /// can ever be returned.
+        /// </summary>
+        private ICssProperty FindUnserializedLonghand(String name, IEnumerable<String> serialized)
+        {
+            if (serialized is ICollection<String> collection)
+            {
+                if (collection.Count > 0 && collection.Contains(name))
+                {
+                    return null;
+                }
+            }
+            else if (serialized.Contains(name))
+            {
+                return null;
+            }
+
+            for (var i = 0; i < _declarations.Count; i++)
+            {
+                var declaration = _declarations[i];
+
+                if (declaration.Name == name)
+                {
+                    return declaration;
+                }
+            }
+
+            return null;
+        }
 
         private ICssProperty CreateProperty(String propertyName)
         {

--- a/src/AngleSharp.Css/Dom/Internal/Rules/CssStyleRule.cs
+++ b/src/AngleSharp.Css/Dom/Internal/Rules/CssStyleRule.cs
@@ -21,7 +21,7 @@ namespace AngleSharp.Css.Dom
         private readonly CssStyleDeclaration _style;
         private readonly CssRuleList _rules;
         private ISelector _selector;
-        private IEnumerable<ISelector> _selectorList;
+        private ISelector[] _selectorList;
         private Boolean _nested;
 
         #endregion
@@ -120,8 +120,13 @@ namespace AngleSharp.Css.Dom
 
             if (_selectorList is not null)
             {
-                foreach (var selector in _selectorList.OrderByDescending(m => m.Specificity))
+                // Already ordered by descending specificity when the selector was
+                // assigned - sorting here would repeat the work for every single
+                // element the rule is matched against.
+                for (var i = 0; i < _selectorList.Length; i++)
                 {
+                    var selector = _selectorList[i];
+
                     if (selector.Match(element, scope))
                     {
                         specificity += selector.Specificity;
@@ -186,7 +191,9 @@ namespace AngleSharp.Css.Dom
 
         void ISelectorVisitor.List(IEnumerable<ISelector> selectors)
         {
-            _selectorList = selectors;
+            // OrderByDescending is stable, so selectors of equal specificity keep
+            // their declared order - same as when this ran per match attempt.
+            _selectorList = selectors.OrderByDescending(m => m.Specificity).ToArray();
         }
 
         void ISelectorVisitor.Combinator(IEnumerable<ISelector> selectors, IEnumerable<string> symbols)

--- a/src/AngleSharp.Css/Dom/Internal/StyleCollection.cs
+++ b/src/AngleSharp.Css/Dom/Internal/StyleCollection.cs
@@ -3,6 +3,7 @@ namespace AngleSharp.Css.Dom
     using AngleSharp.Dom;
     using System.Collections;
     using System.Collections.Generic;
+    using System.Linq;
 
     sealed class StyleCollection : IStyleCollection
     {
@@ -10,6 +11,7 @@ namespace AngleSharp.Css.Dom
 
         private readonly IEnumerable<ICssStyleSheet> _sheets;
         private readonly IRenderDevice _device;
+        private List<ICssStyleRule>? _rules;
 
         #endregion
 
@@ -31,25 +33,39 @@ namespace AngleSharp.Css.Dom
 
         #region Methods
 
-        public IEnumerator<ICssStyleRule> GetEnumerator()
-        {
-            foreach (var sheet in _sheets)
-            {
-                if (!sheet.IsDisabled && sheet.Media.Validate(_device))
-                {
-                    var rules = sheet.Rules.GetMatchingStyles(_device);
+        public IEnumerator<ICssStyleRule> GetEnumerator() => GetRules().GetEnumerator();
 
-                    foreach (var rule in rules)
-                    {
-                        yield return rule;
-                    }
-                }
-            }
-        }
+        /// <summary>
+        /// Gets the flattened list of style rules that apply to the current
+        /// device. The supplied sheet sequence is usually a lazy query over the
+        /// document, so it is walked exactly once and the result is reused for
+        /// the lifetime of the collection - which spans a single cascade or
+        /// render pass. Without this the whole DOM would be re-walked for every
+        /// element, and for every one of its ancestors.
+        /// </summary>
+        internal List<ICssStyleRule> GetRules() => _rules ??= CollectRules();
 
         #endregion
 
         #region Helpers
+
+        private List<ICssStyleRule> CollectRules()
+        {
+            var rules = new List<ICssStyleRule>();
+
+            foreach (var sheet in _sheets)
+            {
+                if (!sheet.IsDisabled && sheet.Media.Validate(_device))
+                {
+                    foreach (var rule in sheet.Rules.GetMatchingStyles(_device))
+                    {
+                        rules.Add(rule);
+                    }
+                }
+            }
+
+            return rules;
+        }
 
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 

--- a/src/AngleSharp.Css/Extensions/StyleCollectionExtensions.cs
+++ b/src/AngleSharp.Css/Extensions/StyleCollectionExtensions.cs
@@ -113,11 +113,11 @@ namespace AngleSharp.Css
         {
             var ctx = element.Owner?.Context ?? throw new InvalidOperationException("The element must be associated with a browsing context.");
             var computedStyle = new CssStyleDeclaration(ctx);
-            var rules = styles.SortBySpecificity(element);
+            var matches = styles.SortBySpecificity(element);
 
-            foreach (var rule in rules)
+            for (var i = 0; i < matches.Count; i++)
             {
-                var inlineStyle = rule.Style;
+                var inlineStyle = matches[i].Rule.Style;
                 computedStyle.SetDeclarations(inlineStyle);
             }
 
@@ -158,33 +158,80 @@ namespace AngleSharp.Css
 
         #region Helpers
 
-        private static IEnumerable<ICssStyleRule> SortBySpecificity(this IEnumerable<ICssStyleRule> rules, IElement element)
+        private static List<RuleMatch> SortBySpecificity(this IStyleCollection styles, IElement element)
         {
-            IEnumerable<Tuple<ICssStyleRule, Priority>> MapPriority(ICssStyleRule rule)
-            {
-                if (rule.TryMatch(element, null, out var specificity))
-                {
-                    yield return Tuple.Create(rule, specificity);
-                }
+            // Resolving the scope once is equivalent to letting every TryMatch call
+            // fall back to it, but avoids re-reading DocumentElement per rule.
+            var scope = element.Owner?.DocumentElement;
+            var matches = new List<RuleMatch>();
 
-                foreach (var subRule in rule.Rules)
+            if (styles is StyleCollection collection)
+            {
+                var rules = collection.GetRules();
+
+                for (var i = 0; i < rules.Count; i++)
                 {
-                    if (subRule is ICssStyleRule style)
-                    {
-                        foreach (var item in MapPriority(style))
-                        {
-                            yield return item;
-                        }
-                    }
+                    MapPriority(rules[i], element, scope, matches);
+                }
+            }
+            else
+            {
+                foreach (var rule in styles)
+                {
+                    MapPriority(rule, element, scope, matches);
                 }
             }
 
-            return rules.SelectMany(MapPriority).OrderBy(GetPriority).Select(GetRule);
+            // OrderBy is a stable sort; the index tie-break reproduces that for
+            // rules that share the same specificity.
+            matches.Sort(RuleMatchComparer.Instance);
+            return matches;
         }
 
-        private static Priority GetPriority(Tuple<ICssStyleRule, Priority> item) => item.Item2;
+        private static void MapPriority(ICssStyleRule rule, IElement element, IElement? scope, List<RuleMatch> matches)
+        {
+            if (rule.TryMatch(element, scope, out var specificity))
+            {
+                matches.Add(new RuleMatch(rule, specificity, matches.Count));
+            }
 
-        private static ICssStyleRule GetRule(Tuple<ICssStyleRule, Priority> item) => item.Item1;
+            var subRules = rule.Rules;
+
+            for (var i = 0; i < subRules.Length; i++)
+            {
+                if (subRules[i] is ICssStyleRule style)
+                {
+                    MapPriority(style, element, scope, matches);
+                }
+            }
+        }
+
+        private readonly struct RuleMatch
+        {
+            public RuleMatch(ICssStyleRule rule, Priority priority, Int32 index)
+            {
+                Rule = rule;
+                Priority = priority;
+                Index = index;
+            }
+
+            public ICssStyleRule Rule { get; }
+
+            public Priority Priority { get; }
+
+            public Int32 Index { get; }
+        }
+
+        private sealed class RuleMatchComparer : IComparer<RuleMatch>
+        {
+            public static readonly RuleMatchComparer Instance = new RuleMatchComparer();
+
+            public Int32 Compare(RuleMatch x, RuleMatch y)
+            {
+                var result = Comparer<Priority>.Default.Compare(x.Priority, y.Priority);
+                return result != 0 ? result : x.Index.CompareTo(y.Index);
+            }
+        }
 
         #endregion
     }

--- a/src/AngleSharp.Performance.Css/CssCascadeBenchmarks.cs
+++ b/src/AngleSharp.Performance.Css/CssCascadeBenchmarks.cs
@@ -1,0 +1,148 @@
+namespace AngleSharp.Performance.Css
+{
+    using AngleSharp;
+    using AngleSharp.Css.Dom;
+    using AngleSharp.Css.Parser;
+    using AngleSharp.Dom;
+    using BenchmarkDotNet.Attributes;
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+
+    /// <summary>
+    /// Covers the styling side of the library: cascade resolution via
+    /// getComputedStyle, full render tree construction and the parsing of
+    /// inline style attributes.
+    /// </summary>
+    [MemoryDiagnoser]
+    public class CssCascadeBenchmarks
+    {
+        private static readonly CssParser DeclarationParser = new CssParser();
+
+        private IDocument _document = null!;
+        private IWindow _window = null!;
+        private IElement[] _elements = null!;
+        private String[] _inlineStyles = null!;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            var config = Configuration.Default.WithCss();
+            var context = BrowsingContext.New(config);
+            _document = context.OpenAsync(req => req.Content(BuildDocument())).GetAwaiter().GetResult();
+            _window = _document.DefaultView!;
+
+            // A representative sample instead of every element - keeps a single
+            // benchmark iteration in a sane range while still walking the cascade
+            // for elements at different depths.
+            _elements = _document.QuerySelectorAll("#root *").Where((_, i) => i % 12 == 0).ToArray();
+            _inlineStyles = BuildInlineStyles();
+        }
+
+        [Benchmark]
+        public Int32 ComputedStyle()
+        {
+            var total = 0;
+
+            foreach (var element in _elements)
+            {
+                total += _window.GetComputedStyle(element).Length;
+            }
+
+            return total;
+        }
+
+        [Benchmark]
+        public Object RenderTree()
+        {
+            return _window.Render();
+        }
+
+        [Benchmark]
+        public Int32 ParseInlineDeclarations()
+        {
+            var total = 0;
+
+            foreach (var style in _inlineStyles)
+            {
+                total += DeclarationParser.ParseDeclaration(style)?.Length ?? 0;
+            }
+
+            return total;
+        }
+
+        private static String[] BuildInlineStyles()
+        {
+            var templates = new[]
+            {
+                "color:#333;background:#fff",
+                "display:none",
+                "margin:0;padding:0",
+                "width:100%;height:auto",
+                "font-family:Arial,Helvetica,sans-serif;font-size:12px",
+                "border:1px solid #ccc;border-radius:4px",
+                "position:absolute;top:0;left:0;z-index:10",
+                "background-image:url(https://example.com/i.png);background-repeat:no-repeat",
+                "text-align:center;line-height:1.5",
+                "float:left;clear:both;overflow:hidden",
+                "background:linear-gradient(to right,#fff 0%,#000 100%)",
+                "transform:translate(10px,20px) rotate(45deg)",
+                "box-shadow:0 1px 2px rgba(0,0,0,.2)",
+                "flex:1 1 auto;align-items:center;justify-content:space-between",
+                "padding:10px 15px 10px 15px;margin:0 auto",
+                "visibility:hidden;opacity:0.5",
+                "color:rgb(51,51,51);background-color:rgba(255,255,255,0.9)",
+                "font:bold 14px/1.2 'Segoe UI',sans-serif",
+                "grid-template-columns:repeat(3,1fr);gap:10px",
+                "transition:all .3s ease-in-out",
+            };
+
+            var list = new List<String>();
+
+            for (var i = 0; i < 10; i++)
+            {
+                list.AddRange(templates);
+            }
+
+            return list.ToArray();
+        }
+
+        private static String BuildDocument()
+        {
+            var sb = new StringBuilder();
+            sb.Append("<!doctype html><html><head><style>");
+
+            // Roughly the shape and size of a component library sheet: plain
+            // class selectors, descendant combinators and a selector list.
+            for (var i = 0; i < 400; i++)
+            {
+                sb.Append(".c-").Append(i % 40).Append(" .child-").Append(i % 20)
+                  .Append("{color:#").Append((i % 9) + 1).Append("33;margin:").Append(i % 12)
+                  .Append("px;padding:2px;display:block;font-size:1").Append(i % 6).Append("px;}");
+            }
+
+            sb.Append("h1,h2,h3,p.big,a:hover,.c-1 span{font-weight:bold;letter-spacing:0.02em;}");
+            sb.Append(".hidden{display:none}.big{font-size:24px}a{color:blue}");
+            sb.Append("</style></head><body><main id='root'>");
+
+            for (var s = 0; s < 25; s++)
+            {
+                sb.Append("<section class='c-").Append(s % 40).Append("'>");
+
+                for (var c = 0; c < 12; c++)
+                {
+                    sb.Append("<div class='child-").Append(c % 20).Append("' style='color:#").Append(c).Append("11'>");
+                    sb.Append("<p class='big'>Text ").Append(s).Append('-').Append(c).Append("</p>");
+                    sb.Append("<a href='#'>link</a>");
+                    sb.Append("</div>");
+                }
+
+                sb.Append("</section>");
+            }
+
+            sb.Append("</main></body></html>");
+            return sb.ToString();
+        }
+    }
+}


### PR DESCRIPTION
## What

CPU-profiled the library's most common workloads (stylesheet parsing, `getComputedStyle`, render tree construction, serialization) with [ultra](https://github.com/xoofx/ultra) ETW sampling at 8190 Hz, then fixed what the profile pointed at. The cascade path turned out to be doing a large amount of repeated work per element.

## Findings and fixes

**`StyleCollection` re-walked the DOM on every enumeration.** It held a lazy sheet sequence (`defaultSheets.Concat(document.GetStyleSheets().OfType<ICssStyleSheet>())`), and the collection is enumerated once per element *and* once per ancestor during cascade resolution. `StyleExtensions.GetStyleSheets` alone was 48% of the profile. The sequence is now walked once and the flattened matching rules cached for the lifetime of the collection — which spans a single cascade or render pass.

**`CssStyleRule.TryMatch` sorted its selector list on every match attempt.** `_selectorList.OrderByDescending(m => m.Specificity)` ran per element per rule — 29% of `TryMatch`'s own subtree and most of its allocation traffic. The list only changes when the selector is assigned, so it is sorted there. `OrderByDescending` is stable, so equal-specificity ordering is unchanged.

**`SortBySpecificity` paid 16.6% of the profile in array covariance checks.** `SelectMany(...).OrderBy(...)` over `Tuple<ICssStyleRule, Priority>` meant LINQ's internal `ToArray` under shared generics hit `CastHelpers.StelemRef` / `StelemRef_Helper` for every store. Replaced with a `List<RuleMatch>` of structs and an index tie-break that reproduces `OrderBy`'s stability exactly.

**`TryMatch` re-resolved `DocumentElement` per rule** because scope was always passed as `null` and fell back internally. Now resolved once per element.

**Parsing:** `TryCreateShorthand` allocated a filtered `List` plus LINQ closures per declaration; replaced with a direct scan. The serialized-set filter only depends on the name being looked up, so this is equivalent.

## Measurements

BenchmarkDotNet, MediumRun, idle machine, baseline = `devel` checked out in a worktree running identical benchmark source.

| Benchmark | Baseline | This PR | Change |
|---|---:|---:|---:|
| `ComputedStyle` | 23,169 µs ±0.5% | 5,100 µs ±0.3% | **4.5x faster** |
| `RenderTree` | 29,828 µs ±1.0% | 7,288 µs ±1.0% | **4.1x faster** |
| `ComputedStyle` allocated | 25.19 MB | 1.41 MB | **18x less** |
| `RenderTree` allocated | 56.25 MB | 5.25 MB | **11x less** |
| `ParseInlineDeclarations` | 838 µs | 785 µs | 6% faster |

Stylesheet parsing (`CssParserBenchmarks`, eight real-world sheets): **throughput unchanged** — deltas are mixed in sign and all inside the error bars, so no speedup is claimed there. Allocations, which are deterministic, drop consistently:

| Sheet | Baseline | This PR |
|---|---:|---:|
| cdnjs.cloudflare | 1616.6 KB | 1379.8 KB (−14.6%) |
| florian-rappl | 2580.4 KB | 2268.8 KB (−12.1%) |
| z-ecx.images-amazon | 5724.0 KB | 5076.9 KB (−11.3%) |
| static.licdn | 1208.0 KB | 1095.9 KB (−9.3%) |
| csszengarden | 1395.5 KB | 1283.2 KB (−8.0%) |
| maxcdn.bootstrapcdn | 5341.1 KB | 4977.7 KB (−6.8%) |
| style.aliunicorn | 930.0 KB | 897.8 KB (−3.5%) |
| s.yimg | 1052.2 KB | 1032.2 KB (−1.9%) |

## Notes

- All 1950 tests pass.
- Adds `CssCascadeBenchmarks` — the styling side had no benchmark coverage, so there was nothing to gate a change like this against.
- **Not addressed:** `GetComputedStyle` still constructs a fresh style collection per call, leaving `GetStyleSheets` at ~25% of that path. Removing it requires caching a collection across calls with invalidation when stylesheets change, which is a design change with real correctness risk — better as its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
