### PR TITLE
Answer the user-preference media features from the render device

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,37 @@ var config = Configuration.Default
 
 If no specific `IRenderDevice` (e.g., via creating an `DefaultRenderDevice` object) instance is created a default implementation will be set.
 
+The render device also carries the *user preferences* of the Media Queries Level 5 (and Level 4) user-preference features. `DefaultRenderDevice` implements `IRenderDevicePreferences` for that, and any custom `IRenderDevice` can implement it as well. The dictionary is keyed by the media feature name and holds the keyword that the feature should answer with:
+
+```cs
+var config = Configuration.Default
+    .WithCss()
+    .WithRenderDevice(new DefaultRenderDevice
+    {
+        Preferences = new Dictionary<String, String>
+        {
+            { "prefers-color-scheme", "dark" },
+            { "prefers-reduced-motion", "reduce" },
+        },
+    });
+```
+
+With this device `@media (prefers-color-scheme: dark)` applies in the cascade and `window.MatchMedia("(prefers-color-scheme: dark)").IsMatched` is `true`. A key that is not set leaves its media feature unknown, i.e., a query using it never matches. The keys a browser would set are:
+
+| Key | Keywords |
+| --- | --- |
+| `prefers-color-scheme` | `light`, `dark` |
+| `prefers-reduced-motion` | `no-preference`, `reduce` |
+| `prefers-reduced-transparency` | `no-preference`, `reduce` |
+| `prefers-contrast` | `no-preference`, `more`, `less`, `custom` |
+| `prefers-reduced-data` | `no-preference`, `reduce` |
+| `forced-colors` | `none`, `active` |
+| `hover`, `any-hover` | `none`, `hover` |
+| `pointer`, `any-pointer` | `none`, `coarse`, `fine` |
+| `display-mode` | `fullscreen`, `standalone`, `minimal-ui`, `browser` |
+
+The value is compared to the queried keyword case insensitively, so a keyword that is newer than this library works as well. Used without a value, e.g., `@media (prefers-reduced-motion)`, the feature evaluates in a boolean context, where `no-preference` (and `none` for `forced-colors`, `hover`, `any-hover`, `pointer` and `any-pointer`) is `false`. Without a preference `hover` and `pointer` keep answering as they did before, i.e., as a device with no input mechanism.
+
 Going a bit further it is possible to `Render` the current document. This render tree information can then be used to retrieve or other information, e.g.,
 
 ```cs

--- a/docs/general/05-Extensibility.md
+++ b/docs/general/05-Extensibility.md
@@ -20,6 +20,8 @@ AngleSharp.Css is designed to be composed through services in the AngleSharp con
 : Add pseudo-element behavior.
 - `IRenderDevice`
 : Provide device characteristics for style computation.
+- `IRenderDevicePreferences`
+: Provide the user preferences answering the user-preference media features.
 
 ## Override The Default Stylesheet
 
@@ -55,6 +57,37 @@ var config = Configuration.Default
     .WithCss()
     .WithRenderDevice(renderDevice);
 ```
+
+## Provide The User Preferences
+
+Beside the dimensions a render device carries the user preferences, which answer the user-preference media features. `DefaultRenderDevice` implements `IRenderDevicePreferences` for that; a custom `IRenderDevice` can implement it as well and is picked up the same way.
+
+```cs
+var renderDevice = new DefaultRenderDevice
+{
+    Preferences = new Dictionary<String, String>
+    {
+        { "prefers-color-scheme", "dark" },
+        { "prefers-reduced-motion", "reduce" },
+    },
+};
+```
+
+The dictionary is keyed by the media feature name and holds the keyword the feature answers with. A key that is not set leaves its media feature unknown, i.e., a query using it never matches.
+
+| Key | Keywords |
+| --- | --- |
+| `prefers-color-scheme` | `light`, `dark` |
+| `prefers-reduced-motion` | `no-preference`, `reduce` |
+| `prefers-reduced-transparency` | `no-preference`, `reduce` |
+| `prefers-contrast` | `no-preference`, `more`, `less`, `custom` |
+| `prefers-reduced-data` | `no-preference`, `reduce` |
+| `forced-colors` | `none`, `active` |
+| `hover`, `any-hover` | `none`, `hover` |
+| `pointer`, `any-pointer` | `none`, `coarse`, `fine` |
+| `display-mode` | `fullscreen`, `standalone`, `minimal-ui`, `browser` |
+
+The value is compared to the queried keyword case insensitively, so a keyword that is newer than this library works as well. Used without a value, e.g., `@media (prefers-reduced-motion)`, the feature evaluates in a boolean context, where `no-preference` (and `none` for `forced-colors`, `hover`, `any-hover`, `pointer` and `any-pointer`) is `false`. Without a preference `hover` and `pointer` keep answering as they did before, i.e., as a device with no input mechanism.
 
 ## Composition Pattern
 

--- a/src/AngleSharp.Css.Tests/CssConstructionFunctions.cs
+++ b/src/AngleSharp.Css.Tests/CssConstructionFunctions.cs
@@ -98,6 +98,13 @@ namespace AngleSharp.Css.Tests
             return device => validator.Validate(feature, device);
         }
 
+        internal static Predicate<IRenderDevice> CreateBooleanValidator(String name)
+        {
+            var validator = CreateMediaFeatureValidator(name);
+            var feature = new MediaFeature(name);
+            return device => validator.Validate(feature, device);
+        }
+
         internal static CssFontFeatureValuesRule ParseFontFeatureValuesRule(String source)
         {
             ICssParser parser = new CssParser();

--- a/src/AngleSharp.Css.Tests/Extensions/MediaPreferences.cs
+++ b/src/AngleSharp.Css.Tests/Extensions/MediaPreferences.cs
@@ -1,0 +1,163 @@
+#nullable disable
+namespace AngleSharp.Css.Tests.Extensions
+{
+    using AngleSharp.Css.Dom;
+    using AngleSharp.Css.Tests.Mocks;
+    using AngleSharp.Dom;
+    using AngleSharp.Html.Parser;
+    using NUnit.Framework;
+    using System;
+    using System.Collections.Generic;
+
+    [TestFixture]
+    public class MediaPreferencesTests
+    {
+        [Test]
+        public void MatchMediaPrefersColorSchemeDarkIsMatchedWhenDarkIsPreferred()
+        {
+            var window = CreateWindow(DeviceWith(FeatureNames.PrefersColorScheme, CssKeywords.Dark));
+            Assert.IsTrue(window.MatchMedia("(prefers-color-scheme: dark)").IsMatched);
+        }
+
+        [Test]
+        public void MatchMediaPrefersColorSchemeDarkIsNotMatchedWhenLightIsPreferred()
+        {
+            var window = CreateWindow(DeviceWith(FeatureNames.PrefersColorScheme, CssKeywords.Light));
+            Assert.IsFalse(window.MatchMedia("(prefers-color-scheme: dark)").IsMatched);
+        }
+
+        [Test]
+        public void MatchMediaPrefersColorSchemeDarkIsNotMatchedWithoutAnyPreference()
+        {
+            var window = CreateWindow(new DefaultRenderDevice());
+            Assert.IsFalse(window.MatchMedia("(prefers-color-scheme: dark)").IsMatched);
+        }
+
+        [Test]
+        public void MatchMediaNotPrefersColorSchemeDarkIsMatchedWhenLightIsPreferred()
+        {
+            var window = CreateWindow(DeviceWith(FeatureNames.PrefersColorScheme, CssKeywords.Light));
+            Assert.IsTrue(window.MatchMedia("not (prefers-color-scheme: dark)").IsMatched);
+        }
+
+        [Test]
+        public void MatchMediaPrefersColorSchemeDarkIsMatchedForAThirdPartyDevice()
+        {
+            var window = CreateWindow(new PreferringRenderDevice(FeatureNames.PrefersColorScheme, CssKeywords.Dark));
+            Assert.IsTrue(window.MatchMedia("(prefers-color-scheme: dark)").IsMatched);
+        }
+
+        [Test]
+        public void MatchMediaPrefersColorSchemeDarkIsNotMatchedForADeviceWithoutPreferences()
+        {
+            var window = CreateWindow(new PlainRenderDevice());
+            Assert.IsFalse(window.MatchMedia("(prefers-color-scheme: dark)").IsMatched);
+        }
+
+        [Test]
+        public void MatchMediaScreenAndPrefersColorSchemeDarkIsMatchedWhenDarkIsPreferred()
+        {
+            var window = CreateWindow(DeviceWith(FeatureNames.PrefersColorScheme, CssKeywords.Dark));
+            Assert.IsTrue(window.MatchMedia("screen and (prefers-color-scheme: dark)").IsMatched);
+        }
+
+        [Test]
+        public void MatchMediaPrefersColorSchemeInBooleanContextIsMatchedWhenSet()
+        {
+            var window = CreateWindow(DeviceWith(FeatureNames.PrefersColorScheme, CssKeywords.Dark));
+            Assert.IsTrue(window.MatchMedia("(prefers-color-scheme)").IsMatched);
+        }
+
+        [Test]
+        public void MatchMediaPrefersColorSchemeInBooleanContextIsNotMatchedWithoutAnyPreference()
+        {
+            var window = CreateWindow(new DefaultRenderDevice());
+            Assert.IsFalse(window.MatchMedia("(prefers-color-scheme)").IsMatched);
+        }
+
+        [Test]
+        public void MatchMediaPrefersReducedMotionIsMatchedWhenReduceIsPreferred()
+        {
+            var window = CreateWindow(DeviceWith(FeatureNames.PrefersReducedMotion, CssKeywords.Reduce));
+            Assert.IsTrue(window.MatchMedia("(prefers-reduced-motion: reduce)").IsMatched);
+            Assert.IsTrue(window.MatchMedia("(prefers-reduced-motion)").IsMatched);
+        }
+
+        [Test]
+        public void MatchMediaPrefersReducedMotionIsNotMatchedWhenNoPreferenceIsSet()
+        {
+            var window = CreateWindow(DeviceWith(FeatureNames.PrefersReducedMotion, CssKeywords.NoPreference));
+            Assert.IsFalse(window.MatchMedia("(prefers-reduced-motion: reduce)").IsMatched);
+            Assert.IsFalse(window.MatchMedia("(prefers-reduced-motion)").IsMatched);
+        }
+
+        [Test]
+        public void MatchMediaForcedColorsIsMatchedWhenActive()
+        {
+            var window = CreateWindow(DeviceWith(FeatureNames.ForcedColors, CssKeywords.Active));
+            Assert.IsTrue(window.MatchMedia("(forced-colors: active)").IsMatched);
+            Assert.IsTrue(window.MatchMedia("(forced-colors)").IsMatched);
+        }
+
+        [Test]
+        public void MatchMediaHoverIsMatchedFromThePreference()
+        {
+            var window = CreateWindow(DeviceWith(FeatureNames.Hover, CssKeywords.Hover));
+            Assert.IsTrue(window.MatchMedia("(hover: hover)").IsMatched);
+            Assert.IsFalse(window.MatchMedia("(hover: none)").IsMatched);
+        }
+
+        [Test]
+        public void PrefersReducedMotionMediaRuleIsAppliedInTheCascade()
+        {
+            var document = CreateDocument(DeviceWith(FeatureNames.PrefersReducedMotion, CssKeywords.Reduce));
+            var style = document.QuerySelector("div").ComputeCurrentStyle();
+            Assert.AreEqual("rgba(0, 128, 0, 1)", style.GetColor());
+        }
+
+        [Test]
+        public void PrefersReducedMotionMediaRuleIsSkippedWithoutThePreference()
+        {
+            var document = CreateDocument(new DefaultRenderDevice());
+            var style = document.QuerySelector("div").ComputeCurrentStyle();
+            Assert.AreEqual("rgba(255, 0, 0, 1)", style.GetColor());
+        }
+
+        [Test]
+        public void PrefersReducedMotionMediaRuleIsSkippedForADeviceWithoutPreferences()
+        {
+            var document = CreateDocument(new PlainRenderDevice());
+            var style = document.QuerySelector("div").ComputeCurrentStyle();
+            Assert.AreEqual("rgba(255, 0, 0, 1)", style.GetColor());
+        }
+
+        private static DefaultRenderDevice DeviceWith(String name, String value) => new DefaultRenderDevice
+        {
+            Preferences = new Dictionary<String, String>(StringComparer.OrdinalIgnoreCase)
+            {
+                { name, value },
+            },
+        };
+
+        private static IDocument CreateDocument(IRenderDevice device)
+        {
+            var source = @"<!doctype html><style>
+div { color: red }
+@media (prefers-reduced-motion: reduce) { div { color: green } }
+</style><div></div>";
+            var config = Configuration.Default.WithCss().WithRenderDevice(device);
+            var context = BrowsingContext.New(config);
+            var parser = context.GetService<IHtmlParser>();
+            return parser.ParseDocument(source);
+        }
+
+        private static IWindow CreateWindow(IRenderDevice device)
+        {
+            var config = Configuration.Default.WithCss().WithRenderDevice(device);
+            var context = BrowsingContext.New(config);
+            var parser = context.GetService<IHtmlParser>();
+            var document = parser.ParseDocument("<!doctype html><title>Example</title>");
+            return document.DefaultView;
+        }
+    }
+}

--- a/src/AngleSharp.Css.Tests/Mocks/PlainRenderDevice.cs
+++ b/src/AngleSharp.Css.Tests/Mocks/PlainRenderDevice.cs
@@ -1,0 +1,43 @@
+namespace AngleSharp.Css.Tests.Mocks
+{
+    using AngleSharp.Css;
+    using System;
+
+    /// <summary>
+    /// A render device that deliberately does not implement
+    /// <see cref="IRenderDevicePreferences"/>, i.e., what an existing
+    /// third-party implementation of <see cref="IRenderDevice"/> looks like.
+    /// </summary>
+    sealed class PlainRenderDevice : IRenderDevice
+    {
+        public DeviceCategory Category => DeviceCategory.Screen;
+
+        public Int32 ColorBits => 32;
+
+        public Int32 DeviceHeight => 800;
+
+        public Int32 DeviceWidth => 1000;
+
+        public Int32 Frequency => 60;
+
+        public Boolean IsGrid => false;
+
+        public Boolean IsInterlaced => false;
+
+        public Boolean IsScripting => true;
+
+        public Int32 MonochromeBits => 16;
+
+        public Int32 Resolution => 96;
+
+        public Int32 ViewPortHeight => 800;
+
+        public Int32 ViewPortWidth => 1000;
+
+        public Double RenderWidth => ViewPortWidth;
+
+        public Double RenderHeight => ViewPortHeight;
+
+        public Double FontSize => 16;
+    }
+}

--- a/src/AngleSharp.Css.Tests/Mocks/PreferringRenderDevice.cs
+++ b/src/AngleSharp.Css.Tests/Mocks/PreferringRenderDevice.cs
@@ -1,0 +1,55 @@
+namespace AngleSharp.Css.Tests.Mocks
+{
+    using AngleSharp.Css;
+    using System;
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// A third-party render device that opts into the user preferences
+    /// without deriving from <see cref="DefaultRenderDevice"/>.
+    /// </summary>
+    sealed class PreferringRenderDevice : IRenderDevice, IRenderDevicePreferences
+    {
+        private readonly Dictionary<String, String> _preferences;
+
+        public PreferringRenderDevice(String name, String value)
+        {
+            _preferences = new Dictionary<String, String>(StringComparer.OrdinalIgnoreCase)
+            {
+                { name, value },
+            };
+        }
+
+        public IReadOnlyDictionary<String, String> Preferences => _preferences;
+
+        public DeviceCategory Category => DeviceCategory.Screen;
+
+        public Int32 ColorBits => 32;
+
+        public Int32 DeviceHeight => 800;
+
+        public Int32 DeviceWidth => 1000;
+
+        public Int32 Frequency => 60;
+
+        public Boolean IsGrid => false;
+
+        public Boolean IsInterlaced => false;
+
+        public Boolean IsScripting => true;
+
+        public Int32 MonochromeBits => 16;
+
+        public Int32 Resolution => 96;
+
+        public Int32 ViewPortHeight => 800;
+
+        public Int32 ViewPortWidth => 1000;
+
+        public Double RenderWidth => ViewPortWidth;
+
+        public Double RenderHeight => ViewPortHeight;
+
+        public Double FontSize => 16;
+    }
+}

--- a/src/AngleSharp.Css.Tests/Rules/CssMediaPreferenceFeatures.cs
+++ b/src/AngleSharp.Css.Tests/Rules/CssMediaPreferenceFeatures.cs
@@ -1,0 +1,258 @@
+#nullable disable
+namespace AngleSharp.Css.Tests.Rules
+{
+    using AngleSharp.Css;
+    using AngleSharp.Css.FeatureValidators;
+    using AngleSharp.Css.Tests.Mocks;
+    using NUnit.Framework;
+    using System;
+    using System.Collections.Generic;
+    using static CssConstructionFunctions;
+
+    [TestFixture]
+    public class CssMediaPreferenceFeaturesTests
+    {
+        [Test]
+        public void CssMediaPreferenceFeatureValidatorFactory()
+        {
+            Assert.IsInstanceOf<PreferenceFeatureValidator>(CreateMediaFeatureValidator(FeatureNames.PrefersColorScheme));
+            Assert.IsInstanceOf<PreferenceFeatureValidator>(CreateMediaFeatureValidator(FeatureNames.PrefersReducedMotion));
+            Assert.IsInstanceOf<PreferenceFeatureValidator>(CreateMediaFeatureValidator(FeatureNames.PrefersReducedTransparency));
+            Assert.IsInstanceOf<PreferenceFeatureValidator>(CreateMediaFeatureValidator(FeatureNames.PrefersReducedData));
+            Assert.IsInstanceOf<PreferenceFeatureValidator>(CreateMediaFeatureValidator(FeatureNames.PrefersContrast));
+            Assert.IsInstanceOf<PreferenceFeatureValidator>(CreateMediaFeatureValidator(FeatureNames.ForcedColors));
+            Assert.IsInstanceOf<PreferenceFeatureValidator>(CreateMediaFeatureValidator(FeatureNames.DisplayMode));
+            Assert.IsInstanceOf<HoverFeatureValidator>(CreateMediaFeatureValidator(FeatureNames.Hover));
+            Assert.IsInstanceOf<HoverFeatureValidator>(CreateMediaFeatureValidator(FeatureNames.AnyHover));
+            Assert.IsInstanceOf<PointerFeatureValidator>(CreateMediaFeatureValidator(FeatureNames.Pointer));
+            Assert.IsInstanceOf<PointerFeatureValidator>(CreateMediaFeatureValidator(FeatureNames.AnyPointer));
+        }
+
+        [Test]
+        public void CssMediaPrefersColorSchemeValidation()
+        {
+            var validate = CreateValidator(FeatureNames.PrefersColorScheme, CssKeywords.Dark);
+            Assert.IsTrue(validate(DeviceWith(FeatureNames.PrefersColorScheme, CssKeywords.Dark)));
+            Assert.IsFalse(validate(DeviceWith(FeatureNames.PrefersColorScheme, CssKeywords.Light)));
+            Assert.IsFalse(validate(new DefaultRenderDevice()));
+        }
+
+        [Test]
+        public void CssMediaPrefersColorSchemeIsComparedCaseInsensitively()
+        {
+            var validate = CreateValidator(FeatureNames.PrefersColorScheme, CssKeywords.Dark);
+            Assert.IsTrue(validate(DeviceWith(FeatureNames.PrefersColorScheme, "DARK")));
+        }
+
+        [Test]
+        public void CssMediaPrefersColorSchemeIsFoundForAnUppercaseKey()
+        {
+            var validate = CreateValidator(FeatureNames.PrefersColorScheme, CssKeywords.Dark);
+            Assert.IsTrue(validate(DeviceWith("Prefers-Color-Scheme", CssKeywords.Dark)));
+        }
+
+        [Test]
+        public void CssMediaPrefersColorSchemeInBooleanContext()
+        {
+            var validate = CreateBooleanValidator(FeatureNames.PrefersColorScheme);
+            Assert.IsTrue(validate(DeviceWith(FeatureNames.PrefersColorScheme, CssKeywords.Dark)));
+            Assert.IsTrue(validate(DeviceWith(FeatureNames.PrefersColorScheme, CssKeywords.Light)));
+            Assert.IsFalse(validate(DeviceWith(FeatureNames.PrefersColorScheme, CssKeywords.NoPreference)));
+            Assert.IsFalse(validate(new DefaultRenderDevice()));
+        }
+
+        [Test]
+        public void CssMediaPrefersReducedMotionValidation()
+        {
+            var validate = CreateValidator(FeatureNames.PrefersReducedMotion, CssKeywords.Reduce);
+            Assert.IsTrue(validate(DeviceWith(FeatureNames.PrefersReducedMotion, CssKeywords.Reduce)));
+            Assert.IsFalse(validate(DeviceWith(FeatureNames.PrefersReducedMotion, CssKeywords.NoPreference)));
+            Assert.IsFalse(validate(new DefaultRenderDevice()));
+        }
+
+        [Test]
+        public void CssMediaPrefersReducedMotionInBooleanContext()
+        {
+            var validate = CreateBooleanValidator(FeatureNames.PrefersReducedMotion);
+            Assert.IsTrue(validate(DeviceWith(FeatureNames.PrefersReducedMotion, CssKeywords.Reduce)));
+            Assert.IsFalse(validate(DeviceWith(FeatureNames.PrefersReducedMotion, CssKeywords.NoPreference)));
+            Assert.IsFalse(validate(new DefaultRenderDevice()));
+        }
+
+        [Test]
+        public void CssMediaPrefersReducedTransparencyValidation()
+        {
+            var validate = CreateValidator(FeatureNames.PrefersReducedTransparency, CssKeywords.Reduce);
+            Assert.IsTrue(validate(DeviceWith(FeatureNames.PrefersReducedTransparency, CssKeywords.Reduce)));
+            Assert.IsFalse(validate(DeviceWith(FeatureNames.PrefersReducedTransparency, CssKeywords.NoPreference)));
+            Assert.IsFalse(validate(new DefaultRenderDevice()));
+        }
+
+        [Test]
+        public void CssMediaPrefersReducedTransparencyInBooleanContext()
+        {
+            var validate = CreateBooleanValidator(FeatureNames.PrefersReducedTransparency);
+            Assert.IsTrue(validate(DeviceWith(FeatureNames.PrefersReducedTransparency, CssKeywords.Reduce)));
+            Assert.IsFalse(validate(DeviceWith(FeatureNames.PrefersReducedTransparency, CssKeywords.NoPreference)));
+        }
+
+        [Test]
+        public void CssMediaPrefersReducedDataValidation()
+        {
+            var validate = CreateValidator(FeatureNames.PrefersReducedData, CssKeywords.Reduce);
+            Assert.IsTrue(validate(DeviceWith(FeatureNames.PrefersReducedData, CssKeywords.Reduce)));
+            Assert.IsFalse(validate(DeviceWith(FeatureNames.PrefersReducedData, CssKeywords.NoPreference)));
+            Assert.IsFalse(validate(new DefaultRenderDevice()));
+        }
+
+        [Test]
+        public void CssMediaPrefersReducedDataInBooleanContext()
+        {
+            var validate = CreateBooleanValidator(FeatureNames.PrefersReducedData);
+            Assert.IsTrue(validate(DeviceWith(FeatureNames.PrefersReducedData, CssKeywords.Reduce)));
+            Assert.IsFalse(validate(DeviceWith(FeatureNames.PrefersReducedData, CssKeywords.NoPreference)));
+        }
+
+        [Test]
+        public void CssMediaPrefersContrastValidation()
+        {
+            var validate = CreateValidator(FeatureNames.PrefersContrast, CssKeywords.More);
+            Assert.IsTrue(validate(DeviceWith(FeatureNames.PrefersContrast, CssKeywords.More)));
+            Assert.IsFalse(validate(DeviceWith(FeatureNames.PrefersContrast, CssKeywords.Less)));
+            Assert.IsFalse(validate(DeviceWith(FeatureNames.PrefersContrast, CssKeywords.Custom)));
+            Assert.IsFalse(validate(new DefaultRenderDevice()));
+        }
+
+        [Test]
+        public void CssMediaPrefersContrastInBooleanContext()
+        {
+            var validate = CreateBooleanValidator(FeatureNames.PrefersContrast);
+            Assert.IsTrue(validate(DeviceWith(FeatureNames.PrefersContrast, CssKeywords.More)));
+            Assert.IsTrue(validate(DeviceWith(FeatureNames.PrefersContrast, CssKeywords.Less)));
+            Assert.IsTrue(validate(DeviceWith(FeatureNames.PrefersContrast, CssKeywords.Custom)));
+            Assert.IsFalse(validate(DeviceWith(FeatureNames.PrefersContrast, CssKeywords.NoPreference)));
+        }
+
+        [Test]
+        public void CssMediaForcedColorsValidation()
+        {
+            var validate = CreateValidator(FeatureNames.ForcedColors, CssKeywords.Active);
+            Assert.IsTrue(validate(DeviceWith(FeatureNames.ForcedColors, CssKeywords.Active)));
+            Assert.IsFalse(validate(DeviceWith(FeatureNames.ForcedColors, CssKeywords.None)));
+            Assert.IsFalse(validate(new DefaultRenderDevice()));
+        }
+
+        [Test]
+        public void CssMediaForcedColorsInBooleanContext()
+        {
+            var validate = CreateBooleanValidator(FeatureNames.ForcedColors);
+            Assert.IsTrue(validate(DeviceWith(FeatureNames.ForcedColors, CssKeywords.Active)));
+            Assert.IsFalse(validate(DeviceWith(FeatureNames.ForcedColors, CssKeywords.None)));
+            Assert.IsFalse(validate(new DefaultRenderDevice()));
+        }
+
+        [Test]
+        public void CssMediaDisplayModeValidation()
+        {
+            var validate = CreateValidator(FeatureNames.DisplayMode, "standalone");
+            Assert.IsTrue(validate(DeviceWith(FeatureNames.DisplayMode, "standalone")));
+            Assert.IsFalse(validate(DeviceWith(FeatureNames.DisplayMode, "browser")));
+            Assert.IsFalse(validate(new DefaultRenderDevice()));
+        }
+
+        [Test]
+        public void CssMediaDisplayModeInBooleanContext()
+        {
+            var validate = CreateBooleanValidator(FeatureNames.DisplayMode);
+            Assert.IsTrue(validate(DeviceWith(FeatureNames.DisplayMode, "browser")));
+            Assert.IsFalse(validate(new DefaultRenderDevice()));
+        }
+
+        [Test]
+        public void CssMediaPreferencesAreNotReadFromADeviceWithoutTheInterface()
+        {
+            var device = new PlainRenderDevice();
+            Assert.IsFalse(CreateValidator(FeatureNames.PrefersColorScheme, CssKeywords.Dark)(device));
+            Assert.IsFalse(CreateValidator(FeatureNames.PrefersReducedMotion, CssKeywords.Reduce)(device));
+            Assert.IsFalse(CreateValidator(FeatureNames.PrefersReducedTransparency, CssKeywords.Reduce)(device));
+            Assert.IsFalse(CreateValidator(FeatureNames.PrefersReducedData, CssKeywords.Reduce)(device));
+            Assert.IsFalse(CreateValidator(FeatureNames.PrefersContrast, CssKeywords.More)(device));
+            Assert.IsFalse(CreateValidator(FeatureNames.ForcedColors, CssKeywords.Active)(device));
+            Assert.IsFalse(CreateValidator(FeatureNames.DisplayMode, "browser")(device));
+            Assert.IsFalse(CreateBooleanValidator(FeatureNames.PrefersColorScheme)(device));
+        }
+
+        [Test]
+        public void CssMediaHoverKeepsItsAnswerWithoutAPreference()
+        {
+            Assert.IsTrue(CreateValidator(FeatureNames.Hover, CssKeywords.None)(new DefaultRenderDevice()));
+            Assert.IsFalse(CreateValidator(FeatureNames.Hover, CssKeywords.Hover)(new DefaultRenderDevice()));
+            Assert.IsTrue(CreateValidator(FeatureNames.Hover, CssKeywords.None)(new PlainRenderDevice()));
+            Assert.IsFalse(CreateBooleanValidator(FeatureNames.Hover)(new DefaultRenderDevice()));
+        }
+
+        [Test]
+        public void CssMediaHoverIsTakenFromThePreference()
+        {
+            var device = DeviceWith(FeatureNames.Hover, CssKeywords.Hover);
+            Assert.IsTrue(CreateValidator(FeatureNames.Hover, CssKeywords.Hover)(device));
+            Assert.IsFalse(CreateValidator(FeatureNames.Hover, CssKeywords.None)(device));
+            Assert.IsTrue(CreateBooleanValidator(FeatureNames.Hover)(device));
+            Assert.IsFalse(CreateBooleanValidator(FeatureNames.Hover)(DeviceWith(FeatureNames.Hover, CssKeywords.None)));
+        }
+
+        [Test]
+        public void CssMediaAnyHoverIsTakenFromThePreference()
+        {
+            var device = DeviceWith(FeatureNames.AnyHover, CssKeywords.Hover);
+            Assert.IsTrue(CreateValidator(FeatureNames.AnyHover, CssKeywords.Hover)(device));
+            Assert.IsFalse(CreateValidator(FeatureNames.AnyHover, CssKeywords.None)(device));
+            Assert.IsTrue(CreateBooleanValidator(FeatureNames.AnyHover)(device));
+            Assert.IsTrue(CreateValidator(FeatureNames.AnyHover, CssKeywords.None)(new DefaultRenderDevice()));
+        }
+
+        [Test]
+        public void CssMediaPointerKeepsItsAnswerWithoutAPreference()
+        {
+            Assert.IsTrue(CreateValidator(FeatureNames.Pointer, CssKeywords.None)(new DefaultRenderDevice()));
+            Assert.IsFalse(CreateValidator(FeatureNames.Pointer, CssKeywords.Fine)(new DefaultRenderDevice()));
+            Assert.IsTrue(CreateValidator(FeatureNames.Pointer, CssKeywords.None)(new PlainRenderDevice()));
+            Assert.IsFalse(CreateBooleanValidator(FeatureNames.Pointer)(new DefaultRenderDevice()));
+        }
+
+        [Test]
+        public void CssMediaPointerIsTakenFromThePreference()
+        {
+            var device = DeviceWith(FeatureNames.Pointer, CssKeywords.Fine);
+            Assert.IsTrue(CreateValidator(FeatureNames.Pointer, CssKeywords.Fine)(device));
+            Assert.IsFalse(CreateValidator(FeatureNames.Pointer, CssKeywords.Coarse)(device));
+            Assert.IsTrue(CreateBooleanValidator(FeatureNames.Pointer)(device));
+            Assert.IsFalse(CreateBooleanValidator(FeatureNames.Pointer)(DeviceWith(FeatureNames.Pointer, CssKeywords.None)));
+        }
+
+        [Test]
+        public void CssMediaAnyPointerIsTakenFromThePreference()
+        {
+            var device = DeviceWith(FeatureNames.AnyPointer, CssKeywords.Coarse);
+            Assert.IsTrue(CreateValidator(FeatureNames.AnyPointer, CssKeywords.Coarse)(device));
+            Assert.IsFalse(CreateValidator(FeatureNames.AnyPointer, CssKeywords.Fine)(device));
+            Assert.IsTrue(CreateBooleanValidator(FeatureNames.AnyPointer)(device));
+            Assert.IsTrue(CreateValidator(FeatureNames.AnyPointer, CssKeywords.None)(new DefaultRenderDevice()));
+        }
+
+        [Test]
+        public void CssMediaPreferenceOfAnotherFeatureIsNotUsed()
+        {
+            var validate = CreateValidator(FeatureNames.PrefersColorScheme, CssKeywords.Dark);
+            Assert.IsFalse(validate(DeviceWith(FeatureNames.PrefersReducedMotion, CssKeywords.Dark)));
+        }
+
+        private static DefaultRenderDevice DeviceWith(String name, String value) => new DefaultRenderDevice
+        {
+            Preferences = new Dictionary<String, String>(StringComparer.OrdinalIgnoreCase)
+            {
+                { name, value },
+            },
+        };
+    }
+}

--- a/src/AngleSharp.Css/Constants/CssKeywords.cs
+++ b/src/AngleSharp.Css/Constants/CssKeywords.cs
@@ -2126,5 +2126,35 @@ namespace AngleSharp.Css
         /// The manipulation keyword for touch-action property.
         /// </summary>
         public static readonly String Manipulation = "manipulation";
+
+        /// <summary>
+        /// The no-preference keyword for the user preference media features.
+        /// </summary>
+        public static readonly String NoPreference = "no-preference";
+
+        /// <summary>
+        /// The reduce keyword for the user preference media features.
+        /// </summary>
+        public static readonly String Reduce = "reduce";
+
+        /// <summary>
+        /// The more keyword for the prefers-contrast media feature.
+        /// </summary>
+        public static readonly String More = "more";
+
+        /// <summary>
+        /// The less keyword for the prefers-contrast media feature.
+        /// </summary>
+        public static readonly String Less = "less";
+
+        /// <summary>
+        /// The custom keyword for the prefers-contrast media feature.
+        /// </summary>
+        public static readonly String Custom = "custom";
+
+        /// <summary>
+        /// The active keyword for the forced-colors media feature.
+        /// </summary>
+        public static readonly String Active = "active";
     }
 }

--- a/src/AngleSharp.Css/Constants/FeatureNames.cs
+++ b/src/AngleSharp.Css/Constants/FeatureNames.cs
@@ -206,5 +206,50 @@
         /// Gets the name of the hover feature.
         /// </summary>
         public readonly static String Hover = "hover";
+
+        /// <summary>
+        /// Gets the name of the any-pointer feature.
+        /// </summary>
+        public readonly static String AnyPointer = "any-pointer";
+
+        /// <summary>
+        /// Gets the name of the any-hover feature.
+        /// </summary>
+        public readonly static String AnyHover = "any-hover";
+
+        /// <summary>
+        /// Gets the name of the prefers-color-scheme feature.
+        /// </summary>
+        public readonly static String PrefersColorScheme = "prefers-color-scheme";
+
+        /// <summary>
+        /// Gets the name of the prefers-reduced-motion feature.
+        /// </summary>
+        public readonly static String PrefersReducedMotion = "prefers-reduced-motion";
+
+        /// <summary>
+        /// Gets the name of the prefers-reduced-transparency feature.
+        /// </summary>
+        public readonly static String PrefersReducedTransparency = "prefers-reduced-transparency";
+
+        /// <summary>
+        /// Gets the name of the prefers-reduced-data feature.
+        /// </summary>
+        public readonly static String PrefersReducedData = "prefers-reduced-data";
+
+        /// <summary>
+        /// Gets the name of the prefers-contrast feature.
+        /// </summary>
+        public readonly static String PrefersContrast = "prefers-contrast";
+
+        /// <summary>
+        /// Gets the name of the forced-colors feature.
+        /// </summary>
+        public readonly static String ForcedColors = "forced-colors";
+
+        /// <summary>
+        /// Gets the name of the display-mode feature.
+        /// </summary>
+        public readonly static String DisplayMode = "display-mode";
     }
 }

--- a/src/AngleSharp.Css/DefaultRenderDevice.cs
+++ b/src/AngleSharp.Css/DefaultRenderDevice.cs
@@ -1,11 +1,12 @@
 namespace AngleSharp.Css
 {
     using System;
+    using System.Collections.Generic;
 
     /// <summary>
     /// Represents the default render device.
     /// </summary>
-    public class DefaultRenderDevice : IRenderDevice
+    public class DefaultRenderDevice : IRenderDevice, IRenderDevicePreferences
     {
         /// <inheritdoc />
         public DeviceCategory Category
@@ -69,6 +70,13 @@ namespace AngleSharp.Css
             get;
             set;
         } = 16;
+
+        /// <inheritdoc />
+        public IReadOnlyDictionary<String, String> Preferences
+        {
+            get;
+            set;
+        } = new Dictionary<String, String>(StringComparer.OrdinalIgnoreCase);
 
         /// <inheritdoc />
         public Int32 Resolution

--- a/src/AngleSharp.Css/Extensions/RenderDeviceExtensions.cs
+++ b/src/AngleSharp.Css/Extensions/RenderDeviceExtensions.cs
@@ -1,0 +1,26 @@
+namespace AngleSharp.Css
+{
+    using System;
+
+    static class RenderDeviceExtensions
+    {
+        /// <summary>
+        /// Gets the value of the given user preference, or null if the device
+        /// carries no preferences at all, or none for the given media feature.
+        /// </summary>
+        public static String? GetPreference(this IRenderDevice? device, String name)
+        {
+            if (device is IRenderDevicePreferences source)
+            {
+                var preferences = source.Preferences;
+
+                if (preferences is not null && preferences.TryGetValue(name, out var value) && !String.IsNullOrEmpty(value))
+                {
+                    return value;
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/AngleSharp.Css/Extensions/RenderDeviceExtensions.cs
+++ b/src/AngleSharp.Css/Extensions/RenderDeviceExtensions.cs
@@ -2,12 +2,19 @@ namespace AngleSharp.Css
 {
     using System;
 
-    static class RenderDeviceExtensions
+    /// <summary>
+    /// Convenience methods for reading a render device's user preferences,
+    /// such as the ones a DefaultRenderDevice is configured with.
+    /// </summary>
+    public static class RenderDeviceExtensions
     {
         /// <summary>
         /// Gets the value of the given user preference, or null if the device
         /// carries no preferences at all, or none for the given media feature.
         /// </summary>
+        /// <param name="device">The render device to read, which may be null.</param>
+        /// <param name="name">The media feature name, e.g., prefers-color-scheme.</param>
+        /// <returns>The preference's keyword, or null if there is none.</returns>
         public static String? GetPreference(this IRenderDevice? device, String name)
         {
             if (device is IRenderDevicePreferences source)

--- a/src/AngleSharp.Css/Factories/DefaultFeatureValidatorFactory.cs
+++ b/src/AngleSharp.Css/Factories/DefaultFeatureValidatorFactory.cs
@@ -56,8 +56,17 @@ namespace AngleSharp.Css
             { FeatureNames.Scan, () => new ScanFeatureValidator() },
             { FeatureNames.UpdateFrequency, () => new UpdateFrequencyFeatureValidator() },
             { FeatureNames.Scripting, () => new ScriptingFeatureValidator() },
-            { FeatureNames.Pointer, () => new PointerFeatureValidator() },
-            { FeatureNames.Hover, () => new HoverFeatureValidator() },
+            { FeatureNames.Pointer, () => new PointerFeatureValidator(FeatureNames.Pointer) },
+            { FeatureNames.AnyPointer, () => new PointerFeatureValidator(FeatureNames.AnyPointer) },
+            { FeatureNames.Hover, () => new HoverFeatureValidator(FeatureNames.Hover) },
+            { FeatureNames.AnyHover, () => new HoverFeatureValidator(FeatureNames.AnyHover) },
+            { FeatureNames.PrefersColorScheme, () => new PreferenceFeatureValidator(FeatureNames.PrefersColorScheme, CssKeywords.NoPreference) },
+            { FeatureNames.PrefersReducedMotion, () => new PreferenceFeatureValidator(FeatureNames.PrefersReducedMotion, CssKeywords.NoPreference) },
+            { FeatureNames.PrefersReducedTransparency, () => new PreferenceFeatureValidator(FeatureNames.PrefersReducedTransparency, CssKeywords.NoPreference) },
+            { FeatureNames.PrefersReducedData, () => new PreferenceFeatureValidator(FeatureNames.PrefersReducedData, CssKeywords.NoPreference) },
+            { FeatureNames.PrefersContrast, () => new PreferenceFeatureValidator(FeatureNames.PrefersContrast, CssKeywords.NoPreference) },
+            { FeatureNames.ForcedColors, () => new PreferenceFeatureValidator(FeatureNames.ForcedColors, CssKeywords.None) },
+            { FeatureNames.DisplayMode, () => new PreferenceFeatureValidator(FeatureNames.DisplayMode, null) },
         };
 
         /// <summary>

--- a/src/AngleSharp.Css/FeatureValidators/HoverFeatureValidator.cs
+++ b/src/AngleSharp.Css/FeatureValidators/HoverFeatureValidator.cs
@@ -7,8 +7,22 @@ namespace AngleSharp.Css.FeatureValidators
 
     sealed class HoverFeatureValidator : IFeatureValidator
     {
+        private readonly String _name;
+
+        public HoverFeatureValidator(String name)
+        {
+            _name = name;
+        }
+
         public Boolean Validate(IMediaFeature feature, IRenderDevice renderDevice)
         {
+            var preference = renderDevice.GetPreference(_name);
+
+            if (preference is not null)
+            {
+                return PreferenceFeatureValidator.Matches(feature, preference, CssKeywords.None);
+            }
+
             var hover = HoverAbilityConverter.Convert(feature.Value);
 
             if (hover != null)

--- a/src/AngleSharp.Css/FeatureValidators/PointerFeatureValidator.cs
+++ b/src/AngleSharp.Css/FeatureValidators/PointerFeatureValidator.cs
@@ -7,8 +7,22 @@ namespace AngleSharp.Css.FeatureValidators
 
     sealed class PointerFeatureValidator : IFeatureValidator
     {
+        private readonly String _name;
+
+        public PointerFeatureValidator(String name)
+        {
+            _name = name;
+        }
+
         public Boolean Validate(IMediaFeature feature, IRenderDevice renderDevice)
         {
+            var preference = renderDevice.GetPreference(_name);
+
+            if (preference is not null)
+            {
+                return PreferenceFeatureValidator.Matches(feature, preference, CssKeywords.None);
+            }
+
             var accuracy = PointerAccuracyConverter.Convert(feature.Value);
 
             if (accuracy != null)

--- a/src/AngleSharp.Css/FeatureValidators/PreferenceFeatureValidator.cs
+++ b/src/AngleSharp.Css/FeatureValidators/PreferenceFeatureValidator.cs
@@ -1,0 +1,54 @@
+namespace AngleSharp.Css.FeatureValidators
+{
+    using AngleSharp.Css.Dom;
+    using AngleSharp.Text;
+    using System;
+
+    /// <summary>
+    /// Validates a user preference media feature, e.g., prefers-color-scheme,
+    /// against the preferences carried by the render device.
+    /// https://drafts.csswg.org/mediaqueries-5/#mf-user-preferences
+    /// </summary>
+    sealed class PreferenceFeatureValidator : IFeatureValidator
+    {
+        private readonly String _name;
+        private readonly String? _noPreference;
+
+        /// <summary>
+        /// Creates a validator for the given media feature.
+        /// </summary>
+        /// <param name="name">The name of the media feature, which is also the key of the preference.</param>
+        /// <param name="noPreference">The keyword that evaluates to false in a boolean context, if any.</param>
+        public PreferenceFeatureValidator(String name, String? noPreference)
+        {
+            _name = name;
+            _noPreference = noPreference;
+        }
+
+        public Boolean Validate(IMediaFeature feature, IRenderDevice renderDevice)
+        {
+            var preference = renderDevice.GetPreference(_name);
+            return preference is not null && Matches(feature, preference, _noPreference);
+        }
+
+        /// <summary>
+        /// Compares the queried keyword against the preference of the device.
+        /// A feature used without a value is evaluated in a boolean context,
+        /// where the keyword standing for "no preference" yields false.
+        /// https://drafts.csswg.org/mediaqueries-5/#mq-boolean-context
+        /// </summary>
+        /// <param name="feature">The feature to examine.</param>
+        /// <param name="preference">The preference carried by the device.</param>
+        /// <param name="noPreference">The keyword that evaluates to false in a boolean context, if any.</param>
+        /// <returns>True if the feature is present, otherwise false.</returns>
+        public static Boolean Matches(IMediaFeature feature, String preference, String? noPreference)
+        {
+            if (!feature.HasValue)
+            {
+                return noPreference is null || !preference.Isi(noPreference);
+            }
+
+            return preference.Isi(feature.Value);
+        }
+    }
+}

--- a/src/AngleSharp.Css/IRenderDevicePreferences.cs
+++ b/src/AngleSharp.Css/IRenderDevicePreferences.cs
@@ -1,0 +1,20 @@
+namespace AngleSharp.Css
+{
+    using System;
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Represents a render device that also carries the user preferences,
+    /// e.g., the preferred color scheme.
+    /// </summary>
+    public interface IRenderDevicePreferences
+    {
+        /// <summary>
+        /// Gets the user preferences, keyed by the name of the media feature
+        /// they answer, e.g., "prefers-color-scheme" mapped to "dark". A name
+        /// that is not contained remains an unknown media feature, i.e., a
+        /// query using it never matches.
+        /// </summary>
+        IReadOnlyDictionary<String, String> Preferences { get; }
+    }
+}


### PR DESCRIPTION
`IRenderDevice` models the Media Queries Level 3/4 device features but none of the [Level 5 user-preference features](https://drafts.csswg.org/mediaqueries-5/#mf-user-preferences), so `@media (prefers-color-scheme: dark)` never applied in the cascade and `matchMedia("(prefers-color-scheme: dark)").matches` was always `false` — with no way for a host that *has* a preference (a headless browser emulating a dark theme, say) to say so.

This is the non-breaking route picked in #234: a small `IRenderDevicePreferences` with the single `Preferences` member, already implemented by `DefaultRenderDevice`, which the validators probe with `as`. Nothing that implements `IRenderDevice` today has to change.

```cs
var config = Configuration.Default
    .WithCss()
    .WithRenderDevice(new DefaultRenderDevice
    {
        Preferences = new Dictionary<String, String>
        {
            { "prefers-color-scheme", "dark" },
            { "prefers-reduced-motion", "reduce" },
        },
    });
```

## What is in it

- `IRenderDevicePreferences` beside `IRenderDevice`, with `IReadOnlyDictionary<String, String> Preferences`. `DefaultRenderDevice` implements it with a settable property defaulting to an empty, case-insensitive dictionary; its existing members are untouched.
- One `PreferenceFeatureValidator`, parameterized by the feature name, registered in `DefaultFeatureValidatorFactory` for every key below. It answers `false` when the device does not implement the interface or does not carry the key, and otherwise compares the queried keyword with the value case insensitively.
- `hover` / `pointer` already had validators that read nothing from the device and assumed a headless browser (`(hover: none)` is `true`). They now route through the dictionary **when it carries the key** and keep exactly that answer when it does not. `any-hover` / `any-pointer` were unregistered — they are now registered and behave like their siblings, so `(any-hover: none)` answers `true` on a bare device where it previously answered `false` as an unknown feature. That is the only behaviour change for a host that sets no preferences.
- `FeatureNames` and `CssKeywords` entries, and the key table in `README.md` and `docs/general/05-Extensibility.md`.

| Key | Keywords |
| --- | --- |
| `prefers-color-scheme` | `light`, `dark` |
| `prefers-reduced-motion` | `no-preference`, `reduce` |
| `prefers-reduced-transparency` | `no-preference`, `reduce` |
| `prefers-contrast` | `no-preference`, `more`, `less`, `custom` |
| `prefers-reduced-data` | `no-preference`, `reduce` |
| `forced-colors` | `none`, `active` |
| `hover`, `any-hover` | `none`, `hover` |
| `pointer`, `any-pointer` | `none`, `coarse`, `fine` |
| `display-mode` | `fullscreen`, `standalone`, `minimal-ui`, `browser` |

The keyword is compared verbatim rather than against a hard-coded grammar per feature, so a value newer than this library (another `display-mode`, another `prefers-contrast` level) works without a release — which is the point of the untyped dictionary. Used without a value the feature evaluates in a boolean context per [MQ5 §3.1](https://drafts.csswg.org/mediaqueries-5/#mq-boolean-context): `(prefers-reduced-motion)` is `true` unless the value is `no-preference`, `(forced-colors)` unless it is `none`, and `(hover)` is `true` when the value is `hover`.

## Tests

41 new tests in `src/AngleSharp.Css.Tests/Rules/CssMediaPreferenceFeatures.cs` (validator level: each feature true / false / absent, boolean context, case insensitivity, a device that does not implement the interface, the `hover` and `pointer` fallbacks) and `src/AngleSharp.Css.Tests/Extensions/MediaPreferences.cs` (`matchMedia` end to end beside the tests from #228, a third-party device implementing both interfaces, and `@media (prefers-reduced-motion: reduce)` applying a declaration under `ComputeCurrentStyle`). Full suite: 2073 passing, 0 failing; solution builds with 0 warnings over all five target frameworks. Rebased onto `devel` at 87a30c7, i.e., on top of the #230-#233 fixes.

Run against the unfixed behaviour first, 31 of the 41 fail and 10 pass on both sides — the 10 are the ones asserting that an absent preference, or a device without the interface, changes nothing, plus the two pinning that `hover` and `pointer` keep their current answer.

## Not in this PR

The four media-query evaluation defects filed alongside #234 (#230-#233) are untouched here - they are already fixed on `devel`, and this branch is rebased on top of those fixes.

Fixes #234

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqCcJrL3MJecCPRBMQsZyC
