### PR TITLE
Avoid rebuilding shorthands when setting a declaration

### DIFF
--- a/src/AngleSharp.Css.Tests/Declarations/SetPropertyOverwriteTests.cs
+++ b/src/AngleSharp.Css.Tests/Declarations/SetPropertyOverwriteTests.cs
@@ -1,0 +1,81 @@
+#nullable disable
+namespace AngleSharp.Css.Tests.Declarations
+{
+    using AngleSharp.Css.Dom;
+    using NUnit.Framework;
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using static CssConstructionFunctions;
+
+    /// <summary>
+    /// Setting a declaration builds a fresh property and assigns its value, which always
+    /// replaces the raw value it starts with. These cases pin down that re-declaring a
+    /// property - longhand over shorthand, shorthand over longhand, important over
+    /// normal, or an invalid value over a valid one - does not depend on the new property
+    /// being seeded from the old one first.
+    ///
+    /// The expectations are a captured baseline of the behaviour, not a statement about
+    /// what the spec requires.
+    /// </summary>
+    [TestFixture]
+    public class SetPropertyOverwriteTests
+    {
+        private static readonly (String Input, String Expected)[] Cases =
+        {
+            ("color:red;color:blue", "color: rgba(0, 0, 255, 1)"),
+            ("color:blue;color:red", "color: rgba(255, 0, 0, 1)"),
+            ("color:red;color:notacolor", "color: rgba(255, 0, 0, 1)"),
+            ("color:red !important;color:blue", "color: rgba(255, 0, 0, 1) !important"),
+            ("color:red;color:blue !important", "color: rgba(0, 0, 255, 1) !important"),
+            ("color:red !important;color:blue !important", "color: rgba(0, 0, 255, 1) !important"),
+            ("--x:1;--x:2", "--x: 2"),
+            ("--x:1;color:red", "--x: 1; color: rgba(255, 0, 0, 1)"),
+            ("margin:1px;margin-top:2px", "margin-bottom: 1px; margin-left: 1px; margin-right: 1px; margin-top: 2px"),
+            ("margin-top:2px;margin:1px", "margin-bottom: 1px; margin-left: 1px; margin-right: 1px; margin-top: 1px"),
+            ("margin:1px;margin:notalength", "margin-bottom: 1px; margin-left: 1px; margin-right: 1px; margin-top: 1px"),
+            ("margin:1px !important;margin-top:2px", "margin-bottom: 1px !important; margin-left: 1px !important; margin-right: 1px !important; margin-top: 1px !important"),
+            ("padding:1px 2px;padding-left:9px;padding:3px", "padding-bottom: 3px; padding-left: 3px; padding-right: 3px; padding-top: 3px"),
+            ("border-radius:4px;border-top-left-radius:9px", "border-bottom-left-radius: 4px; border-bottom-right-radius: 4px; border-top-left-radius: 9px; border-top-right-radius: 4px"),
+            ("flex:1 1 auto;flex-grow:5", "flex-basis: auto; flex-grow: 5; flex-shrink: 1"),
+            ("overflow:hidden;overflow-x:scroll", "overflow-x: scroll; overflow: hidden"),
+            ("grid-area:a;grid-row:2", "grid-column-end: a; grid-column-start: a; grid-row-end: auto; grid-row-start: 2"),
+            ("grid-row:2;grid-area:a", "grid-column-end: a; grid-column-start: a; grid-row-end: a; grid-row-start: a"),
+            ("transition:all .3s;transition-duration:1s", "transition-delay: initial; transition-duration: 1s; transition-property: all; transition-timing-function: initial"),
+            ("font:bold 14px/1.2 Arial;font-size:20px", "font-family: Arial; font-size: 20px; font-stretch: ; font-style: ; font-variant: ; font-weight: bold; line-height: 1.2"),
+            ("font-size:20px;font:bold 14px/1.2 Arial", "font-family: Arial; font-size: 14px; font-stretch: ; font-style: ; font-variant: ; font-weight: bold; line-height: 1.2"),
+            ("border:1px solid red;border-width:3px", "border-bottom-color: rgba(255, 0, 0, 1); border-bottom-style: solid; border-bottom-width: 3px; border-left-color: rgba(255, 0, 0, 1); border-left-style: solid; border-left-width: 3px; border-right-color: rgba(255, 0, 0, 1); border-right-style: solid; border-right-width: 3px; border-top-color: rgba(255, 0, 0, 1); border-top-style: solid; border-top-width: 3px"),
+            ("border-width:3px;border:1px solid red", "border-bottom-color: rgba(255, 0, 0, 1); border-bottom-style: solid; border-bottom-width: 1px; border-left-color: rgba(255, 0, 0, 1); border-left-style: solid; border-left-width: 1px; border-right-color: rgba(255, 0, 0, 1); border-right-style: solid; border-right-width: 1px; border-top-color: rgba(255, 0, 0, 1); border-top-style: solid; border-top-width: 1px"),
+            ("background:red;background:blue", "background-attachment: initial; background-clip: initial; background-color: rgba(0, 0, 255, 1); background-image: initial; background-origin: initial; background-position-x: initial; background-position-y: initial; background-repeat-x: initial; background-repeat-y: initial; background-size: initial"),
+            ("background:red;background-color:blue", "background-attachment: initial; background-clip: initial; background-color: rgba(0, 0, 255, 1); background-image: initial; background-origin: initial; background-position-x: initial; background-position-y: initial; background-repeat-x: initial; background-repeat-y: initial; background-size: initial"),
+            ("background-color:blue;background:red", "background-attachment: initial; background-clip: initial; background-color: rgba(255, 0, 0, 1); background-image: initial; background-origin: initial; background-position-x: initial; background-position-y: initial; background-repeat-x: initial; background-repeat-y: initial; background-size: initial"),
+            ("background:red;background:", "background-attachment: initial; background-clip: initial; background-color: rgba(255, 0, 0, 1); background-image: initial; background-origin: initial; background-position-x: initial; background-position-y: initial; background-repeat-x: initial; background-repeat-y: initial; background-size: initial"),
+            ("background:linear-gradient(red,blue);background:none", "background-attachment: initial; background-clip: initial; background-color: initial; background-image: none; background-origin: initial; background-position-x: initial; background-position-y: initial; background-repeat-x: initial; background-repeat-y: initial; background-size: initial"),
+        };
+
+        [Test]
+        public void RedeclaringAPropertyProducesTheExpectedBlock()
+        {
+            var failures = new List<String>();
+
+            foreach (var (input, expected) in Cases)
+            {
+                var actual = Describe(ParseDeclarations(input));
+
+                if (!String.Equals(actual, expected, StringComparison.Ordinal))
+                {
+                    failures.Add($"{input}{Environment.NewLine}  expected: {expected}{Environment.NewLine}  actual:   {actual}");
+                }
+            }
+
+            Assert.That(failures, Is.Empty, String.Join(Environment.NewLine, failures));
+        }
+
+        private static String Describe(ICssStyleDeclaration style)
+        {
+            var parts = style.Select(p => $"{p.Name}: {p.Value}{(p.IsImportant ? " !important" : String.Empty)}").ToList();
+            parts.Sort(StringComparer.Ordinal);
+            return String.Join("; ", parts);
+        }
+    }
+}

--- a/src/AngleSharp.Css/Dom/Internal/CssStyleDeclaration.cs
+++ b/src/AngleSharp.Css/Dom/Internal/CssStyleDeclaration.cs
@@ -284,7 +284,12 @@ namespace AngleSharp.Css.Dom
             {
                 if (priority is null || priority.Isi(CssKeywords.Important))
                 {
-                    var property = CreateProperty(propertyName);
+                    // Deliberately not seeded from any existing declaration of the same
+                    // name: assigning Value below always replaces the raw value, so
+                    // reading the old one only costs a lookup. For a shorthand that
+                    // lookup is not even a lookup - it rebuilds the shorthand from its
+                    // longhands just to throw the result away.
+                    var property = _context.CreateProperty(propertyName);
 
                     if (property is not null)
                     {
@@ -370,19 +375,6 @@ namespace AngleSharp.Css.Dom
             }
 
             return null;
-        }
-
-        private ICssProperty CreateProperty(String propertyName)
-        {
-            var newProperty = _context.CreateProperty(propertyName);
-            var existing = GetProperty(propertyName);
-
-            if (existing is not null)
-            {
-                newProperty.RawValue = existing.RawValue;
-            }
-
-            return newProperty;
         }
 
         private void SetProperty(ICssProperty property)


### PR DESCRIPTION
## What

`CssStyleDeclaration.CreateProperty` seeded every newly created property with the raw value of an existing declaration of the same name before returning it:

```csharp
var newProperty = _context.CreateProperty(propertyName);
var existing = GetProperty(propertyName);
if (existing is not null) newProperty.RawValue = existing.RawValue;
```

That seed can never be observed:

1. `CreateProperty` had exactly one caller — `SetProperty(name, value, priority)`.
2. Its very next statement is `property.Value = propertyValue`, and **both** branches of the `CssProperty.Value` setter assign `_value` unconditionally.

The lookup is also far from free. On a miss `GetProperty` falls through to `GetPropertyShorthand`, i.e. `TryCreateShorthand(force: true)`, which for a shorthand such as `background` or `border` reconstructs the entire shorthand from its longhands — allocating an `ICssValue[]`, recursing per longhand and calling `CreateShorthand` — only for the result to be overwritten on the next line. Parsing a sheet paid that cost on **every** declaration.

Removing the seed leaves `GetProperty` and the rest of the public behaviour untouched.

## Results

Sample sheets from `AngleSharp.Performance.Css`, BenchmarkDotNet, net10.0:

| Sample | Time before | Time after | Alloc before | Alloc after |
|---|---|---|---|---|
| cdnjs.cloudflare | 1.963 ms | **1.499 ms (−23.6%)** | 1379.8 KB | **1226.6 KB (−11.1%)** |
| static.licdn | 1.904 ms | **1.588 ms (−16.6%)** | 1095.9 KB | **972.1 KB (−11.3%)** |
| maxcdn.bootstrapcdn | 7.811 ms | **6.522 ms (−16.5%)** | 4978.0 KB | **4419.8 KB (−11.2%)** |
| csszengarden | 1.743 ms | **1.446 ms (−17.0%)** | 1283.2 KB | **1178.1 KB (−8.2%)** |
| florian-rappl | 4.137 ms | **3.683 ms (−11.0%)** | 2268.8 KB | **2077.5 KB (−8.4%)** |
| s.yimg | 1.935 ms | 1.807 ms (−6.6%) | 1032.2 KB | 1000.5 KB (−3.1%) |
| style.aliunicorn | 1.507 ms | 1.434 ms (−4.8%) | 897.8 KB | 876.1 KB (−2.4%) |

`ParseInlineDeclarations` improves similarly: **968.4 µs → 724.8 µs (−25.2%)**.

`ComputedStyle` and `RenderTree` are unchanged, as expected — they merge declarations via `SetDeclarations`/`UpdateDeclarations` rather than going through this setter.

The gains track the allocation profile: the two files that improve least (`style.aliunicorn`, `s.yimg`) are the tokenizer-dominated sheets, where tokenization is 78% and 72% of parse allocation and declarations are comparatively few.

## Correctness

`SetPropertyOverwriteTests` covers 28 re-declaration cases: longhand over shorthand and back, `!important` in either order, an invalid value after a valid one, an empty value, custom properties, `grid-area`/`grid-row`, `font`, `flex`, `border-radius`, `overflow`, `transition`, `padding` and `border-radius` partial overrides.

The expectations are a baseline **captured from the previous implementation**, which produced byte-identical output for all 28 cases. So the test is a genuine differential against the old behaviour, not a restatement of the new one. It is labelled as a captured baseline rather than a claim about what the spec requires.

- Full suite: 1951 passing.
- Builds clean on all target frameworks: `netstandard2.0`, `net8.0`, `net10.0`, `net462`, `net472`.

## Notes for review

The load-bearing claim is that the removed seed is dead. Worth confirming both halves independently:

- `CreateProperty` really had only the one caller (`SetProperty(String, String, String)`).
- `CssProperty.Value`'s setter assigns `_value` on every path, including the shorthand-with-`var()` early return.

`GetProperty` itself is deliberately not touched — the forced-shorthand behaviour on a lookup miss is still there for the public API, and only the internal seeding call is gone.
