### PR TITLE
Fix case-sensitive matching of and/or and from/to keywords in CSS parsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Released on Saturday, September 5 2026
 - Fixed `not <known media type>` is always false (#231)
 - Fixed `calc()` computations in AoT-compiled applications (#236) @sebastienros
 - Fixed usage of `calc()` with unitless scaling (multiplication / division)
+- Fixed case-sensitive matching of `and` / `or` in `@supports` and `from` / `to` in `@keyframes` (#240)
 - Added optional CSSOM compliant color seralization (#229) @lahma
 - Added user-preference media features to the render device (#235) @lahma
 - Added media query list evaluation using `IRenderDevice` (#228) @lahma

--- a/src/AngleSharp.Css.Tests/Rules/CssKeyframeRule.cs
+++ b/src/AngleSharp.Css.Tests/Rules/CssKeyframeRule.cs
@@ -84,5 +84,38 @@ namespace AngleSharp.Css.Tests.Rules
             Assert.AreEqual(3, rule.Key.Stops.Count());
             Assert.AreEqual(0, rule.Style.Length);
         }
+
+        [Test]
+        public void KeyframeRuleWithUppercaseFrom()
+        {
+            var rule = ParseKeyframeRule(@"  FROM {
+    margin-left: 0px;
+  }");
+            Assert.IsNotNull(rule);
+            Assert.AreEqual("0%", rule.KeyText);
+            Assert.AreEqual(1, rule.Key.Stops.Count());
+            Assert.AreEqual(1, rule.Style.Length);
+        }
+
+        [Test]
+        public void KeyframeRuleWithUppercaseTo()
+        {
+            var rule = ParseKeyframeRule(@"  TO {
+    margin-left: 200px;
+  }");
+            Assert.IsNotNull(rule);
+            Assert.AreEqual("100%", rule.KeyText);
+            Assert.AreEqual(1, rule.Key.Stops.Count());
+            Assert.AreEqual(1, rule.Style.Length);
+        }
+
+        [Test]
+        public void KeyframeRuleWithMixedCaseFromAndTo()
+        {
+            var rule = ParseKeyframeRule(@"  From, To { }");
+            Assert.IsNotNull(rule);
+            Assert.AreEqual("0%, 100%", rule.KeyText);
+            Assert.AreEqual(2, rule.Key.Stops.Count());
+        }
     }
 }

--- a/src/AngleSharp.Css.Tests/Rules/CssSupports.cs
+++ b/src/AngleSharp.Css.Tests/Rules/CssSupports.cs
@@ -209,5 +209,57 @@ namespace AngleSharp.Css.Tests.Rules
             Assert.AreEqual("not (display: flex)", supports.ConditionText);
             Assert.IsFalse(supports.Condition.Check(device));
         }
+
+        [Test]
+        public void SupportsUppercaseAndKeywordRule()
+        {
+            var source = @"@supports ((background-color: red) AND (color: blue)) { }";
+            var sheet = ParseStyleSheet(source);
+            var device = new DefaultRenderDevice();
+            Assert.AreEqual(1, sheet.Rules.Length);
+            Assert.IsInstanceOf<CssSupportsRule>(sheet.Rules[0]);
+            var supports = sheet.Rules[0] as CssSupportsRule;
+            Assert.AreEqual("((background-color: red) and (color: blue))", supports.ConditionText);
+            Assert.IsTrue(supports.Condition.Check(device));
+        }
+
+        [Test]
+        public void SupportsUppercaseOrKeywordRule()
+        {
+            var source = @"@supports ((background-transparency: half) OR (color: blue)) { }";
+            var sheet = ParseStyleSheet(source);
+            var device = new DefaultRenderDevice();
+            Assert.AreEqual(1, sheet.Rules.Length);
+            Assert.IsInstanceOf<CssSupportsRule>(sheet.Rules[0]);
+            var supports = sheet.Rules[0] as CssSupportsRule;
+            Assert.AreEqual("((background-transparency: half) or (color: blue))", supports.ConditionText);
+            Assert.IsTrue(supports.Condition.Check(device));
+        }
+
+        [Test]
+        public void SupportsMixedCaseAndKeywordChainRule()
+        {
+            var source = @"@supports ((background-color: red) And (color: blue) aND (width: 10px)) { }";
+            var sheet = ParseStyleSheet(source);
+            var device = new DefaultRenderDevice();
+            Assert.AreEqual(1, sheet.Rules.Length);
+            Assert.IsInstanceOf<CssSupportsRule>(sheet.Rules[0]);
+            var supports = sheet.Rules[0] as CssSupportsRule;
+            Assert.AreEqual("((background-color: red) and (color: blue) and (width: 10px))", supports.ConditionText);
+            Assert.IsTrue(supports.Condition.Check(device));
+        }
+
+        [Test]
+        public void SupportsUppercaseAndKeywordKeepsInnerRules()
+        {
+            var source = @"@supports (color: red) AND (display: flex) {
+  body { width: 100%; }
+}";
+            var sheet = ParseStyleSheet(source);
+            Assert.AreEqual(1, sheet.Rules.Length);
+            Assert.IsInstanceOf<CssSupportsRule>(sheet.Rules[0]);
+            var supports = sheet.Rules[0] as CssSupportsRule;
+            Assert.AreEqual(1, supports.Rules.Length);
+        }
     }
 }

--- a/src/AngleSharp.Css/Parser/Micro/ConditionParser.cs
+++ b/src/AngleSharp.Css/Parser/Micro/ConditionParser.cs
@@ -57,8 +57,8 @@ namespace AngleSharp.Css.Parser
 
             if (ident != null)
             {
-                var isAnd = ident.Is(CssKeywords.And);
-                var isOr = ident.Is(CssKeywords.Or);
+                var isAnd = ident.Isi(CssKeywords.And);
+                var isOr = ident.Isi(CssKeywords.Or);
 
                 if (isAnd || isOr)
                 {
@@ -141,7 +141,7 @@ namespace AngleSharp.Css.Parser
                 source.SkipSpacesAndComments();
                 ident = source.ParseIdent();
             }
-            while (ident != null && ident.Is(keyword));
+            while (ident != null && ident.Isi(keyword));
 
             return conditions;
         }

--- a/src/AngleSharp.Css/Parser/Micro/KeyframeParser.cs
+++ b/src/AngleSharp.Css/Parser/Micro/KeyframeParser.cs
@@ -43,11 +43,11 @@ namespace AngleSharp.Css.Parser
 
                     stops.Add(test.Value);
                 }
-                else if (id.Is(CssKeywords.From))
+                else if (id.Isi(CssKeywords.From))
                 {
                     stops.Add(0f);
                 }
-                else if (id.Is(CssKeywords.To))
+                else if (id.Isi(CssKeywords.To))
                 {
                     stops.Add(1f);
                 }


### PR DESCRIPTION
# Types of Changes

## Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

## Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## Description

CSS keywords are ASCII case-insensitive, but two micro parsers compared them with ordinal equality.

**`ConditionParser`** used `.Is(...)` for the `and` / `or` keywords in `@supports` conditions. `Negation` on the line just above already used the case-insensitive `.Isi(...)` for `not`, which is what makes the divergence visible: `@supports NOT (...)` worked, while `@supports (color: red) AND (display: flex) { ... }` parsed to **zero rules**, silently discarding the conditional group and every rule inside it with no parse error.

A third comparison in `Scan` had the same problem. It compares each subsequent keyword against the raw text of the *first* one, so a chain like `(a) And (b) aND (c)` still truncated after the second group even once the first two comparisons were fixed.

**`KeyframeParser`** used `.Is(...)` for `from` / `to`. `@keyframes x { FROM {...} TO {...} }` failed selector parsing, leaving `CssKeyframeRule._selector` null. The rule stays in the CSSOM with a null `KeyText`, so the animation endpoints vanish and the round-tripped CSS is invalid.

### Changes

Switched all five comparisons to the case-insensitive `Isi` helper:

- `Parser/Micro/ConditionParser.cs` — `and` / `or` in `ConjunctionOrDisjunction`, and the chain continuation in `Scan`
- `Parser/Micro/KeyframeParser.cs` — `from` / `to`

### Tests

7 new tests, each confirmed failing before the change and passing after:

- `Rules/CssSupports.cs` — uppercase `AND`, uppercase `OR`, a mixed-case `And` / `aND` chain, and one asserting the inner rules of an uppercase-`AND` group survive
- `Rules/CssKeyframeRule.cs` — `FROM`, `TO`, and mixed-case `From, To`

Full suite: 2094 passed, 0 failed.

### Notes for reviewers

- A grep over `Parser/` confirms the only remaining ordinal `.Is(` is `sheet.Href.Is(href)` in `CssParser.cs`, a URL comparison that should stay case-sensitive.
- Not included: a malformed keyframe selector still yields a rule with a null key rather than being rejected outright. That is a separate public CSSOM behavior change and no longer reachable through the uppercase path now that these parse. Happy to add it if you'd prefer the rule be dropped or the parse throw.
