### PR TITLE
Fix calc() computation in trimmed / NativeAOT applications

### DIFF
--- a/src/AngleSharp.Css.Tests/Values/Calc.cs
+++ b/src/AngleSharp.Css.Tests/Values/Calc.cs
@@ -1,8 +1,13 @@
+#nullable disable
 namespace AngleSharp.Css.Tests.Values
 {
+    using AngleSharp.Css.Dom;
     using AngleSharp.Css.Parser;
+    using AngleSharp.Css.Values;
+    using AngleSharp.Dom;
     using AngleSharp.Text;
     using NUnit.Framework;
+    using System;
     using static CssConstructionFunctions;
 
     [TestFixture]
@@ -99,6 +104,48 @@ namespace AngleSharp.Css.Tests.Values
             var property = ParseDeclaration(source);
             Assert.IsTrue(property.HasValue);
             Assert.AreEqual("calc(21 + 5 - 4 * 2)", property.Value);
+        }
+
+        [Test]
+        public void CalcAdditionOfLengthsIsComputed()
+        {
+            var document = ParseDocument("<style>p { width: calc(100px + 20px) }</style><p></p>");
+            var style = document.QuerySelector("p").ComputeCurrentStyle();
+            Assert.AreEqual("120px", style.GetWidth());
+        }
+
+        [Test]
+        public void CalcSubtractionOfLengthsIsComputed()
+        {
+            var document = ParseDocument("<style>p { width: calc(100px - 20px) }</style><p></p>");
+            var style = document.QuerySelector("p").ComputeCurrentStyle();
+            Assert.AreEqual("80px", style.GetWidth());
+        }
+
+        [Test]
+        public void CalcAdditionOfTimesIsComputed()
+        {
+            var document = ParseDocument("<style>p { transition-duration: calc(30ms + 20ms) }</style><p></p>");
+            var style = document.QuerySelector("p").ComputeCurrentStyle();
+            Assert.AreEqual("50ms", style.GetTransitionDuration());
+        }
+
+        [TestCase(typeof(CssAngleValue))]
+        [TestCase(typeof(CssFrequencyValue))]
+        [TestCase(typeof(CssIntegerValue))]
+        [TestCase(typeof(CssLengthValue))]
+        [TestCase(typeof(CssNumberValue))]
+        [TestCase(typeof(CssPercentageValue))]
+        [TestCase(typeof(CssResolutionValue))]
+        [TestCase(typeof(CssTimeValue))]
+        public void MetricValueCanBeCreatedWithAnotherValue(Type type)
+        {
+            var template = (ICssMetricValue)Activator.CreateInstance(type, 2.0);
+            var result = template.WithValue(5.0);
+
+            Assert.IsInstanceOf(type, result);
+            Assert.AreEqual(5.0, ((ICssMetricValue)result).Value);
+            Assert.AreEqual(template.UnitString, ((ICssMetricValue)result).UnitString);
         }
     }
 }

--- a/src/AngleSharp.Css/Extensions/CssMetricValueExtensions.cs
+++ b/src/AngleSharp.Css/Extensions/CssMetricValueExtensions.cs
@@ -1,0 +1,39 @@
+#nullable disable
+namespace AngleSharp.Css.Values
+{
+    using AngleSharp.Css.Dom;
+    using System;
+#if NET5_0_OR_GREATER
+    using System.Diagnostics.CodeAnalysis;
+#endif
+
+    /// <summary>
+    /// A set of helpers for dealing with metric values.
+    /// </summary>
+    static class CssMetricValueExtensions
+    {
+        /// <summary>
+        /// Creates a new metric value of the same type as the given template, but
+        /// carrying the provided value.
+        /// </summary>
+        /// <param name="template">The value determining the type to create.</param>
+        /// <param name="value">The value to use for the created instance.</param>
+        /// <returns>The newly created metric value.</returns>
+#if NET5_0_OR_GREATER
+        [DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors, typeof(CssAngleValue))]
+        [DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors, typeof(CssFrequencyValue))]
+        [DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors, typeof(CssIntegerValue))]
+        [DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors, typeof(CssLengthValue))]
+        [DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors, typeof(CssNumberValue))]
+        [DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors, typeof(CssPercentageValue))]
+        [DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors, typeof(CssResolutionValue))]
+        [DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors, typeof(CssTimeValue))]
+        [UnconditionalSuppressMessage("Trimming", "IL2072",
+            Justification = "The constructors of the metric values shipped with AngleSharp.Css are preserved via " +
+                "DynamicDependency. Metric values implemented outside of AngleSharp.Css have to preserve their " +
+                "public constructor taking a single Double themselves, e.g., via DynamicDependency.")]
+#endif
+        public static ICssValue WithValue(this ICssMetricValue template, Double value) =>
+            (ICssValue)Activator.CreateInstance(template.GetType(), value);
+    }
+}

--- a/src/AngleSharp.Css/Values/Expressions/CssCalcAddExpression.cs
+++ b/src/AngleSharp.Css/Values/Expressions/CssCalcAddExpression.cs
@@ -60,7 +60,7 @@ namespace AngleSharp.Css.Values
             if (left is ICssMetricValue x && right is ICssMetricValue y && x.UnitString == y.UnitString)
             {
                 var result = x.Value + y.Value;
-                return (ICssValue)Activator.CreateInstance(x.GetType(), result);
+                return x.WithValue(result);
             }
 
             return null;

--- a/src/AngleSharp.Css/Values/Expressions/CssCalcDivExpression.cs
+++ b/src/AngleSharp.Css/Values/Expressions/CssCalcDivExpression.cs
@@ -60,7 +60,7 @@ namespace AngleSharp.Css.Values
             if (left is ICssMetricValue x && right is ICssMetricValue y && x.UnitString == y.UnitString)
             {
                 var result = x.Value / y.Value;
-                return (ICssValue)Activator.CreateInstance(x.GetType(), result);
+                return x.WithValue(result);
             }
 
             return null;

--- a/src/AngleSharp.Css/Values/Expressions/CssCalcMulExpression.cs
+++ b/src/AngleSharp.Css/Values/Expressions/CssCalcMulExpression.cs
@@ -60,7 +60,7 @@ namespace AngleSharp.Css.Values
             if (left is ICssMetricValue x && right is ICssMetricValue y && x.UnitString == y.UnitString)
             {
                 var result = x.Value * y.Value;
-                return (ICssValue)Activator.CreateInstance(x.GetType(), result);
+                return x.WithValue(result);
             }
 
             return null;

--- a/src/AngleSharp.Css/Values/Expressions/CssCalcSubExpression.cs
+++ b/src/AngleSharp.Css/Values/Expressions/CssCalcSubExpression.cs
@@ -60,7 +60,7 @@ namespace AngleSharp.Css.Values
             if (left is ICssMetricValue x && right is ICssMetricValue y && x.UnitString == y.UnitString)
             {
                 var result = x.Value - y.Value;
-                return (ICssValue)Activator.CreateInstance(x.GetType(), result);
+                return x.WithValue(result);
             }
 
             return null;


### PR DESCRIPTION
### Problem

Computing any `calc()` that combines two metric values throws in NativeAOT (and trimmed) apps:

```
System.MissingMethodException: No parameterless constructor defined for type 'AngleSharp.Css.Values.CssLengthValue'.
   at AngleSharp.Css.Values.CssCalcAddExpression.AngleSharp.Css.Dom.ICssValue.Compute(ICssComputeContext)
   at AngleSharp.Css.Dom.CssProperty.Compute(ICssComputeContext)
```

Repro (NativeAOT, net10.0): `<style>p { width: calc(100px + 20px) }</style>` + `GetComputedStyle` returns `120px` on JIT but throws under AOT.

The four calc expressions build their result with `Activator.CreateInstance(x.GetType(), result)`. The trimmer cannot follow that, so it removes the `CssXyzValue(Double)` constructors that nothing else calls. Publishing an app with these packages surfaced this as 4 `IL2072` trim warnings — the only trim warnings coming out of AngleSharp.Css (AngleSharp, AngleSharp.Xml and AngleSharp.XPath produce none).

### Change

- Moved the reflection call into a single internal helper `ICssMetricValue.WithValue(Double)` that roots the public constructors of the eight built-in metric values via `[DynamicDependency]`, plus a documented `[UnconditionalSuppressMessage]` for `IL2072`. `ICssMetricValue` is public, so the dynamic path is kept for external implementations — those simply have to preserve their own single-`Double` constructor (the justification text says so).
- Did not enable `IsAotCompatible` in this bug-fix PR. That property should be considered in a later release because it also opts the assembly into trimming; enabling it now could cause unexpected trimming in applications referencing AngleSharp.Css.
- Added tests: computed `calc()` addition/subtraction for lengths and times, and a `WithValue` round-trip for all eight metric types.

### Verification

- `dotnet test src/AngleSharp.Css.Tests/AngleSharp.Css.Tests.csproj` → 2084 passed.
- `dotnet build src/AngleSharp.Css.sln -c Release` → 0 warnings.
- NativeAOT publish (osx-arm64, net10.0) of a sample app against this branch → 0 IL warnings, and `calc(100px + 20px)` / `calc(100px - 20px)` now compute `120px` / `80px` just like on JIT.

Note: `calc(2 * 8px)` and `calc(30px / 2)` still fail with `InvalidOperationException: Unsupported unit cannot be converted.` — that is a pre-existing issue that reproduces identically on JIT and is out of scope here.
