### PR TITLE
Fix unquoted and invalid url() handling

### DIFF
--- a/src/AngleSharp.Css.Tests/Styling/CssSheet.cs
+++ b/src/AngleSharp.Css.Tests/Styling/CssSheet.cs
@@ -875,6 +875,118 @@ h1 { color: blue }");
         }
 
         [Test]
+        public void CssSheetWithEmptyUrlKeepsTheDeclaration()
+        {
+            var sheet = ParseStyleSheet("a { background-image: url(); color: red }");
+            var rule = sheet.Rules[0] as CssStyleRule;
+            Assert.AreEqual(2, rule.Style.Length);
+            var decl = rule.Style as ICssStyleDeclaration;
+            Assert.AreEqual("url(\"\")", decl.GetBackgroundImage());
+            Assert.AreEqual("rgba(255, 0, 0, 1)", decl.GetColor());
+        }
+
+        [Test]
+        public void CssSheetWithEmptyUrlContainingSpacesKeepsTheDeclaration()
+        {
+            var sheet = ParseStyleSheet("a { background-image: url(   ); color: red }");
+            var decl = (sheet.Rules[0] as CssStyleRule).Style as ICssStyleDeclaration;
+            Assert.AreEqual("url(\"\")", decl.GetBackgroundImage());
+        }
+
+        [Test]
+        public void CssSheetWithWhitespaceInsideUnquotedUrlDropsTheDeclaration()
+        {
+            var sheet = ParseStyleSheet("a { background-image: url(a b); color: red }");
+            var rule = sheet.Rules[0] as CssStyleRule;
+            Assert.AreEqual(1, rule.Style.Length);
+            var decl = rule.Style as ICssStyleDeclaration;
+            Assert.AreEqual("rgba(255, 0, 0, 1)", decl.GetColor());
+        }
+
+        [Test]
+        public void CssSheetWithParenthesisInsideUnquotedUrlDropsTheDeclaration()
+        {
+            var sheet = ParseStyleSheet("a { background-image: url(a(b); color: red }");
+            var rule = sheet.Rules[0] as CssStyleRule;
+            Assert.AreEqual(1, rule.Style.Length);
+            var decl = rule.Style as ICssStyleDeclaration;
+            Assert.AreEqual("rgba(255, 0, 0, 1)", decl.GetColor());
+        }
+
+        [Test]
+        public void CssSheetWithQuoteInsideUnquotedUrlDropsTheDeclaration()
+        {
+            var sheet = ParseStyleSheet("a { background-image: url(a\"b); color: red }");
+            var rule = sheet.Rules[0] as CssStyleRule;
+            Assert.AreEqual(1, rule.Style.Length);
+            var decl = rule.Style as ICssStyleDeclaration;
+            Assert.AreEqual("rgba(255, 0, 0, 1)", decl.GetColor());
+        }
+
+        [Test]
+        public void CssSheetWithBadUrlInShorthandDropsTheWholeDeclaration()
+        {
+            var sheet = ParseStyleSheet("a { background: url(a b) red }");
+            var rule = sheet.Rules[0] as CssStyleRule;
+            Assert.AreEqual(0, rule.Style.Length);
+        }
+
+        [Test]
+        public void CssSheetWithBadUrlDoesNotAffectFollowingRules()
+        {
+            var sheet = ParseStyleSheet("a { background-image: url(a b) } b { color: red }");
+            Assert.AreEqual(2, sheet.Rules.Length);
+            Assert.AreEqual(0, (sheet.Rules[0] as CssStyleRule).Style.Length);
+            var decl = (sheet.Rules[1] as CssStyleRule).Style as ICssStyleDeclaration;
+            Assert.AreEqual("rgba(255, 0, 0, 1)", decl.GetColor());
+        }
+
+        [Test]
+        public void CssSheetWithUnterminatedUnquotedUrlKeepsTheDeclaration()
+        {
+            var sheet = ParseStyleSheet("a { background-image: url(abc");
+            var decl = (sheet.Rules[0] as CssStyleRule).Style as ICssStyleDeclaration;
+            Assert.AreEqual("url(\"abc\")", decl.GetBackgroundImage());
+        }
+
+        [Test]
+        public void CssSheetImportWithBadUrlIsDropped()
+        {
+            var sheet = ParseStyleSheet("@import url(a b); a { color: red }");
+            Assert.AreEqual(1, sheet.Rules.Length);
+            Assert.IsInstanceOf<CssStyleRule>(sheet.Rules[0]);
+        }
+
+        [Test]
+        public void CssSheetImportWithUnterminatedUrlIsKept()
+        {
+            var sheet = ParseStyleSheet("@import url(abc");
+            Assert.AreEqual(1, sheet.Rules.Length);
+            var import = sheet.Rules[0] as CssImportRule;
+            Assert.IsNotNull(import);
+            Assert.AreEqual("abc", import.Href);
+        }
+
+        [Test]
+        public void CssSheetNamespaceWithBadUrlIsDropped()
+        {
+            var sheet = ParseStyleSheet("@namespace x url(a b); a { color: red }");
+            Assert.AreEqual(1, sheet.Rules.Length);
+            Assert.IsInstanceOf<CssStyleRule>(sheet.Rules[0]);
+        }
+
+        [Test]
+        public void CssSheetNamespaceAcceptsAStringUri()
+        {
+            var sheet = ParseStyleSheet("@namespace x \"http://foo\"; a { color: red }");
+            Assert.AreEqual(2, sheet.Rules.Length);
+            var ns = sheet.Rules[0] as CssNamespaceRule;
+            Assert.IsNotNull(ns);
+            Assert.AreEqual("x", ns.Prefix);
+            Assert.AreEqual("http://foo", ns.NamespaceUri);
+        }
+
+        [Test]
         public void CssSheetFromStreamWeirdBytesLeadingToInfiniteLoop()
         {
             var bs = new Byte[8];

--- a/src/AngleSharp.Css.Tests/Styling/CssSheet.cs
+++ b/src/AngleSharp.Css.Tests/Styling/CssSheet.cs
@@ -768,6 +768,113 @@ h1 { color: blue }");
         }
 
         [Test]
+        public void CssSheetWithUnquotedDataUrlAsBackgroundImage()
+        {
+            var sheet = ParseStyleSheet("a { background-image: url(data:image/svg+xml;base64,PHN2Zz48L3N2Zz4=); color: red }");
+            var rule = sheet.Rules[0] as CssStyleRule;
+            Assert.IsNotNull(rule);
+            Assert.AreEqual(2, rule.Style.Length);
+            var decl = rule.Style as ICssStyleDeclaration;
+            Assert.AreEqual("url(\"data:image/svg+xml;base64,PHN2Zz48L3N2Zz4=\")", decl.GetBackgroundImage());
+        }
+
+        [Test]
+        public void CssSheetWithUnquotedUrlKeepsSemicolonAsLastDeclaration()
+        {
+            var sheet = ParseStyleSheet("a { background-image: url(data:image/svg+xml;base64,PHN2Zz48L3N2Zz4=) }");
+            var rule = sheet.Rules[0] as CssStyleRule;
+            Assert.IsNotNull(rule);
+            Assert.AreEqual(1, rule.Style.Length);
+            var decl = rule.Style as ICssStyleDeclaration;
+            Assert.AreEqual("url(\"data:image/svg+xml;base64,PHN2Zz48L3N2Zz4=\")", decl.GetBackgroundImage());
+        }
+
+        [Test]
+        public void CssSheetWithUnquotedUrlIsCaseInsensitive()
+        {
+            var sheet = ParseStyleSheet("a { background-image: URL(data:x;y); color: red }");
+            var decl = (sheet.Rules[0] as CssStyleRule).Style as ICssStyleDeclaration;
+            Assert.AreEqual("url(\"data:x;y\")", decl.GetBackgroundImage());
+            Assert.AreEqual("rgba(255, 0, 0, 1)", decl.GetColor());
+        }
+
+        [Test]
+        public void CssSheetWithUnquotedUrlContainingCurlyBrace()
+        {
+            var sheet = ParseStyleSheet("a { background-image: url(a}b); color: red }");
+            var decl = (sheet.Rules[0] as CssStyleRule).Style as ICssStyleDeclaration;
+            Assert.AreEqual("url(\"a}b\")", decl.GetBackgroundImage());
+            Assert.AreEqual("rgba(255, 0, 0, 1)", decl.GetColor());
+        }
+
+        [Test]
+        public void CssSheetWithUnquotedUrlContainingEscapedSemicolon()
+        {
+            var sheet = ParseStyleSheet("a { background-image: url(a\\;b); color: red }");
+            var decl = (sheet.Rules[0] as CssStyleRule).Style as ICssStyleDeclaration;
+            Assert.AreEqual("url(\"a;b\")", decl.GetBackgroundImage());
+            Assert.AreEqual("rgba(255, 0, 0, 1)", decl.GetColor());
+        }
+
+        [Test]
+        public void CssSheetWithUnquotedUrlSurroundedByWhitespace()
+        {
+            var sheet = ParseStyleSheet("a { background-image: url( data:image/svg+xml;base64,AAA= ); color: red }");
+            var decl = (sheet.Rules[0] as CssStyleRule).Style as ICssStyleDeclaration;
+            Assert.AreEqual("url(\"data:image/svg+xml;base64,AAA=\")", decl.GetBackgroundImage());
+        }
+
+        [Test]
+        public void CssSheetWithQuotedUrlContainingClosingParenthesis()
+        {
+            var sheet = ParseStyleSheet("a { background-image: url( \"a)b\" ); color: red }");
+            var decl = (sheet.Rules[0] as CssStyleRule).Style as ICssStyleDeclaration;
+            Assert.AreEqual("url(\"a)b\")", decl.GetBackgroundImage());
+            Assert.AreEqual("rgba(255, 0, 0, 1)", decl.GetColor());
+        }
+
+        [Test]
+        public void CssSheetWithUnquotedUrlInShorthandAndImportant()
+        {
+            var sheet = ParseStyleSheet("a { background: url(x;y) no-repeat !important; color: red }");
+            var rule = sheet.Rules[0] as CssStyleRule;
+            var decl = rule.Style as ICssStyleDeclaration;
+            Assert.AreEqual("url(\"x;y\")", decl.GetBackgroundImage());
+            Assert.AreEqual("important", decl.GetPropertyPriority("background"));
+            Assert.AreEqual("rgba(255, 0, 0, 1)", decl.GetColor());
+        }
+
+        [Test]
+        public void CssSheetWithUnquotedUrlInsideMediaRule()
+        {
+            var sheet = ParseStyleSheet("@media (min-width:1px) { a { background-image: url(data:image/svg+xml;base64,QQ==); color: red } }");
+            var media = sheet.Rules[0] as CssMediaRule;
+            Assert.IsNotNull(media);
+            var decl = (media.Rules[0] as CssStyleRule).Style as ICssStyleDeclaration;
+            Assert.AreEqual("url(\"data:image/svg+xml;base64,QQ==\")", decl.GetBackgroundImage());
+        }
+
+        [Test]
+        public void CssSheetWithUnquotedUrlInSupportsCondition()
+        {
+            var sheet = ParseStyleSheet("@supports (background-image: url(a;b)) { a { color: red } }");
+            Assert.AreEqual(1, sheet.Rules.Length);
+            var supports = sheet.Rules[0] as CssSupportsRule;
+            Assert.IsNotNull(supports);
+            Assert.AreEqual("(background-image: url(a;b))", supports.ConditionText);
+        }
+
+        [Test]
+        public void CssSheetWithFunctionEndingInUrlIsNotAUrlToken()
+        {
+            var sheet = ParseStyleSheet("a { background-image: myurl(a;b); color: red }");
+            var rule = sheet.Rules[0] as CssStyleRule;
+            Assert.AreEqual(1, rule.Style.Length);
+            var decl = rule.Style as ICssStyleDeclaration;
+            Assert.AreEqual("rgba(255, 0, 0, 1)", decl.GetColor());
+        }
+
+        [Test]
         public void CssSheetFromStreamWeirdBytesLeadingToInfiniteLoop()
         {
             var bs = new Byte[8];

--- a/src/AngleSharp.Css.Tests/Values/ErrorHandling.cs
+++ b/src/AngleSharp.Css.Tests/Values/ErrorHandling.cs
@@ -11,9 +11,24 @@ namespace AngleSharp.Css.Tests.Values
     public class ErrorHandlingTests
     {
         [Test]
-        public void ParseInlineStyleWithToleratedInvalidValueShouldReturnThatValue()
+        public void ParseInlineStyleWithBadUnquotedUrlShouldDropThatDeclaration()
         {
+            // An unquoted url() may not contain '(' - that makes it a bad url, and
+            // the whole declaration is dropped rather than guessing at its value.
             var source = "<div style=\"background-image: url(javascript:alert(1))\"></div>";
+            var document = ParseDocument(source, new CssParserOptions
+            {
+                IsIncludingUnknownDeclarations = true,
+                IsIncludingUnknownRules = true
+            });
+            var div = document.QuerySelector<IHtmlElement>("div");
+            Assert.AreEqual(0, div.GetStyle().Length);
+        }
+
+        [Test]
+        public void ParseInlineStyleWithQuotedUrlShouldReturnThatValue()
+        {
+            var source = "<div style=\"background-image: url('javascript:alert(1)')\"></div>";
             var document = ParseDocument(source, new CssParserOptions
             {
                 IsIncludingUnknownDeclarations = true,

--- a/src/AngleSharp.Css/Parser/CssBuilder.cs
+++ b/src/AngleSharp.Css/Parser/CssBuilder.cs
@@ -73,6 +73,7 @@ namespace AngleSharp.Css.Parser
 
                 case CssTokenType.String:
                 case CssTokenType.Url:
+                case CssTokenType.BadUrl:
                 case CssTokenType.CurlyBracketClose:
                 case CssTokenType.RoundBracketClose:
                 case CssTokenType.SquareBracketClose:
@@ -267,11 +268,14 @@ namespace AngleSharp.Css.Parser
             rule.Prefix = GetRuleName(ref token);
             CollectTrivia(rule.Owner, ref token);
 
-            if (token.Type == CssTokenType.Url)
+            if (!token.Is(CssTokenType.String, CssTokenType.Url))
             {
-                rule.NamespaceUri = token.Data;
+                RaiseErrorOccurred(CssParseError.InvalidToken, token.Position);
+                JumpToEnd(ref token);
+                return null;
             }
 
+            rule.NamespaceUri = token.Data;
             JumpToEnd(ref token);
             return rule;
         }

--- a/src/AngleSharp.Css/Parser/CssTokenType.cs
+++ b/src/AngleSharp.Css/Parser/CssTokenType.cs
@@ -14,6 +14,10 @@
         /// </summary>
         Url,
         /// <summary>
+        /// A bad URL token, i.e. a url() that could not be parsed.
+        /// </summary>
+        BadUrl,
+        /// <summary>
         /// A color token.
         /// </summary>
         Color,

--- a/src/AngleSharp.Css/Parser/CssTokenizer.cs
+++ b/src/AngleSharp.Css/Parser/CssTokenizer.cs
@@ -1087,7 +1087,7 @@ namespace AngleSharp.Css.Parser
             {
                 case Symbols.EndOfFile:
                     RaiseErrorOccurred(CssParseError.EOF);
-                    return NewUrl(String.Empty, bad: true);
+                    return NewUrl(String.Empty, bad: false);
 
                 case Symbols.DoubleQuote:
                     return UrlDQ();
@@ -1217,7 +1217,7 @@ namespace AngleSharp.Css.Parser
                 }
                 else if (current == Symbols.EndOfFile)
                 {
-                    return NewUrl(FlushBuffer(), bad: true);
+                    return NewUrl(FlushBuffer(), bad: false);
                 }
                 else if (current is Symbols.DoubleQuote or Symbols.SingleQuote or Symbols.RoundBracketOpen || current.IsNonPrintable())
                 {
@@ -1272,50 +1272,26 @@ namespace AngleSharp.Css.Parser
         private CssToken UrlBad()
         {
             var current = Current;
-            var curly = 0;
-            var round = 1;
 
+            // The remnants of a bad url are consumed so that parsing can resume
+            // after it, but they are not part of any value - they are discarded.
             while (current != Symbols.EndOfFile)
             {
-                if (current == Symbols.Semicolon)
+                if (current == Symbols.RoundBracketClose)
                 {
-                    Back();
-                    return NewUrl(FlushBuffer(), true);
-                }
-                else if (current == Symbols.CurlyBracketClose && --curly == -1)
-                {
-                    Back();
-                    return NewUrl(FlushBuffer(), true);
-                }
-                else if (current == Symbols.RoundBracketClose && --round == 0)
-                {
-                    StringBuffer.Append(current);
-                    return NewUrl(FlushBuffer(), true);
+                    break;
                 }
                 else if (IsValidEscape(current))
                 {
                     current = GetNext();
-                    StringBuffer.Append(ConsumeEscape(current));
-                }
-                else
-                {
-                    if (current == Symbols.RoundBracketOpen)
-                    {
-                        ++round;
-                    }
-                    else if (curly == Symbols.CurlyBracketOpen)
-                    {
-                        ++curly;
-                    }
-
-                    StringBuffer.Append(current);
+                    ConsumeEscape(current);
                 }
 
                 current = GetNext();
             }
 
-            RaiseErrorOccurred(CssParseError.EOF);
-            return NewUrl(FlushBuffer(), bad: true);
+            FlushBuffer();
+            return NewUrl(String.Empty, bad: true);
         }
 
         /// <summary>
@@ -1487,7 +1463,7 @@ namespace AngleSharp.Css.Parser
 
         private CssToken NewUrl(String data, Boolean bad = false)
         {
-            return new CssToken(CssTokenType.Url, data) { Position = _position };
+            return new CssToken(bad ? CssTokenType.BadUrl : CssTokenType.Url, data) { Position = _position };
         }
 
         private CssToken NewRange(String data)

--- a/src/AngleSharp.Css/Parser/CssTokenizer.cs
+++ b/src/AngleSharp.Css/Parser/CssTokenizer.cs
@@ -8,6 +8,7 @@ namespace AngleSharp.Css.Parser
     using AngleSharp.Text;
     using System;
     using System.Globalization;
+    using System.Text;
 
     /// <summary>
     /// The CSS tokenizer.
@@ -74,6 +75,12 @@ namespace AngleSharp.Css.Parser
                     break;
                 }
 
+                if ((current == 'u' || current == 'U') && !IsIdentContinuation(previous) && TryAppendUrl(sb, ref current, ref previous))
+                {
+                    trailingWhitespace = 0;
+                    continue;
+                }
+
                 if ((current == Symbols.DoubleQuote || current == Symbols.SingleQuote) && previous != Symbols.ReverseSolidus)
                 {
                     trailingWhitespace = 0;
@@ -135,6 +142,80 @@ namespace AngleSharp.Css.Parser
 
             Back();
             return sb.ToPool();
+        }
+
+        /// <summary>
+        /// Checks if the given character would continue an identifier, i.e. if a
+        /// following "url(" belongs to a longer function name such as "myurl(".
+        /// </summary>
+        private static Boolean IsIdentContinuation(Char current) =>
+            current != Symbols.EndOfFile && (current.IsName() || current == Symbols.ReverseSolidus);
+
+        /// <summary>
+        /// Appends a url token starting at the current position, if there is one.
+        /// The contents of an unquoted url token may contain ';', '{' and '}',
+        /// which must not be mistaken for the end of the surrounding value.
+        /// </summary>
+        private Boolean TryAppendUrl(StringBuilder sb, ref Char current, ref Char previous)
+        {
+            var start = Position;
+            var r = GetNext();
+            var l = (r == 'r' || r == 'R') ? GetNext() : Symbols.EndOfFile;
+            var open = (l == 'l' || l == 'L') ? GetNext() : Symbols.EndOfFile;
+
+            if (open != Symbols.RoundBracketOpen)
+            {
+                Back(Position - start);
+                return false;
+            }
+
+            sb.Append(current).Append(r).Append(l).Append(open);
+            previous = open;
+            current = GetNext();
+
+            while (current.IsSpaceCharacter())
+            {
+                sb.Append(current);
+                previous = current;
+                current = GetNext();
+            }
+
+            // A quoted url() is an ordinary function token; the string is handled by
+            // the caller. Only the unquoted form treats ';', '{' and '}' as content.
+            if (current == Symbols.DoubleQuote || current == Symbols.SingleQuote)
+            {
+                return true;
+            }
+
+            while (current != Symbols.EndOfFile)
+            {
+                sb.Append(current);
+
+                if (current == Symbols.RoundBracketClose)
+                {
+                    previous = current;
+                    current = GetNext();
+                    return true;
+                }
+
+                if (current == Symbols.ReverseSolidus)
+                {
+                    previous = current;
+                    current = GetNext();
+
+                    if (current == Symbols.EndOfFile)
+                    {
+                        break;
+                    }
+
+                    sb.Append(current);
+                }
+
+                previous = current;
+                current = GetNext();
+            }
+
+            return true;
         }
 
         internal void RaiseErrorOccurred(CssParseError error, TextPosition position)

--- a/src/AngleSharp.Css/Parser/Micro/CssUriParser.cs
+++ b/src/AngleSharp.Css/Parser/Micro/CssUriParser.cs
@@ -16,18 +16,29 @@ namespace AngleSharp.Css.Parser
         /// </summary>
         public static CssUrlValue ParseUri(this StringSource source)
         {
+            var start = source.Index;
+
             if (source.IsFunction(FunctionNames.Url))
             {
                 var current = source.SkipSpacesAndComments();
 
-                return current switch
+                var result = current switch
                 {
                     Symbols.DoubleQuote => DoubleQuoted(source),
                     Symbols.SingleQuote => SingleQuoted(source),
-                    Symbols.RoundBracketClose => new CssUrlValue(String.Empty),
+                    Symbols.RoundBracketClose => Empty(source),
                     Symbols.EndOfFile => new CssUrlValue(String.Empty),
                     _ => Unquoted(source),
                 };
+
+                if (result is null)
+                {
+                    // A bad url yields no value at all. Nothing is consumed either, so
+                    // that the caller sees the url() as unparsed instead of as absent.
+                    source.BackTo(start);
+                }
+
+                return result;
             }
 
             return null;
@@ -43,7 +54,7 @@ namespace AngleSharp.Css.Parser
 
                 if (current.IsLineBreak())
                 {
-                    return Bad(source, buffer);
+                    return Bad(buffer);
                 }
                 else if (Symbols.EndOfFile == current)
                 {
@@ -89,7 +100,7 @@ namespace AngleSharp.Css.Parser
 
                 if (current.IsLineBreak())
                 {
-                    return Bad(source, buffer);
+                    return Bad(buffer);
                 }
                 else if (current == Symbols.EndOfFile)
                 {
@@ -142,7 +153,7 @@ namespace AngleSharp.Css.Parser
                 }
                 else if (current is Symbols.DoubleQuote or Symbols.SingleQuote or Symbols.RoundBracketOpen || current.IsNonPrintable())
                 {
-                    return Bad(source, buffer);
+                    return Bad(buffer);
                 }
                 else if (current != Symbols.ReverseSolidus)
                 {
@@ -154,7 +165,7 @@ namespace AngleSharp.Css.Parser
                 }
                 else
                 {
-                    return Bad(source, buffer);
+                    return Bad(buffer);
                 }
 
                 current = source.Next();
@@ -171,52 +182,19 @@ namespace AngleSharp.Css.Parser
                 return new CssUrlValue(buffer.ToPool());
             }
 
-            return Bad(source, buffer);
+            return Bad(buffer);
         }
 
-        private static CssUrlValue Bad(StringSource source, StringBuilder buffer)
+        private static CssUrlValue Empty(StringSource source)
         {
-            var current = source.Current;
-            var curly = 0;
-            var round = 1;
+            source.Next();
+            return new CssUrlValue(String.Empty);
+        }
 
-            while (current != Symbols.EndOfFile)
-            {
-                if (current == Symbols.Semicolon)
-                {
-                    return new CssUrlValue(buffer.ToPool());
-                }
-                else if (current == Symbols.CurlyBracketClose && --curly == -1)
-                {
-                    return new CssUrlValue(buffer.ToPool());
-                }
-                else if (current == Symbols.RoundBracketClose && --round == 0)
-                {
-                    source.Next();
-                    return new CssUrlValue(buffer.ToPool());
-                }
-                else if (source.IsValidEscape())
-                {
-                    buffer.Append(source.ConsumeEscape());
-                }
-                else
-                {
-                    if (current == Symbols.RoundBracketOpen)
-                    {
-                        ++round;
-                    }
-                    else if (current == Symbols.CurlyBracketOpen)
-                    {
-                        ++curly;
-                    }
-
-                    buffer.Append(current);
-                }
-
-                current = source.Next();
-            }
-            
-            return new CssUrlValue(buffer.ToPool());
+        private static CssUrlValue Bad(StringBuilder buffer)
+        {
+            buffer.ToPool();
+            return null;
         }
     }
 }


### PR DESCRIPTION
# Types of Changes

## Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

## Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## Description

Two commits fixing `url()` handling. The first fixes where a url token **ends**; the second fixes what happens when one is **invalid**. Both were found from the same symptom — stylesheets silently getting a wrong value instead of the right one or none at all.

Behaviour throughout was validated against Chrome's CSSOM rather than from the spec alone, over a 30-case matrix. After both commits there is **no remaining divergence** in that matrix.

---

### 1. Unquoted `url()` values were truncated at `;`, `{` or `}`

`CssTokenizer.ContentFrom` re-scans the raw source to recover a declaration value or an at-rule prelude, and breaks at the first `;`, `{` or `}`. It special-cased quoted strings but knew nothing about url tokens, where all three characters are legal content.

```css
a { background-image: url(data:image/svg+xml;base64,PHN2Zz48L3N2Zz4=) }
```

parsed to `url("data:image/svg+xml")` — cut at the first semicolon. The remainder failed to re-tokenize as a declaration and was silently dropped, so a round-trip through `CssText` destroyed the asset. Unquoted data URIs are emitted by every major bundler for icon sprites and inlined SVG, so this affects a lot of real stylesheets.

The existing test `CssSheetWithDataUrlAsBackgroundImage` missed it because it uses the **quoted** form, which took the string branch and round-tripped fine.

Through `GetArgument` the same flaw discarded whole rules — a `@supports` condition containing `url(a;b)` lost its entire rule. Escaped separators were mangled too: `url(a\;b)` produced `url("a\\")`. `@import` was *not* affected; `CreateImport` takes the href straight off the token stream.

Three subtleties from the browser shaped the fix:

- **The ident must be *immediately* followed by `(`.** `myurl(`, `-url(`, `local-url(` and `url\t(` are ordinary function tokens where `;` *does* terminate the declaration. A plain substring match for `url(` would have introduced a new bug; hence the ident-boundary guard.
- **`url( "a)b" )` is a function token, not a url token** — the quoted string wins and the `)` inside it does not close it. So the scan skips whitespace after `(` and defers to the existing string handling on a quote.
- **Bad-url cases still consume through the matching `)`**, so a single "consume to unescaped `)`" rule extracts the correct span in every case.

### 2. Invalid `url()` values produced garbage instead of failing

The root cause was that **a bad url had no way to be reported as a failure**.

`CssUriParser.Bad()` returned a `CssUrlValue` built from whatever characters it had scanned past, so an invalid url produced a plausible-looking but wrong value instead of failing:

| input | before | Chrome / now |
|---|---|---|
| `url(a b)` | `url("ab")` | declaration dropped |
| `url(a(b)` | `url("a(b)")` | declaration dropped |
| `url(javascript:alert(1))` | `url("javascript:alert(1)")` | declaration dropped |
| `url()` | declaration dropped | `url("")` |

`Bad()` now returns `null` and `ParseUri` rewinds the source. The rewind matters: merely *consuming* the bad url let `background: url(a b) red` silently re-parse as `background: red` instead of being dropped.

`ParseUri` also never consumed the `)` of an empty `url()`, leaving the source mid-value so the declaration was rejected. `url()` is valid and means the empty URL.

At the sheet level, `CssTokenizer.NewUrl` accepted a `bad` parameter and **ignored it**, so no bad-url token could ever exist and `UrlBad`'s scanned-over characters became the url's content — `@import url(a b)` imported the garbage href `a  b)`. A `BadUrl` token type now carries the distinction (both `CssTokenType` and `CssToken` are internal, so this is not a public API change), and `UrlBad` discards the remnants it consumes.

Per the spec, **EOF ends a url token rather than invalidating it**, so the two EOF paths that flagged `bad` no longer do — `@import url(abc` still imports `abc`, as Chrome does.

Rule-level consequences, all matching Chrome:

- `@import` with a bad url is dropped instead of importing a garbage href.
- `@namespace` with a bad url is dropped. **Fixing this forced a decision on the string form**, since one condition governs both: `@namespace` accepted only a url token, so `@namespace x "http://foo"` silently produced an empty namespace URI. It now accepts a string as the spec requires. This is the one change here that is not strictly about `url()` — it was unavoidable, and it is browser-validated.