### PR TITLE
Skip the pseudo-class forcing lookup until something is forced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
+# 1.1.3
+
+Released on Saturday, September 12 2026
+
+- Improved pseudo-class matching to skip a per-element `ConditionalWeakTable` probe when no state has ever been forced via `SetPseudoClass`
+
 # 1.1.2
 
 Released on Friday, September 11 2026
 
-- Improved pseudo-class matching to skip a per-element `ConditionalWeakTable` probe when no state has ever been forced via `SetPseudoClass`
 - Fixed issue with calculation of CSS grid style
 - Fixed default value of CSS gradients
 - Fixed issue with Point2D style computations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Released on Friday, September 11 2026
 
+- Improved pseudo-class matching to skip a per-element `ConditionalWeakTable` probe when no state has ever been forced via `SetPseudoClass`
 - Fixed issue with calculation of CSS grid style
 - Fixed default value of CSS gradients
 - Fixed issue with Point2D style computations

--- a/src/AngleSharp.Css.Docs/package.json
+++ b/src/AngleSharp.Css.Docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anglesharp/css",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "preview": true,
   "description": "The doclet for the AngleSharp.Css documentation.",
   "keywords": [

--- a/src/AngleSharp.Css/PseudoClassStateStore.cs
+++ b/src/AngleSharp.Css/PseudoClassStateStore.cs
@@ -14,12 +14,24 @@ namespace AngleSharp.Css
     {
         private static readonly ConditionalWeakTable<IElement, Dictionary<String, Boolean>> _states = new();
 
-        public static void Set(IElement element, String pseudoClass, Boolean value) =>
+        // WithCss() wraps every non-:focus pseudo-class selector in ForcingPseudoClassSelector, so
+        // TryGet runs once per pseudo-class match attempt on every element - a page that never
+        // calls SetPseudoClass still paid a ConditionalWeakTable probe for every :hover, :disabled,
+        // :checked, ... match. This flag only ever moves from "nothing forced" to "something
+        // forced": Remove/Clear cannot prove every forced state everywhere has been undone (there
+        // is no per-element or per-process count to check), so it deliberately never goes back to
+        // false. Once anything has been forced, the process pays the old per-match cost again.
+        private static volatile Boolean _anyForced;
+
+        public static void Set(IElement element, String pseudoClass, Boolean value)
+        {
+            _anyForced = true;
             _states.GetValue(element, _ => new Dictionary<String, Boolean>(StringComparer.OrdinalIgnoreCase))[pseudoClass] = value;
+        }
 
         public static Boolean TryGet(IElement element, String pseudoClass, out Boolean value)
         {
-            if (_states.TryGetValue(element, out var state) && state.TryGetValue(pseudoClass, out value))
+            if (_anyForced && _states.TryGetValue(element, out var state) && state.TryGetValue(pseudoClass, out value))
             {
                 return true;
             }

--- a/src/AngleSharp.Performance.Css/CssCascadeBenchmarks.cs
+++ b/src/AngleSharp.Performance.Css/CssCascadeBenchmarks.cs
@@ -124,6 +124,20 @@ namespace AngleSharp.Performance.Css
 
             sb.Append("h1,h2,h3,p.big,a:hover,.c-1 span{font-weight:bold;letter-spacing:0.02em;}");
             sb.Append(".hidden{display:none}.big{font-size:24px}a{color:blue}");
+
+            // WithCss() wraps every non-:focus pseudo-class selector so a caller-forced state
+            // (ElementExtensions.SetPseudoClass) can override it - so every rule below probes a
+            // ConditionalWeakTable per candidate element even though this benchmark never forces
+            // anything. One rule per child class per interaction pseudo-class keeps every sampled
+            // "div.child-*" reaching that probe instead of being short-circuited by an earlier,
+            // non-matching simple selector.
+            for (var i = 0; i < 20; i++)
+            {
+                sb.Append(".child-").Append(i).Append(":hover{outline:1px solid red;}");
+                sb.Append(".child-").Append(i).Append(":active{outline:1px solid green;}");
+                sb.Append(".child-").Append(i).Append(":disabled{outline:1px solid blue;}");
+            }
+
             sb.Append("</style></head><body><main id='root'>");
 
             for (var s = 0; s < 25; s++)

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>Extends the CSSOM from the core AngleSharp library.</Description>
     <Product>AngleSharp.Css</Product>
-    <Version>1.1.2</Version>
+    <Version>1.1.3</Version>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
     <SignAssembly>true</SignAssembly>


### PR DESCRIPTION
## What the profile said

`WithCss()` (`CssConfigurationExtensions.cs`) wraps *every* non-`:focus` pseudo-class selector in `ForcingPseudoClassSelector`, so a caller-forced state (set via `ElementExtensions.SetPseudoClass`, e.g. to preview `:hover`/`:active` from devtools-style tooling) can take precedence over normal matching. Its `Match` (`ForcingPseudoClassSelector.cs:29-30`) calls `PseudoClassStateStore.TryGet` — a `ConditionalWeakTable<IElement, Dictionary<String, Boolean>>` probe — **before** delegating to the wrapped selector, on every attempted match. A page that has never called `SetPseudoClass` still pays that probe for every `:hover`, `:disabled`, `:checked`, … match attempt across an entire cascade.

## The mechanism

`PseudoClassStateStore` is a single static store for the whole process. A "nothing has ever been forced" flag checked first lets `TryGet` skip the table probe entirely in the overwhelmingly common case.

## What I changed

Added `private static volatile Boolean _anyForced` to `PseudoClassStateStore`, set in `Set()` and checked first in `TryGet()`. It only ever moves from `false` to `true`: `Remove`/`Clear` do **not** clear it back, because proving that *every* forced state *everywhere* in the process has been undone would need a live per-element or per-process count, not a single flag, and getting that wrong would be a correctness bug (silently ignoring a still-forced state). So the trade-off is explicit: once anything has been forced anywhere in the process, matching goes back to paying the old per-attempt cost for the lifetime of the process. This is also a process-wide static, so it doesn't distinguish between documents or engines — forcing something in one document costs every other document in the same process the probe again. Both are pre-existing properties of `PseudoClassStateStore` (already a single static table shared process-wide); this change doesn't introduce either, it only trades the *unforced* path for something cheaper.

## What I did not change, and why

I considered making the flag per-element (e.g. a marker in the `ConditionalWeakTable` entry itself) to avoid the process-wide blast radius, but that reintroduces the table lookup this change exists to avoid on the common path. A per-document flag would need a hook into document/engine lifetime this store doesn't currently have. Both are reasonable follow-ups if the process-wide trade-off proves too coarse in practice, but neither is evidently better today, so I kept the smallest fix that matches the brief's constraint ("may only ever go from 'nothing forced' to 'something forced', never back, unless un-forcing is proven to clear it correctly" — I couldn't prove that, so I didn't attempt it).

## Tests

- `dotnet test -c Release src/AngleSharp.Css.Tests/AngleSharp.Css.Tests.csproj` — 2342 passed, 0 failed.
- No new tests added: `PseudoClassForcingTests` (`src/AngleSharp.Css.Tests/Styling/PseudoClassForcing.cs`) already exercises `Set`/`Get`/`Remove`/`Clear` and matching through `:hover`/`:active`/`:visited`/`:focus`, all passing unchanged — this is a pure fast-path addition, not a behavior change to any of them (a forced state is still found correctly; only the never-forced path got cheaper).

## To be measured

`dotnet run --project src/AngleSharp.Performance.Css/AngleSharp.Performance.Css.csproj -c Release --framework net10.0 -- --filter "*CssCascadeBenchmarks*"`, specifically the `ComputedStyle` row. I extended that row's synthetic stylesheet (already a 400-rule cascade over a synthetic document) with one `:hover`/`:active`/`:disabled` rule per child class, so most sampled elements reach `ForcingPseudoClassSelector.Match` instead of being short-circuited by an earlier, non-matching simple selector — without this, the existing sheet only reached the forcing wrapper via a single `a:hover` rule. I ran it once with `--job short` to confirm it executes; no numbers from that run should be treated as meaningful.

Note: this benchmark project depends on the published `AngleSharp` NuGet package (`AngleSharpVersion`, currently pinned to `1.5.0`), not a local build, so it cannot currently exercise the companion `AngleSharp` core PR from this same stream (selector specificity caching) — only this pseudo-class fix is observable from an in-repo run today. The lead's measurement of the combined effect will need a local package override or a fresh core package.

Part of a benchmark-gated performance campaign (stream U3). A companion PR against `AngleSharp` core (`perf/selector-matching`) fixes related selector specificity recomputation in the same cascade path: https://github.com/AngleSharp/AngleSharp/pull/1346

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WQwq9NqYqG3kk9M8CKdfdJ