### PR TITLE
Fix operator associativity and result units in calc()

### DIFF
--- a/src/AngleSharp.Css.Tests/Values/Calc.cs
+++ b/src/AngleSharp.Css.Tests/Values/Calc.cs
@@ -140,6 +140,38 @@ namespace AngleSharp.Css.Tests.Values
             Assert.AreEqual(expected, style.GetWidth());
         }
 
+        [TestCase("calc(10px - 2px - 3px)", "5px")]
+        [TestCase("calc(100px - 10px - 20px - 30px)", "40px")]
+        [TestCase("calc(30px - 10px + 5px)", "25px")]
+        [TestCase("calc(10px + 20px - 5px)", "25px")]
+        [TestCase("calc(50px - (10px - 5px))", "45px")]
+        public void CalcSameOperatorChainIsLeftAssociative(String expression, String expected)
+        {
+            var document = ParseDocument($"<style>p {{ width: {expression} }}</style><p></p>");
+            var style = document.QuerySelector("p").ComputeCurrentStyle();
+            Assert.AreEqual(expected, style.GetWidth());
+        }
+
+        [TestCase("calc(100px / 2 / 5)", "10px")]
+        [TestCase("calc(100px / 2 * 5)", "250px")]
+        [TestCase("calc(100px * 2 / 5)", "40px")]
+        [TestCase("calc(1px * 2 * 3)", "6px")]
+        public void CalcMultiplicativeChainIsLeftAssociative(String expression, String expected)
+        {
+            var document = ParseDocument($"<style>p {{ width: {expression} }}</style><p></p>");
+            var style = document.QuerySelector("p").ComputeCurrentStyle();
+            Assert.AreEqual(expected, style.GetWidth());
+        }
+
+        [TestCase("calc(2 * 3px + 1px)", "7px")]
+        [TestCase("calc(21px + 5px - 4px * 2)", "18px")]
+        public void CalcMixedPrecedenceIsComputed(String expression, String expected)
+        {
+            var document = ParseDocument($"<style>p {{ width: {expression} }}</style><p></p>");
+            var style = document.QuerySelector("p").ComputeCurrentStyle();
+            Assert.AreEqual(expected, style.GetWidth());
+        }
+
         [TestCase(typeof(CssAngleValue))]
         [TestCase(typeof(CssFrequencyValue))]
         [TestCase(typeof(CssIntegerValue))]

--- a/src/AngleSharp.Css.Tests/Values/Calc.cs
+++ b/src/AngleSharp.Css.Tests/Values/Calc.cs
@@ -172,6 +172,39 @@ namespace AngleSharp.Css.Tests.Values
             Assert.AreEqual(expected, style.GetWidth());
         }
 
+        [TestCase("opacity", "calc(10px / 20px)", "0.5")]
+        [TestCase("opacity", "calc(2s / 8s)", "0.25")]
+        [TestCase("flex-grow", "calc(100px / 50px)", "2")]
+        [TestCase("z-index", "calc(100px / 25px)", "4")]
+        [TestCase("line-height", "calc(40px / 20px)", "2")]
+        public void CalcDivisionOfEqualUnitsYieldsNumber(String property, String expression, String expected)
+        {
+            var document = ParseDocument($"<style>p {{ {property}: {expression} }}</style><p></p>");
+            var style = document.QuerySelector("p").ComputeCurrentStyle();
+            Assert.AreEqual(expected, style.GetPropertyValue(property));
+        }
+
+        [TestCase("width", "calc(100px / 2)", "50px")]
+        [TestCase("width", "calc(100px * 3 / 2)", "150px")]
+        [TestCase("width", "calc(100px / 2px * 3px)", "150px")]
+        [TestCase("transition-duration", "calc(2s / 4)", "500ms")]
+        public void CalcDivisionByNumberKeepsUnitOfLeftOperand(String property, String expression, String expected)
+        {
+            var document = ParseDocument($"<style>p {{ {property}: {expression} }}</style><p></p>");
+            var style = document.QuerySelector("p").ComputeCurrentStyle();
+            Assert.AreEqual(expected, style.GetPropertyValue(property));
+        }
+
+        [TestCase("opacity", "calc(1 / 4)", "0.25")]
+        [TestCase("opacity", "calc(2 * 3)", "6")]
+        [TestCase("flex-shrink", "calc(20 / 8)", "2.5")]
+        public void CalcOfUnitlessOperandsStaysUnitless(String property, String expression, String expected)
+        {
+            var document = ParseDocument($"<style>p {{ {property}: {expression} }}</style><p></p>");
+            var style = document.QuerySelector("p").ComputeCurrentStyle();
+            Assert.AreEqual(expected, style.GetPropertyValue(property));
+        }
+
         [TestCase(typeof(CssAngleValue))]
         [TestCase(typeof(CssFrequencyValue))]
         [TestCase(typeof(CssIntegerValue))]

--- a/src/AngleSharp.Css/Extensions/CssMetricValueExtensions.cs
+++ b/src/AngleSharp.Css/Extensions/CssMetricValueExtensions.cs
@@ -34,6 +34,10 @@ namespace AngleSharp.Css.Values
                 "public constructor taking a single Double themselves, e.g., via DynamicDependency.")]
 #endif
         public static ICssValue WithValue(this ICssMetricValue template, Double value) =>
-            (ICssValue)Activator.CreateInstance(template.GetType(), value);
+            // The single argument constructor of CssLengthValue defaults to pixels, which would
+            // turn a unitless length (e.g., the result of calc(1 / 4)) into a length in pixels.
+            template is CssLengthValue length ?
+                new CssLengthValue(value, length.Type) :
+                (ICssValue)Activator.CreateInstance(template.GetType(), value);
     }
 }

--- a/src/AngleSharp.Css/Parser/Micro/CalcParser.cs
+++ b/src/AngleSharp.Css/Parser/Micro/CalcParser.cs
@@ -48,50 +48,11 @@ namespace AngleSharp.Css.Parser
 
         private static ICssValue ParseAddExpression(this StringSource source)
         {
-            var left = ParseSubExpression(source);
-
-            if (source.Current == Symbols.Plus)
-            {
-                source.SkipCurrentAndSpaces();
-                var right = ParseAddExpression(source);
-
-                if (right == null)
-                {
-                    return null;
-                }
-
-                return new CssCalcAddExpression(left, right);
-            }
-
-            return left;
-        }
-
-        private static ICssValue ParseSubExpression(this StringSource source)
-        {
             var left = ParseMulExpression(source);
 
-            if (source.Current == Symbols.Minus)
+            while (left != null && (source.Current == Symbols.Plus || source.Current == Symbols.Minus))
             {
-                source.SkipCurrentAndSpaces();
-                var right = ParseSubExpression(source);
-
-                if (right == null)
-                {
-                    return null;
-                }
-
-                return new CssCalcSubExpression(left, right);
-            }
-
-            return left;
-        }
-
-        private static ICssValue ParseMulExpression(this StringSource source)
-        {
-            var left = ParseDivExpression(source);
-
-            if (source.Current == Symbols.Asterisk)
-            {
+                var add = source.Current == Symbols.Plus;
                 source.SkipCurrentAndSpaces();
                 var right = ParseMulExpression(source);
 
@@ -100,27 +61,32 @@ namespace AngleSharp.Css.Parser
                     return null;
                 }
 
-                return new CssCalcMulExpression(left, right);
+                left = add ?
+                    new CssCalcAddExpression(left, right) :
+                    (ICssValue)new CssCalcSubExpression(left, right);
             }
 
             return left;
         }
 
-        private static ICssValue ParseDivExpression(this StringSource source)
+        private static ICssValue ParseMulExpression(this StringSource source)
         {
             var left = ParseBracketExpression(source);
 
-            if (source.Current == Symbols.Solidus)
+            while (left != null && (source.Current == Symbols.Asterisk || source.Current == Symbols.Solidus))
             {
+                var mul = source.Current == Symbols.Asterisk;
                 source.SkipCurrentAndSpaces();
-                var right = ParseDivExpression(source);
+                var right = ParseBracketExpression(source);
 
                 if (right == null)
                 {
                     return null;
                 }
 
-                return new CssCalcDivExpression(left, right);
+                left = mul ?
+                    new CssCalcMulExpression(left, right) :
+                    (ICssValue)new CssCalcDivExpression(left, right);
             }
 
             return left;

--- a/src/AngleSharp.Css/Values/Expressions/CssCalcDivExpression.cs
+++ b/src/AngleSharp.Css/Values/Expressions/CssCalcDivExpression.cs
@@ -57,15 +57,20 @@ namespace AngleSharp.Css.Values
             var left = ComputeValue(_left, context);
             var right = ComputeValue(_right, context);
 
-            if (left is ICssMetricValue x && right is ICssMetricValue y && x.UnitString == y.UnitString)
+            if (left is ICssMetricValue x && right is ICssMetricValue y)
             {
-                var result = x.Value / y.Value;
-                return x.WithValue(result);
-            }
+                // Dividing by a plain number scales the left operand, keeping its unit.
+                if (y.UnitString.Length == 0)
+                {
+                    return x.WithValue(x.Value / y.Value);
+                }
 
-            if (left is ICssMetricValue unitLeft && right is ICssMetricValue unitlessRight && unitlessRight.UnitString.Length == 0)
-            {
-                return unitLeft.WithValue(unitLeft.Value / unitlessRight.Value);
+                // Dividing two values sharing a unit cancels the unit out, i.e. the
+                // result is a plain number (calc(40px / 20px) is 2, not 2px).
+                if (x.UnitString == y.UnitString)
+                {
+                    return new CssLengthValue(x.Value / y.Value, CssLengthValue.Unit.None);
+                }
             }
 
             return null;


### PR DESCRIPTION
# Types of Changes

## Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

## Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## Description

Fixes three related defects that made `calc()` report silently wrong numbers. No parse error was raised in any of these cases; the wrong value was simply handed to the computed style. Every expected value below was taken from Chrome via `getComputedStyle` before writing the fix.

### 1. Repeated operators were right associative

`CalcParser` recursed into itself for the right operand of every operator, so the expression tree came out right associative. Chains of two or more identical operators were evaluated in the wrong order:

| Expression | Chrome | Before | After |
| --- | --- | --- | --- |
| `calc(10px - 2px - 3px)` | `5px` | `11px` | `5px` |
| `calc(100px - 10px - 20px - 30px)` | `40px` | `100px` | `40px` |
| `calc(100px / 2 / 5)` | `10px` | `250px` | `10px` |

Mixed precedence expressions such as `calc(2 * 3px + 1px)` happened to come out right, which is why this survived so long.

The four right recursive levels are replaced by two iterative loops that fold operands to the left:

```
expression := term (('+' | '-') term)*
term       := factor (('*' | '/') factor)*
```

That also collapses the artificial split between the `Add`/`Sub` and `Mul`/`Div` levels, which is what introduced the asymmetry. Serialization is unaffected, since `CssText` concatenates operands in order without adding parentheses, so the existing round trip tests still hold.

The loop guard additionally stops a failed left operand from being wrapped in an expression node with a `null` child. Previously only `right` was null checked.

### 2. Dividing equal units kept the unit

Dividing two values that share a unit cancels the unit out and yields a plain number, but `CssCalcDivExpression` kept the unit of the left operand, so a length landed where a number was expected:

| Declaration | Chrome | Before | After |
| --- | --- | --- | --- |
| `opacity: calc(10px / 20px)` | `0.5` | `0.5px` | `0.5` |
| `flex-grow: calc(100px / 50px)` | `2` | `2px` | `2` |
| `z-index: calc(100px / 25px)` | `4` | `4px` | `4` |
| `opacity: calc(2s / 8s)` | `0.25` | `0.25s` | `0.25` |

`line-height: calc(40px / 20px)` in Chrome computes to `32px`, that is the number `2` times the `16px` font size, which confirms the result is a number rather than `2px`.

### 3. `WithValue` turned unitless lengths into pixels

`CssMetricValueExtensions.WithValue` builds the result via `Activator.CreateInstance(type, value)`, and the single argument constructor of `CssLengthValue` defaults to `Unit.Px`. Any unitless length therefore came back as a length in pixels:

| Declaration | Before | After |
| --- | --- | --- |
| `opacity: calc(1 / 4)` | `0.25px` | `0.25` |
| `flex-shrink: calc(20 / 6)` | `3.33333333333333px` | `3.33333333333333` |
| `opacity: calc(2 * 3)` | `6px` | `6` |

It now preserves the template's unit for lengths and falls back to the activator for the other metric types. This one also covers multiplication, not just division.