### PR TITLE
Preserve @font-face descriptors outside the hardcoded set

### DIFF
--- a/src/AngleSharp.Css.Tests/Declarations/CssFontDescriptorProperty.cs
+++ b/src/AngleSharp.Css.Tests/Declarations/CssFontDescriptorProperty.cs
@@ -1,0 +1,91 @@
+namespace AngleSharp.Css.Tests.Declarations
+{
+    using NUnit.Framework;
+    using static CssConstructionFunctions;
+
+    [TestFixture]
+    public class CssFontDescriptorPropertyTests
+    {
+        [TestCase("size-adjust: 100%", "100%")]
+        [TestCase("size-adjust: 90.5%", "90.5%")]
+        [TestCase("size-adjust: 0%", "0%")]
+        public void SizeAdjustLegalValues(string snippet, string expected)
+        {
+            var property = ParseDeclaration(snippet);
+            Assert.AreEqual("size-adjust", property.Name);
+            Assert.IsTrue(property.HasValue);
+            Assert.AreEqual(expected, property.Value);
+        }
+
+        [TestCase("size-adjust: 10px")]
+        [TestCase("size-adjust: 100")]
+        [TestCase("size-adjust: auto")]
+        public void SizeAdjustIllegalValues(string snippet)
+        {
+            var property = ParseDeclaration(snippet);
+            Assert.IsFalse(property.HasValue);
+        }
+
+        [TestCase("ascent-override: 90%", "90%")]
+        [TestCase("ascent-override: normal", "normal")]
+        [TestCase("descent-override: 20%", "20%")]
+        [TestCase("line-gap-override: 0%", "0%")]
+        public void MetricOverrideLegalValues(string snippet, string expected)
+        {
+            var property = ParseDeclaration(snippet);
+            Assert.IsTrue(property.HasValue);
+            Assert.AreEqual(expected, property.Value);
+        }
+
+        [TestCase("ascent-override: 10px")]
+        [TestCase("descent-override: auto")]
+        [TestCase("line-gap-override: none")]
+        public void MetricOverrideIllegalValues(string snippet)
+        {
+            var property = ParseDeclaration(snippet);
+            Assert.IsFalse(property.HasValue);
+        }
+
+        [TestCase("font-feature-settings: normal", "normal")]
+        [TestCase("font-feature-settings: \"liga\"", "\"liga\"")]
+        [TestCase("font-feature-settings: \"liga\" 1", "\"liga\" 1")]
+        [TestCase("font-feature-settings: \"kern\" on", "\"kern\" on")]
+        [TestCase("font-feature-settings: \"kern\" off", "\"kern\" off")]
+        [TestCase("font-feature-settings: \"liga\" 1, \"kern\" off", "\"liga\" 1, \"kern\" off")]
+        public void FontFeatureSettingsLegalValues(string snippet, string expected)
+        {
+            var property = ParseDeclaration(snippet);
+            Assert.AreEqual("font-feature-settings", property.Name);
+            Assert.IsTrue(property.HasValue);
+            Assert.AreEqual(expected, property.Value);
+        }
+
+        [TestCase("font-feature-settings: 12")]
+        [TestCase("font-feature-settings: liga")]
+        [TestCase("font-feature-settings: \"liga\" bogus")]
+        public void FontFeatureSettingsIllegalValues(string snippet)
+        {
+            var property = ParseDeclaration(snippet);
+            Assert.IsFalse(property.HasValue);
+        }
+
+        [TestCase("font-variation-settings: normal", "normal")]
+        [TestCase("font-variation-settings: \"wght\" 400", "\"wght\" 400")]
+        [TestCase("font-variation-settings: \"wght\" 400, \"slnt\" -10", "\"wght\" 400, \"slnt\" -10")]
+        public void FontVariationSettingsLegalValues(string snippet, string expected)
+        {
+            var property = ParseDeclaration(snippet);
+            Assert.AreEqual("font-variation-settings", property.Name);
+            Assert.IsTrue(property.HasValue);
+            Assert.AreEqual(expected, property.Value);
+        }
+
+        [TestCase("font-variation-settings: wght 400")]
+        [TestCase("font-variation-settings: 400")]
+        public void FontVariationSettingsIllegalValues(string snippet)
+        {
+            var property = ParseDeclaration(snippet);
+            Assert.IsFalse(property.HasValue);
+        }
+    }
+}

--- a/src/AngleSharp.Css.Tests/Rules/FontFaceDescriptors.cs
+++ b/src/AngleSharp.Css.Tests/Rules/FontFaceDescriptors.cs
@@ -1,0 +1,162 @@
+namespace AngleSharp.Css.Tests.Rules
+{
+    using AngleSharp.Css.Dom;
+    using AngleSharp.Css.Parser;
+    using NUnit.Framework;
+    using System.Linq;
+    using static CssConstructionFunctions;
+
+    /// <summary>
+    /// Descriptors inside @font-face used to be limited to a hardcoded set of seven,
+    /// with everything else dropped silently and without regard to the parser options.
+    /// These cases pin down that the standard CSS Fonts Level 4 descriptors survive by
+    /// default and that anything else survives when unknown declarations are included.
+    /// </summary>
+    [TestFixture]
+    public class FontFaceDescriptorTests
+    {
+        private static readonly CssParserOptions IncludingUnknown = new() { IsIncludingUnknownDeclarations = true };
+
+        [Test]
+        public void FontFaceKeepsFontDisplay()
+        {
+            var sheet = ParseStyleSheet("@font-face { font-display: swap }");
+            var fontface = (ICssFontFaceRule)sheet.Rules[0];
+            Assert.AreEqual("swap", fontface.GetPropertyValue(PropertyNames.FontDisplay));
+        }
+
+        [Test]
+        public void FontFaceKeepsSizeAdjust()
+        {
+            var sheet = ParseStyleSheet("@font-face { size-adjust: 90% }");
+            var fontface = (ICssFontFaceRule)sheet.Rules[0];
+            Assert.AreEqual("90%", fontface.GetPropertyValue(PropertyNames.SizeAdjust));
+        }
+
+        [TestCase("ascent-override", "90%")]
+        [TestCase("descent-override", "20%")]
+        [TestCase("line-gap-override", "0%")]
+        [TestCase("ascent-override", "normal")]
+        public void FontFaceKeepsMetricOverrides(string name, string value)
+        {
+            var sheet = ParseStyleSheet($"@font-face {{ {name}: {value} }}");
+            var fontface = (ICssFontFaceRule)sheet.Rules[0];
+            Assert.AreEqual(value, fontface.GetPropertyValue(name));
+        }
+
+        [Test]
+        public void FontFaceKeepsFontFeatureSettings()
+        {
+            var sheet = ParseStyleSheet("@font-face { font-feature-settings: \"liga\" 1, \"kern\" on, \"smcp\" }");
+            var fontface = (ICssFontFaceRule)sheet.Rules[0];
+            Assert.AreEqual("\"liga\" 1, \"kern\" on, \"smcp\"", fontface.GetPropertyValue(PropertyNames.FontFeatureSettings));
+        }
+
+        [Test]
+        public void FontFaceKeepsFontVariationSettings()
+        {
+            var sheet = ParseStyleSheet("@font-face { font-variation-settings: \"wght\" 400, \"slnt\" -10 }");
+            var fontface = (ICssFontFaceRule)sheet.Rules[0];
+            Assert.AreEqual("\"wght\" 400, \"slnt\" -10", fontface.GetPropertyValue(PropertyNames.FontVariationSettings));
+        }
+
+        [Test]
+        public void FontFaceFeaturesMapToFontFeatureSettings()
+        {
+            var sheet = ParseStyleSheet("@font-face { font-feature-settings: \"liga\" 1 }");
+            var fontface = (ICssFontFaceRule)sheet.Rules[0];
+            Assert.AreEqual("\"liga\" 1", fontface.Features);
+
+            fontface.Features = "\"kern\" off";
+            Assert.AreEqual("\"kern\" off", fontface.GetPropertyValue(PropertyNames.FontFeatureSettings));
+        }
+
+        [Test]
+        public void FontFaceStandardDescriptorsRoundtripViaToCss()
+        {
+            var src = "@font-face { font-family: \"FontName\"; src: url(\"https://example.com/font.woff\") format(\"woff\"); font-display: swap; size-adjust: 100% }";
+            var sheet = ParseStyleSheet(src);
+            var css = sheet.ToCss();
+            Assert.That(css, Does.Contain("font-display: swap"));
+            Assert.That(css, Does.Contain("size-adjust: 100%"));
+        }
+
+        [Test]
+        public void FontFaceDropsVendorDescriptorByDefault()
+        {
+            var sheet = ParseStyleSheet("@font-face { mso-generic-font-family: auto }");
+            var fontface = (ICssFontFaceRule)sheet.Rules[0];
+            Assert.AreEqual(0, fontface.Length);
+        }
+
+        [Test]
+        public void FontFaceKeepsVendorDescriptorWhenIncludingUnknownDeclarations()
+        {
+            var sheet = ParseStyleSheet("@font-face { mso-generic-font-family: auto }", IncludingUnknown);
+            var fontface = (ICssFontFaceRule)sheet.Rules[0];
+            Assert.AreEqual("auto", fontface.GetPropertyValue("mso-generic-font-family"));
+            Assert.That(sheet.ToCss(), Does.Contain("mso-generic-font-family: auto"));
+        }
+
+        [Test]
+        public void FontFaceKeepsCustomPropertyWhenIncludingUnknownDeclarations()
+        {
+            var sheet = ParseStyleSheet("@font-face { --custom-thing: 12px }", IncludingUnknown);
+            var fontface = (ICssFontFaceRule)sheet.Rules[0];
+            Assert.AreEqual("12px", fontface.GetPropertyValue("--custom-thing"));
+        }
+
+        [Test]
+        public void FontFaceIgnoresInvalidDescriptorValue()
+        {
+            var sheet = ParseStyleSheet("@font-face { size-adjust: 10px; ascent-override: bogus }");
+            var fontface = (ICssFontFaceRule)sheet.Rules[0];
+            Assert.AreEqual(0, fontface.Length);
+            Assert.That(sheet.ToCss(), Does.Not.Contain("size-adjust"));
+        }
+
+        [Test]
+        public void FontFaceInvalidValueDoesNotOverwriteValidOne()
+        {
+            var sheet = ParseStyleSheet("@font-face { font-weight: 400; font-weight: bogus }");
+            var fontface = (ICssFontFaceRule)sheet.Rules[0];
+            Assert.AreEqual("400", fontface.Weight);
+        }
+
+        [Test]
+        public void FontFaceValidValueOverwritesEarlierOne()
+        {
+            var sheet = ParseStyleSheet("@font-face { font-weight: 400; font-weight: 700 }");
+            var fontface = (ICssFontFaceRule)sheet.Rules[0];
+            Assert.AreEqual("700", fontface.Weight);
+            Assert.AreEqual(1, fontface.Length);
+        }
+
+        [Test]
+        public void CounterStyleKeepsDescriptorsWhenIncludingUnknownDeclarations()
+        {
+            var sheet = ParseStyleSheet("@counter-style thumbs { system: cyclic; symbols: \"X\" }", IncludingUnknown);
+            var rule = (ICssProperties)sheet.Rules[0];
+            Assert.AreEqual("cyclic", rule.GetPropertyValue("system"));
+            Assert.AreEqual("\"X\"", rule.GetPropertyValue("symbols"));
+        }
+
+        [Test]
+        public void ViewportKeepsUnknownDescriptorWhenIncludingUnknownDeclarations()
+        {
+            var sheet = ParseStyleSheet("@viewport { width: 100px; foo: bar }", IncludingUnknown);
+            var rule = (ICssProperties)sheet.Rules[0];
+            Assert.AreEqual("bar", rule.GetPropertyValue("foo"));
+            Assert.AreEqual(2, rule.Length);
+        }
+
+        [Test]
+        public void FontFaceDescriptorsAreEnumerable()
+        {
+            var sheet = ParseStyleSheet("@font-face { font-family: \"X\"; font-display: swap; size-adjust: 50% }");
+            var fontface = (ICssFontFaceRule)sheet.Rules[0];
+            var names = fontface.Select(m => m.Name).ToArray();
+            CollectionAssert.AreEquivalent(new[] { "font-family", "font-display", "size-adjust" }, names);
+        }
+    }
+}

--- a/src/AngleSharp.Css/BrowsingContextExtensions.cs
+++ b/src/AngleSharp.Css/BrowsingContextExtensions.cs
@@ -95,7 +95,7 @@ namespace AngleSharp.Css
         private static Boolean AllowsDeclaration(this IBrowsingContext context, DeclarationInfo info) =>
             info.Flags != PropertyFlags.Unknown || context.IsAllowingUnknownDeclarations();
 
-        private static Boolean IsAllowingUnknownDeclarations(this IBrowsingContext context)
+        internal static Boolean IsAllowingUnknownDeclarations(this IBrowsingContext context)
         {
             var parser = context.GetProvider<CssParser>();
             return parser?.Options.IsIncludingUnknownDeclarations ?? true;

--- a/src/AngleSharp.Css/Constants/CssKeywords.cs
+++ b/src/AngleSharp.Css/Constants/CssKeywords.cs
@@ -308,6 +308,16 @@ namespace AngleSharp.Css
         public static readonly String Optional = "optional";
 
         /// <summary>
+        /// The on keyword (font-feature-settings).
+        /// </summary>
+        public static readonly String On = "on";
+
+        /// <summary>
+        /// The off keyword (font-feature-settings).
+        /// </summary>
+        public static readonly String Off = "off";
+
+        /// <summary>
         /// The avoid keyword.
         /// </summary>
         public static readonly String Avoid = "avoid";

--- a/src/AngleSharp.Css/Constants/InitialValues.cs
+++ b/src/AngleSharp.Css/Constants/InitialValues.cs
@@ -47,6 +47,11 @@ namespace AngleSharp.Css
         public static readonly ICssValue FontSynthesisStyleDecl = new CssConstantValue<Object>(CssKeywords.Auto, null);
         public static readonly ICssValue FontSynthesisSmallCapsDecl = new CssConstantValue<Object>(CssKeywords.Auto, null);
         public static readonly ICssValue FontVariationSettingsDecl = new CssConstantValue<Object>(CssKeywords.Normal, null);
+        public static readonly ICssValue FontFeatureSettingsDecl = new CssConstantValue<Object>(CssKeywords.Normal, null);
+        public static readonly ICssValue SizeAdjustDecl = new CssPercentageValue(100.0);
+        public static readonly ICssValue AscentOverrideDecl = new CssConstantValue<Object>(CssKeywords.Normal, null);
+        public static readonly ICssValue DescentOverrideDecl = new CssConstantValue<Object>(CssKeywords.Normal, null);
+        public static readonly ICssValue LineGapOverrideDecl = new CssConstantValue<Object>(CssKeywords.Normal, null);
         public static readonly ICssValue AccentColorDecl = new CssConstantValue<Object>(CssKeywords.Auto, null);
         public static readonly ICssValue AppearanceDecl = new CssIdentifierValue(CssKeywords.Auto);
         public static readonly ICssValue CaretColorDecl = new CssConstantValue<Object>(CssKeywords.Auto, null);

--- a/src/AngleSharp.Css/Constants/PropertyNames.cs
+++ b/src/AngleSharp.Css/Constants/PropertyNames.cs
@@ -908,6 +908,26 @@ namespace AngleSharp.Css
         public static readonly String FontKerning = "font-kerning";
 
         /// <summary>
+        /// The size-adjust declaration (@font-face descriptor).
+        /// </summary>
+        public static readonly String SizeAdjust = "size-adjust";
+
+        /// <summary>
+        /// The ascent-override declaration (@font-face descriptor).
+        /// </summary>
+        public static readonly String AscentOverride = "ascent-override";
+
+        /// <summary>
+        /// The descent-override declaration (@font-face descriptor).
+        /// </summary>
+        public static readonly String DescentOverride = "descent-override";
+
+        /// <summary>
+        /// The line-gap-override declaration (@font-face descriptor).
+        /// </summary>
+        public static readonly String LineGapOverride = "line-gap-override";
+
+        /// <summary>
         /// The font-language-override declaration.
         /// </summary>
         public static readonly String FontLanguageOverride = "font-language-override";

--- a/src/AngleSharp.Css/Declarations/AscentOverrideDeclaration.cs
+++ b/src/AngleSharp.Css/Declarations/AscentOverrideDeclaration.cs
@@ -1,0 +1,17 @@
+namespace AngleSharp.Css.Declarations
+{
+    using AngleSharp.Css.Dom;
+    using System;
+    using static ValueConverters;
+
+    static class AscentOverrideDeclaration
+    {
+        public static String Name = PropertyNames.AscentOverride;
+
+        public static IValueConverter Converter = FontMetricOverrideConverter;
+
+        public static ICssValue InitialValue = InitialValues.AscentOverrideDecl;
+
+        public static PropertyFlags Flags = PropertyFlags.None;
+    }
+}

--- a/src/AngleSharp.Css/Declarations/DescentOverrideDeclaration.cs
+++ b/src/AngleSharp.Css/Declarations/DescentOverrideDeclaration.cs
@@ -1,0 +1,17 @@
+namespace AngleSharp.Css.Declarations
+{
+    using AngleSharp.Css.Dom;
+    using System;
+    using static ValueConverters;
+
+    static class DescentOverrideDeclaration
+    {
+        public static String Name = PropertyNames.DescentOverride;
+
+        public static IValueConverter Converter = FontMetricOverrideConverter;
+
+        public static ICssValue InitialValue = InitialValues.DescentOverrideDecl;
+
+        public static PropertyFlags Flags = PropertyFlags.None;
+    }
+}

--- a/src/AngleSharp.Css/Declarations/FontFeatureSettingsDeclaration.cs
+++ b/src/AngleSharp.Css/Declarations/FontFeatureSettingsDeclaration.cs
@@ -1,0 +1,17 @@
+namespace AngleSharp.Css.Declarations
+{
+    using AngleSharp.Css.Dom;
+    using System;
+    using static ValueConverters;
+
+    static class FontFeatureSettingsDeclaration
+    {
+        public static String Name = PropertyNames.FontFeatureSettings;
+
+        public static IValueConverter Converter = FontFeatureSettingsConverter;
+
+        public static ICssValue InitialValue = InitialValues.FontFeatureSettingsDecl;
+
+        public static PropertyFlags Flags = PropertyFlags.Inherited;
+    }
+}

--- a/src/AngleSharp.Css/Declarations/LineGapOverrideDeclaration.cs
+++ b/src/AngleSharp.Css/Declarations/LineGapOverrideDeclaration.cs
@@ -1,0 +1,17 @@
+namespace AngleSharp.Css.Declarations
+{
+    using AngleSharp.Css.Dom;
+    using System;
+    using static ValueConverters;
+
+    static class LineGapOverrideDeclaration
+    {
+        public static String Name = PropertyNames.LineGapOverride;
+
+        public static IValueConverter Converter = FontMetricOverrideConverter;
+
+        public static ICssValue InitialValue = InitialValues.LineGapOverrideDecl;
+
+        public static PropertyFlags Flags = PropertyFlags.None;
+    }
+}

--- a/src/AngleSharp.Css/Declarations/SizeAdjustDeclaration.cs
+++ b/src/AngleSharp.Css/Declarations/SizeAdjustDeclaration.cs
@@ -1,0 +1,17 @@
+namespace AngleSharp.Css.Declarations
+{
+    using AngleSharp.Css.Dom;
+    using System;
+    using static ValueConverters;
+
+    static class SizeAdjustDeclaration
+    {
+        public static String Name = PropertyNames.SizeAdjust;
+
+        public static IValueConverter Converter = SizeAdjustConverter;
+
+        public static ICssValue InitialValue = InitialValues.SizeAdjustDecl;
+
+        public static PropertyFlags Flags = PropertyFlags.None;
+    }
+}

--- a/src/AngleSharp.Css/Dom/Internal/Rules/CssDeclarationRule.cs
+++ b/src/AngleSharp.Css/Dom/Internal/Rules/CssDeclarationRule.cs
@@ -85,7 +85,11 @@ namespace AngleSharp.Css.Dom
 
         private ICssProperty CreateNewProperty(String propertyName)
         {
-            if (_contained.Contains(propertyName))
+            // Descriptors of the rule itself are always created. Anything else is
+            // kept only when unknown declarations are included - the same switch
+            // that preserves them in ordinary style rules. Without it the
+            // declaration would be dropped silently.
+            if (_contained.Contains(propertyName) || Owner.Context.IsAllowingUnknownDeclarations())
             {
                 return Owner.Context.CreateProperty(propertyName);
             }
@@ -110,22 +114,32 @@ namespace AngleSharp.Css.Dom
         {
             if (!String.IsNullOrEmpty(valueText))
             {
-                foreach (var declaration in _declarations)
+                var property = CreateNewProperty(propertyName);
+
+                if (property is null)
                 {
-                    if (declaration.Name.Is(propertyName))
+                    return;
+                }
+
+                property.Value = valueText;
+
+                if (property.RawValue is null)
+                {
+                    // The value is not valid for this declaration; ignore it instead
+                    // of storing an empty declaration that would serialize as "name: ".
+                    return;
+                }
+
+                for (var i = 0; i < _declarations.Count; i++)
+                {
+                    if (_declarations[i].Name.Is(propertyName))
                     {
-                        declaration.Value = valueText;
+                        _declarations[i] = property;
                         return;
                     }
                 }
 
-                var property = CreateNewProperty(propertyName);
-
-                if (property != null)
-                {
-                    property.Value = valueText;
-                    _declarations.Add(property);
-                }
+                _declarations.Add(property);
             }
             else
             {

--- a/src/AngleSharp.Css/Dom/Internal/Rules/CssFontFaceRule.cs
+++ b/src/AngleSharp.Css/Dom/Internal/Rules/CssFontFaceRule.cs
@@ -22,6 +22,13 @@ namespace AngleSharp.Css.Dom
             PropertyNames.FontStretch,
             PropertyNames.UnicodeRange,
             PropertyNames.FontVariant,
+            PropertyNames.FontDisplay,
+            PropertyNames.FontFeatureSettings,
+            PropertyNames.FontVariationSettings,
+            PropertyNames.SizeAdjust,
+            PropertyNames.AscentOverride,
+            PropertyNames.DescentOverride,
+            PropertyNames.LineGapOverride,
         };
 
         #endregion
@@ -83,8 +90,8 @@ namespace AngleSharp.Css.Dom
 
         String ICssFontFaceRule.Features
         {
-            get => String.Empty;
-            set { }
+            get => GetValue(PropertyNames.FontFeatureSettings);
+            set => SetValue(PropertyNames.FontFeatureSettings, value);
         }
 
         #endregion
@@ -101,6 +108,7 @@ namespace AngleSharp.Css.Dom
             SetValue(PropertyNames.FontStretch, newRule.Stretch);
             SetValue(PropertyNames.UnicodeRange, newRule.Range);
             SetValue(PropertyNames.FontVariant, newRule.Variant);
+            SetValue(PropertyNames.FontFeatureSettings, newRule.Features);
         }
 
         #endregion

--- a/src/AngleSharp.Css/Factories/DefaultDeclarationFactory.cs
+++ b/src/AngleSharp.Css/Factories/DefaultDeclarationFactory.cs
@@ -975,6 +975,41 @@ namespace AngleSharp.Css
                     flags: FontDisplayDeclaration.Flags)
             },
             {
+                FontFeatureSettingsDeclaration.Name, new DeclarationInfo(
+                    name: FontFeatureSettingsDeclaration.Name,
+                    converter: FontFeatureSettingsDeclaration.Converter,
+                    initialValue: FontFeatureSettingsDeclaration.InitialValue,
+                    flags: FontFeatureSettingsDeclaration.Flags)
+            },
+            {
+                SizeAdjustDeclaration.Name, new DeclarationInfo(
+                    name: SizeAdjustDeclaration.Name,
+                    converter: SizeAdjustDeclaration.Converter,
+                    initialValue: SizeAdjustDeclaration.InitialValue,
+                    flags: SizeAdjustDeclaration.Flags)
+            },
+            {
+                AscentOverrideDeclaration.Name, new DeclarationInfo(
+                    name: AscentOverrideDeclaration.Name,
+                    converter: AscentOverrideDeclaration.Converter,
+                    initialValue: AscentOverrideDeclaration.InitialValue,
+                    flags: AscentOverrideDeclaration.Flags)
+            },
+            {
+                DescentOverrideDeclaration.Name, new DeclarationInfo(
+                    name: DescentOverrideDeclaration.Name,
+                    converter: DescentOverrideDeclaration.Converter,
+                    initialValue: DescentOverrideDeclaration.InitialValue,
+                    flags: DescentOverrideDeclaration.Flags)
+            },
+            {
+                LineGapOverrideDeclaration.Name, new DeclarationInfo(
+                    name: LineGapOverrideDeclaration.Name,
+                    converter: LineGapOverrideDeclaration.Converter,
+                    initialValue: LineGapOverrideDeclaration.InitialValue,
+                    flags: LineGapOverrideDeclaration.Flags)
+            },
+            {
                 FontKerningDeclaration.Name, new DeclarationInfo(
                     name: FontKerningDeclaration.Name,
                     converter: FontKerningDeclaration.Converter,

--- a/src/AngleSharp.Css/ValueConverters.cs
+++ b/src/AngleSharp.Css/ValueConverters.cs
@@ -121,6 +121,11 @@ namespace AngleSharp.Css
         public static readonly IValueConverter OnlyLengthOrPercentConverter = new StructValueConverter<CssLengthValue>(UnitParser.ParseDistance);
 
         /// <summary>
+        /// Represents a percentage object, i.e. a number followed by a percent sign.
+        /// </summary>
+        public static readonly IValueConverter OnlyPercentConverter = new StructValueConverter<CssPercentageValue>(ParseOnlyPercent);
+
+        /// <summary>
         /// Represents a string object.
         /// </summary>
         public static readonly IValueConverter StringConverter = new StructValueConverter<CssStringValue>(FromString(StringParser.ParseString));
@@ -215,6 +220,11 @@ namespace AngleSharp.Css
         /// Represents a (calculated) distance object (either Length or Percent).
         /// </summary>
         public static readonly IValueConverter LengthOrPercentConverter = Or(OnlyLengthOrPercentConverter, CalcConverter);
+
+        /// <summary>
+        /// Represents a (calculated) percentage object.
+        /// </summary>
+        public static readonly IValueConverter PercentConverter = Or(OnlyPercentConverter, CalcConverter);
 
         /// <summary>
         /// Represents an number object that is zero or greater.
@@ -1089,6 +1099,32 @@ namespace AngleSharp.Css
             Assign(CssKeywords.Optional, CssKeywords.Optional));
 
         /// <summary>
+        /// Represents a converter for the size-adjust descriptor.
+        /// </summary>
+        public static readonly IValueConverter SizeAdjustConverter = PercentConverter;
+
+        /// <summary>
+        /// Represents a converter for the ascent-override, descent-override and
+        /// line-gap-override descriptors.
+        /// </summary>
+        public static readonly IValueConverter FontMetricOverrideConverter = Or(
+            Assign(CssKeywords.Normal, CssKeywords.Normal),
+            PercentConverter);
+
+        /// <summary>
+        /// Represents a converter for the font-feature-settings property.
+        /// </summary>
+        public static readonly IValueConverter FontFeatureSettingsConverter = Or(
+            Assign(CssKeywords.Normal, CssKeywords.Normal),
+            WithOrder(
+                StringConverter,
+                Or(
+                    NaturalIntegerConverter,
+                    Assign(CssKeywords.On, CssKeywords.On),
+                    Assign(CssKeywords.Off, CssKeywords.Off)))
+            .FromList());
+
+        /// <summary>
         /// Represents a converter for the font-kerning property.
         /// </summary>
         public static readonly IValueConverter FontKerningConverter = Or(
@@ -1152,7 +1188,12 @@ namespace AngleSharp.Css
         /// <summary>
         /// Represents a converter for the font-variation-settings property.
         /// </summary>
-        public static readonly IValueConverter FontVariationSettingsConverter = Assign(CssKeywords.Normal, CssKeywords.Normal);
+        public static readonly IValueConverter FontVariationSettingsConverter = Or(
+            Assign(CssKeywords.Normal, CssKeywords.Normal),
+            WithOrder(
+                StringConverter,
+                NumberConverter)
+            .FromList());
 
         /// <summary>
         /// Represents a converter for the ResizeMode enumeration.
@@ -1702,6 +1743,20 @@ namespace AngleSharp.Css
 
         private static IValueConverter FromParser<T>(Func<StringSource, T> converter)
             where T : class, ICssValue => new ClassValueConverter<T>(converter);
+
+        private static CssPercentageValue? ParseOnlyPercent(this StringSource source)
+        {
+            var pos = source.Index;
+            var result = source.ParsePercentOrNumber();
+
+            if (result?.Type == CssPercentageValue.Unit.Percent)
+            {
+                return result;
+            }
+
+            source.BackTo(pos);
+            return null;
+        }
 
         private static Func<StringSource, CssStringValue?> FromString(Func<StringSource, String> converter) => source =>
         {


### PR DESCRIPTION
## Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

## Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## Description


# Preserve `@font-face` descriptors outside the hardcoded set of seven

Fixes the silent descriptor loss reported downstream in [mganss/HtmlSanitizer#541](https://github.com/mganss/HtmlSanitizer/issues/541).

## Problem

`CssFontFaceRule` kept only the seven descriptors named in its private `ContainedProperties` set. `CssDeclarationRule.CreateNewProperty` returned `null` for everything else, and `SetValue` then skipped the declaration entirely - without ever consulting the parser options:

```csharp
private ICssProperty CreateNewProperty(String propertyName)
{
    if (_contained.Contains(propertyName))
    {
        return Owner.Context.CreateProperty(propertyName);
    }

    return null;   // <- declaration is silently discarded
}
```

So `CssParserOptions.IsIncludingUnknownDeclarations` - the switch that keeps unrecognized declarations alive in ordinary style rules - had no effect inside `@font-face`. Standard CSS Fonts Level 4 descriptors (`font-display`, `size-adjust`, `ascent-override`, `font-feature-settings`, …) and vendor descriptors (`mso-*`, common in email HTML) were both lost. The drop is silent: no exception, no diagnostic, and `ToCss()` emits a rule that looks well-formed, so a caller round-tripping a stylesheet has no way to notice.

`CssViewportRule`, `CssCounterStyleRule` and `CssFontFeatureValuesRule` derive from the same base class. The latter two pass an **empty** contained set, so they were dropping *every* declaration:

```
@counter-style thumbs { system: cyclic; symbols: "X" }   ->   @counter-style { }
```

### Before

```csharp
var parser = new CssParser(new CssParserOptions { IsIncludingUnknownDeclarations = true });
var css = """
@font-face {
    font-family: "FontName";
    src: url("https://example.com/font.woff") format("woff");
    font-display: swap;
    size-adjust: 100%;
}
""";
parser.ParseStyleSheet(css).ToCss();
```

```
@font-face { font-family: "FontName"; src: url("https://example.com/font.woff") format("woff") }
```

Output was byte-identical with `IsIncludingUnknownDeclarations = false`.

### After

```
@font-face { font-family: "FontName"; src: url("https://example.com/font.woff") format("woff"); font-display: swap; size-adjust: 100% }
```

## Changes

### 1. Honour `IsIncludingUnknownDeclarations` in `CssDeclarationRule`

Declarations outside a rule's descriptor set now fall through to the same `IsAllowingUnknownDeclarations()` gate that style rules already use, instead of being dropped unconditionally. `@font-face` and style rules now agree in every configuration. This applies to `@counter-style`, `@font-feature-values` and `@viewport` too, since they share the base class.

`BrowsingContextExtensions.IsAllowingUnknownDeclarations` changed from `private` to `internal` to make this reusable. No public API change.

### 2. Register the missing standard descriptors

Of the dropped descriptors, only `font-display` was actually a *known* declaration. `size-adjust`, `ascent-override`, `descent-override`, `line-gap-override` and `font-feature-settings` had no declaration registered at all - extending `ContainedProperties` alone would not have saved them, since they would still be flagged `PropertyFlags.Unknown` and gated by the option.

They are now registered with real value grammars, so they are kept - typed - by default:

| Descriptor | Grammar | Initial |
|---|---|---|
| `size-adjust` | `<percentage>` | `100%` |
| `ascent-override` | `normal \| <percentage>` | `normal` |
| `descent-override` | `normal \| <percentage>` | `normal` |
| `line-gap-override` | `normal \| <percentage>` | `normal` |
| `font-feature-settings` | `normal \| [ <string> [ <integer> \| on \| off ]? ]#` | `normal` |

Supporting additions: `OnlyPercentConverter` / `PercentConverter` (there was no percentage-only converter - `LengthOrPercentConverter` would have accepted `10px` for `size-adjust`), and the `on` / `off` keywords.

`CssFontFaceRule.ContainedProperties` gains all seven Fonts L4 descriptors.

### 3. Three defects this exposed

- **`font-variation-settings` accepted only `normal`.** Its converter was `Assign(CssKeywords.Normal, …)`, so `"wght" 400` was rejected in style rules and would have been rejected in the newly preserved `@font-face`. Now implements `normal | [<string> <number>]#`.
- **Invalid values produced malformed output.** `CssDeclarationRule.SetValue` added properties without checking they parsed, so `@font-face { size-adjust: 10px }` serialized as `@font-face { size-adjust: ; }`. Invalid values are now ignored and leave an existing valid declaration standing (`font-weight: 400; font-weight: bogus` keeps `400`), matching `CssStyleDeclaration`'s behaviour.
- **`ICssFontFaceRule.Features` was a stub** - `get => String.Empty; set { }` - despite its `featureSettings` DOM name. It now maps to `font-feature-settings`.

## Behaviour summary

| Declaration in `@font-face` | Before | After (default) | After (`IsIncludingUnknownDeclarations`) |
|---|---|---|---|
| `font-family`, `src`, `font-style`, `font-weight`, `font-stretch`, `font-variant`, `unicode-range` | kept | kept | kept |
| `font-display` | dropped | kept, typed | kept, typed |
| `size-adjust`, `ascent-override`, `descent-override`, `line-gap-override` | dropped | kept, typed | kept, typed |
| `font-feature-settings`, `font-variation-settings` | dropped | kept, typed | kept, typed |
| `mso-generic-font-family`, `--custom-thing`, `color` | dropped | dropped | kept |

## Scope 

1. **`@counter-style` and `@font-feature-values` are only fixed under the opt-in.** Their descriptors (`system`, `symbols`, `suffix`, …) are still unregistered, so by default they remain dropped. Registering the ~10 counter-style descriptors is a separate piece of work.
2. **Their prelude is still lost on serialization.** `CssDeclarationRule.ToCss` passes `null` as the prelude, so `@counter-style thumbs { … }` serializes as `@counter-style { … }` even when the declarations survive. Separate defect, worth its own issue.

One pre-existing quirk worth noting, unchanged here: `IsAllowingUnknownDeclarations` resolves via `GetProvider<CssParser>()`, which misses a factory-registered parser that has not been resolved yet and then defaults to permissive. That is why the original report saw identical output for `true` and `false`. This PR reuses that same gate rather than working around it, so the `@font-face` and style-rule paths stay consistent whatever it resolves to.

## Testing

- `src/AngleSharp.Css.Tests/Rules/FontFaceDescriptors.cs` - descriptor preservation, vendor/custom descriptors under both option values, invalid-value handling, overwrite semantics, `Features` mapping, `ToCss` round-trip, and sibling-rule coverage for `@counter-style` / `@viewport`.
- `src/AngleSharp.Css.Tests/Declarations/CssFontDescriptorProperty.cs` - legal and illegal values for each new grammar.
