### PR TITLE
Fix oklab/oklch lightness misparsed as percentage when given as a number

### DIFF
--- a/src/AngleSharp.Css.Tests/Functions/CssColorFunction.cs
+++ b/src/AngleSharp.Css.Tests/Functions/CssColorFunction.cs
@@ -76,6 +76,28 @@ namespace AngleSharp.Css.Tests.Functions
         }
 
         [Test]
+        public void ParseOklabNumberToRgb_First()
+        {
+            var html = @"<p style='color: oklab(0.401 0.1143 0.045)'>Text</p>";
+            var dom = ParseDocument(html);
+            var p = dom.QuerySelector("p");
+            var s = p.GetStyle();
+            var color = s.GetColor();
+            Assert.AreEqual("rgba(125, 35, 40, 1)", color);
+        }
+
+        [Test]
+        public void ParseOklabNumberToRgb_Second()
+        {
+            var html = @"<p style='color: oklab(0.5969 0.1007 0.1191);'>Text</p>";
+            var dom = ParseDocument(html);
+            var p = dom.QuerySelector("p");
+            var s = p.GetStyle();
+            var color = s.GetColor();
+            Assert.AreEqual("rgba(198, 93, 7, 1)", color);
+        }
+
+        [Test]
         public void ParseOklabToRgb_Alpha()
         {
             var html = @"<p style='color: oklab(59.69% 0.1007 0.1191 / 0.5);'>Text</p>";
@@ -101,6 +123,28 @@ namespace AngleSharp.Css.Tests.Functions
         public void ParseOklchToRgb_Second()
         {
             var html = @"<p style='color: oklch(59.69% 0.156 49.77)'>Text</p>";
+            var dom = ParseDocument(html);
+            var p = dom.QuerySelector("p");
+            var s = p.GetStyle();
+            var color = s.GetColor();
+            Assert.AreEqual("rgba(198, 93, 7, 1)", color);
+        }
+
+        [Test]
+        public void ParseOklchNumberToRgb_First()
+        {
+            var html = @"<p style='color: oklch(0.401 0.123 21.57)'>Text</p>";
+            var dom = ParseDocument(html);
+            var p = dom.QuerySelector("p");
+            var s = p.GetStyle();
+            var color = s.GetColor();
+            Assert.AreEqual("rgba(125, 35, 40, 1)", color);
+        }
+
+        [Test]
+        public void ParseOklchNumberToRgb_Second()
+        {
+            var html = @"<p style='color: oklch(0.5969 0.156 49.77)'>Text</p>";
             var dom = ParseDocument(html);
             var p = dom.QuerySelector("p");
             var s = p.GetStyle();

--- a/src/AngleSharp.Css/Parser/Micro/ColorParser.cs
+++ b/src/AngleSharp.Css/Parser/Micro/ColorParser.cs
@@ -292,7 +292,7 @@ namespace AngleSharp.Css.Parser
 
         private static CssColorValue? ParseOklab(StringSource source)
         {
-            var l = ParseLabComponent(source);
+            var l = ParseLabComponent(source, numberScale: 100.0);
             source.SkipSpacesAndComments();
             var a = ParseLabComponent(source);
             source.SkipSpacesAndComments();
@@ -324,7 +324,7 @@ namespace AngleSharp.Css.Parser
 
         private static CssColorValue? ParseOklch(StringSource source)
         {
-            var l = ParseLabComponent(source);
+            var l = ParseLabComponent(source, numberScale: 100.0);
             source.SkipSpacesAndComments();
             var c = ParseLabComponent(source);
             source.SkipSpacesAndComments();
@@ -385,7 +385,7 @@ namespace AngleSharp.Css.Parser
             return null;
         }
 
-        private static Double? ParseLabComponent(StringSource source)
+        private static Double? ParseLabComponent(StringSource source, Double numberScale = 1.0)
         {
             var pos = source.Index;
             var unit = source.ParseUnit();
@@ -404,7 +404,7 @@ namespace AngleSharp.Css.Parser
 
             if ((unit.Dimension == String.Empty || unit.Dimension == "%") && Double.TryParse(unit.Value, NumberStyles.Float, CultureInfo.InvariantCulture, out var value))
             {
-                return value;
+                return unit.Dimension == String.Empty ? value * numberScale : value;
             }
 
             return null;


### PR DESCRIPTION
# Types of Changes

## Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

## Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## Description

### Summary

`oklab()`/`oklch()` accept the L (lightness) component as either a `<percentage>`
or a plain `<number>`. Per the CSS Color 4 spec, the percentage reference range
0%–100% maps to a number range of **0–1** (e.g. `40.1%` ≡ `0.401`).

The parser treated both forms identically, passing the raw parsed value straight
into `CssColorValue.FromOklab`, which expects L in `[0,100]` and internally
divides by 100. Percentages worked (`40.1%` → `40.1`), but numbers didn't
(`0.401` stayed `0.401` → scaled down to `0.00401`), producing a near-black
color instead of the intended one.

### Fix

`ParseLabComponent` in `ColorParser.cs` now takes an optional `numberScale`
factor applied only to the unitless/number form (percentages are unaffected).
`ParseOklab`/`ParseOklch` pass `numberScale: 100.0` for their L component so
`0.401` is normalized to `40.1`, matching `40.1%`.

`lab()`/`lch()` and the `a`/`b`/`c`/`h` components of all four functions were
left untouched — their number and percentage forms already share the same
native range per spec, and no failing test indicated an issue there.

### Testing

- Added `ParseOklchNumberToRgb_First/_Second` and `ParseOklabNumberToRgb_First/_Second`,
  asserting the number form produces the same RGB output as the existing
  percentage-form tests.
- Full test suite: 1999/1999 passing.
