### PR TITLE
Add an opt-in switch for CSSOM-compliant color serialization

### DIFF
--- a/docs/tutorials/04-Questions.md
+++ b/docs/tutorials/04-Questions.md
@@ -6,10 +6,10 @@ section: "AngleSharp.Css"
 
 ## How to change the color output?
 
-By default, AngleSharp.Css uses `rgba()` for the serialization of `Color`. To change this you can set
+By default, AngleSharp.Css uses `rgba()` for the serialization of `CssColorValue`. To change this you can set
 
 ```cs
-Color.UseHex = true;
+CssColorValue.UseHex = true;
 ```
 
 which will automatically use hex for all non-transparent colors. All other colors would still be represented via the `rgba()` function.
@@ -17,12 +17,24 @@ which will automatically use hex for all non-transparent colors. All other color
 So you'd get:
 
 ```cs
-Color.UseHex = true;
-var color1 = new Color(65, 12, 48);
+CssColorValue.UseHex = true;
+var color1 = new CssColorValue(65, 12, 48);
 // color1.CssText = #410C30
-var color2 = new Color(65, 12, 48, 10);
+var color2 = new CssColorValue(65, 12, 48, 10);
 // color2.CssText = rgba(65, 12, 48, 0.04)
 ```
+
+Alternatively, you can follow the serialization rules from the CSSOM specification, which omit the alpha channel of an opaque color:
+
+```cs
+CssColorValue.UseSpecSerialization = true;
+var color1 = new CssColorValue(65, 12, 48);
+// color1.CssText = rgb(65, 12, 48)
+var color2 = new CssColorValue(65, 12, 48, 10);
+// color2.CssText = rgba(65, 12, 48, 0.04)
+```
+
+Both switches are global and `UseHex` wins if both are active.
 
 ## Why is my linked stylesheet not loaded?
 

--- a/src/AngleSharp.Css.Tests/Library/StringRepresentation.cs
+++ b/src/AngleSharp.Css.Tests/Library/StringRepresentation.cs
@@ -16,6 +16,13 @@ namespace AngleSharp.Css.Tests.Library
     [TestFixture]
     public class StringRepresentationTests
     {
+        [TearDown]
+        public void ResetColorSerialization()
+        {
+            CssColorValue.UseHex = false;
+            CssColorValue.UseSpecSerialization = false;
+        }
+
         [Test]
         public void PrettyStyleFormatterStringifyShouldWork_Issue41()
         {
@@ -48,6 +55,62 @@ namespace AngleSharp.Css.Tests.Library
             var text = color.CssText;
             CssColorValue.UseHex = false;
             Assert.AreEqual("#410C300A", text);
+        }
+
+        [Test]
+        public void OpaqueColorKeepsTheAlphaChannelByDefault_Issue227()
+        {
+            var color = new CssColorValue(65, 12, 48);
+            Assert.AreEqual("rgba(65, 12, 48, 1)", color.CssText);
+        }
+
+        [Test]
+        public void OpaqueColorDropsTheAlphaChannelWithSpecOutput_Issue227()
+        {
+            var color = new CssColorValue(65, 12, 48);
+            CssColorValue.UseSpecSerialization = true;
+            Assert.AreEqual("rgb(65, 12, 48)", color.CssText);
+        }
+
+        [Test]
+        public void TransparentColorKeepsTheAlphaChannelWithSpecOutput_Issue227()
+        {
+            var color = new CssColorValue(65, 12, 48, 128);
+            CssColorValue.UseSpecSerialization = true;
+            Assert.AreEqual("rgba(65, 12, 48, 0.5)", color.CssText);
+        }
+
+        [Test]
+        public void OpaqueColorPrefersHexOutputOverSpecOutput_Issue227()
+        {
+            var color = new CssColorValue(65, 12, 48);
+            CssColorValue.UseHex = true;
+            CssColorValue.UseSpecSerialization = true;
+            Assert.AreEqual("#410C30", color.CssText);
+        }
+
+        [Test]
+        public void TransparentColorPrefersHexOutputOverSpecOutput_Issue227()
+        {
+            var color = new CssColorValue(65, 12, 48, 10);
+            CssColorValue.UseHex = true;
+            CssColorValue.UseSpecSerialization = true;
+            Assert.AreEqual("#410C300A", color.CssText);
+        }
+
+        [Test]
+        public void CurrentColorIsNotAffectedBySpecOutput_Issue227()
+        {
+            CssColorValue.UseSpecSerialization = true;
+            Assert.AreEqual("currentColor", CssColorValue.CurrentColor.CssText);
+        }
+
+        [Test]
+        public void DeclarationUsesSpecOutputForOpaqueColors_Issue227()
+        {
+            CssColorValue.UseSpecSerialization = true;
+            var declaration = ParseDeclaration("color: rgba(255, 0, 0, 1)");
+            Assert.AreEqual("color: rgb(255, 0, 0)", declaration.CssText);
         }
 
         [Test]

--- a/src/AngleSharp.Css/Values/Primitives/CssColorValue.cs
+++ b/src/AngleSharp.Css/Values/Primitives/CssColorValue.cs
@@ -470,6 +470,12 @@ namespace AngleSharp.Css.Values
         public static Boolean UseHex { get; set; }
 
         /// <summary>
+        /// Gets or sets if the CSSOM serialization rules should be used, i.e.,
+        /// if the alpha channel of an opaque color should be omitted.
+        /// </summary>
+        public static Boolean UseSpecSerialization { get; set; }
+
+        /// <summary>
         /// Gets the CSS text representation.
         /// </summary>
         public String CssText
@@ -494,6 +500,17 @@ namespace AngleSharp.Css.Values
                     }
 
                     return color;
+                }
+                else if (UseSpecSerialization && _alpha == 255)
+                {
+                    var fn = FunctionNames.Rgb;
+                    var args = String.Join(", ", new[]
+                    {
+                        R.ToString(CultureInfo.InvariantCulture),
+                        G.ToString(CultureInfo.InvariantCulture),
+                        B.ToString(CultureInfo.InvariantCulture),
+                    });
+                    return fn.CssFunction(args);
                 }
                 else
                 {


### PR DESCRIPTION
`CssColorValue` always serializes through `rgba()`, so an opaque color comes out as `rgba(r, g, b, 1)` where https://drafts.csswg.org/cssom/#serializing-css-values asks for `rgb(r, g, b)`; since changing that by default would be breaking, this adds a static switch next to `UseHex` that is off by default and, when on, serializes an opaque color as `rgb(r, g, b)` while anything below full alpha keeps `rgba(r, g, b, a)` - `UseHex` still wins when both are active. I kept your placeholder name `UseSpecSerialization` as the proposal because the deferred named-color reduction fits behind the same switch and it stays a single opt-in; if you would rather the name describe only what it does today, `OmitOpaqueAlpha` reads well and I will rename. Reducing a color back to its named form is not part of this change, and the color FAQ in `docs/tutorials/04-Questions.md` documents the new switch (its existing snippets still used the pre-0.18 `Color` name, so they are updated too).